### PR TITLE
[launcher] remove eager main_menu import

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -18,7 +18,6 @@ from sele_saisie_auto.gui_builder import (
 )
 from sele_saisie_auto.logger_utils import LOG_LEVELS, close_logs, initialize_logger
 from sele_saisie_auto.logging_service import Logger
-from sele_saisie_auto.main_menu import main_menu
 from sele_saisie_auto.read_or_write_file_config_ini_utils import (
     read_config_ini,
     write_config_ini,
@@ -97,6 +96,8 @@ def start_configuration(
         write_config_ini(config, log_file)
         messagebox.showinfo("Info", "Configuration enregistrée")
         root.destroy()
+        from sele_saisie_auto.main_menu import main_menu
+
         main_menu(cle_aes, log_file, encryption_service)
 
     btn_row = create_a_frame(frame, padding=(10, 10))
@@ -119,6 +120,8 @@ def main(argv: list[str] | None = None) -> None:
     multiprocessing.freeze_support()
     with EncryptionService(log_file) as encryption_service:
         cle_aes = encryption_service.cle_aes
+        from sele_saisie_auto.main_menu import main_menu
+
         main_menu(cle_aes, log_file, encryption_service)
     close_logs(log_file)
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -211,7 +211,9 @@ def test_start_configuration_and_save(monkeypatch):
         launcher.messagebox, "showinfo", lambda *a: saved.setdefault("info", True)
     )
     monkeypatch.setattr(
-        launcher, "main_menu", lambda *a, **k: saved.setdefault("menu", True)
+        sys.modules["sele_saisie_auto.main_menu"],
+        "main_menu",
+        lambda *a, **k: saved.setdefault("menu", True),
     )
 
     launcher.start_configuration(b"k", "log", DummyEncryption())
@@ -247,7 +249,11 @@ def test_main(monkeypatch):
     )
     enc = DummyEncryption()
     monkeypatch.setattr(launcher, "EncryptionService", lambda lf: enc)
-    monkeypatch.setattr(launcher, "main_menu", lambda *a: init.setdefault("menu", a))
+    monkeypatch.setattr(
+        sys.modules["sele_saisie_auto.main_menu"],
+        "main_menu",
+        lambda *a: init.setdefault("menu", a),
+    )
     monkeypatch.setattr(launcher, "close_logs", lambda lf: init.setdefault("close", lf))
 
     launcher.main([])


### PR DESCRIPTION
## Contexte
- le module `launcher` importait `main_menu` au chargement ce qui générait une dépendance circulaire
- les tests de `tests/test_launcher.py` patchaient cet import direct

## Changements
- suppression de l'import `main_menu` au niveau module
- import local de `main_menu` dans `launcher.main` et dans `start_configuration.save`
- mise à jour des tests pour patcher `sele_saisie_auto.main_menu.main_menu`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6868589b9b6483218be3b0924d0db096