### PR TITLE
[ExtraInfoHelper] centralize locators

### DIFF
--- a/src/sele_saisie_auto/additional_info_locators.py
+++ b/src/sele_saisie_auto/additional_info_locators.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class AdditionalInfoLocators(str, Enum):
+    """Locator prefixes for additional information lines and fields."""
+
+    ROW_DESCR100 = "DESCR100$"
+    DAY_UC_DAILYREST = "UC_DAILYREST"
+    ROW_DESCR200 = "UC_TIME_LIN_WRK_DESCR200$"
+    DAY_UC_DAILYREST_SPECIAL = "UC_TIME_LIN_WRK_UC_DAILYREST"
+    ROW_DESCR = "DESCR$"
+    DAY_UC_LOCATION_A = "UC_LOCATION_A"

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -24,6 +24,7 @@ from sele_saisie_auto import (
     plugins,
     remplir_jours_feuille_de_temps,
 )
+from sele_saisie_auto.additional_info_locators import AdditionalInfoLocators
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.encryption_utils import EncryptionService
@@ -113,8 +114,8 @@ class PSATimeAutomation:
             descriptions=[
                 {
                     "description_cible": "Temps de repos de 11h entre 2 jours travaillés respecté",
-                    "id_value_ligne": "DESCR100$",
-                    "id_value_jours": "UC_DAILYREST",
+                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
+                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.additional_information[
                         "periode_repos_respectee"
@@ -124,8 +125,8 @@ class PSATimeAutomation:
                     "description_cible": (
                         "Mon temps de travail effectif a débuté entre 8h00 et 10h00 et Mon temps de travail effectif a pris fin entre 16h30 et 19h00"
                     ),
-                    "id_value_ligne": "DESCR100$",
-                    "id_value_jours": "UC_DAILYREST",
+                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
+                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.additional_information[
                         "horaire_travail_effectif"
@@ -133,8 +134,8 @@ class PSATimeAutomation:
                 },
                 {
                     "description_cible": "J’ai travaillé plus d’une demi-journée",
-                    "id_value_ligne": "DESCR100$",
-                    "id_value_jours": "UC_DAILYREST",
+                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
+                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.additional_information[
                         "plus_demi_journee_travaillee"
@@ -142,8 +143,8 @@ class PSATimeAutomation:
                 },
                 {
                     "description_cible": "Durée de la pause déjeuner",
-                    "id_value_ligne": "UC_TIME_LIN_WRK_DESCR200$",
-                    "id_value_jours": "UC_TIME_LIN_WRK_UC_DAILYREST",
+                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR200.value,
+                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value,
                     "type_element": "input",
                     "valeurs_a_remplir": app_config.additional_information[
                         "duree_pause_dejeuner"
@@ -151,15 +152,15 @@ class PSATimeAutomation:
                 },
                 {
                     "description_cible": "Matin",
-                    "id_value_ligne": "DESCR$",
-                    "id_value_jours": "UC_LOCATION_A",
+                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR.value,
+                    "id_value_jours": AdditionalInfoLocators.DAY_UC_LOCATION_A.value,
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.work_location_am,
                 },
                 {
                     "description_cible": "Après-midi",
-                    "id_value_ligne": "DESCR$",
-                    "id_value_jours": "UC_LOCATION_A",
+                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR.value,
+                    "id_value_jours": AdditionalInfoLocators.DAY_UC_LOCATION_A.value,
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.work_location_pm,
                 },

--- a/tests/test_extra_info_helper.py
+++ b/tests/test_extra_info_helper.py
@@ -5,14 +5,17 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 from sele_saisie_auto import messages  # noqa: E402
 from sele_saisie_auto import remplir_informations_supp_utils as risu  # noqa: E402
+from sele_saisie_auto.additional_info_locators import (  # noqa: E402
+    AdditionalInfoLocators,
+)
 
 
 def make_config(**overrides):
     base_values = {day: f"val_{day}" for day in risu.JOURS_SEMAINE.values()}
     cfg = {
         "description_cible": "desc",
-        "id_value_ligne": "ID_LINE_",
-        "id_value_jours": "ID_DAY_",
+        "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
+        "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
         "type_element": "input",
         "valeurs_a_remplir": base_values,
     }
@@ -87,7 +90,8 @@ def test_traiter_description_select_special(monkeypatch):
     )
 
     cfg = make_config(
-        type_element="select", id_value_jours="UC_TIME_LIN_WRK_UC_DAILYREST"
+        type_element="select",
+        id_value_jours=AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value,
     )
     del cfg["valeurs_a_remplir"]["mardi"]
     risu.traiter_description(None, cfg)

--- a/tests/test_remplir_informations_supp_utils.py
+++ b/tests/test_remplir_informations_supp_utils.py
@@ -5,6 +5,9 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 from sele_saisie_auto import messages  # noqa: E402
 from sele_saisie_auto import remplir_informations_supp_utils as risu  # noqa: E402
+from sele_saisie_auto.additional_info_locators import (  # noqa: E402
+    AdditionalInfoLocators,
+)
 
 # Helper to build config dictionaries
 
@@ -13,8 +16,8 @@ def make_config(**overrides):
     base_values = {day: f"val_{day}" for day in risu.JOURS_SEMAINE.values()}
     cfg = {
         "description_cible": "desc",
-        "id_value_ligne": "ROW",
-        "id_value_jours": "DAY_",
+        "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
+        "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
         "type_element": "input",
         "valeurs_a_remplir": base_values,
     }
@@ -68,7 +71,7 @@ def test_traiter_description_fill_input(monkeypatch):
     del cfg["valeurs_a_remplir"]["mardi"]
     risu.traiter_description(None, cfg)
 
-    assert "DAY_1$1" in ids
+    assert f"{AdditionalInfoLocators.DAY_UC_DAILYREST.value}1$1" in ids
 
     assert ("lundi", "val_lundi") not in filled  # element missing
     assert ("mardi", "val_mardi") not in filled  # value missing


### PR DESCRIPTION
## Contexte
Ajout d'un module dédié `additional_info_locators.py` afin de centraliser les identifiants utilisés pour le remplissage des informations supplémentaires.

## Étapes de test
1. `poetry run pre-commit run --files src/sele_saisie_auto/additional_info_locators.py src/sele_saisie_auto/saisie_automatiser_psatime.py tests/test_extra_info_helper.py tests/test_remplir_informations_supp_utils.py`
2. `poetry run pytest`

## Impact
Pas d'impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6868506ffe388321928ecaafe2a6228b