### PR TITLE
[SeleniumFiller] log file optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Une interface graphique Tkinter permet de renseigner vos identifiants chiffrés 
   ```bash
   poetry run psatime-auto
   ```
+  Cette commande crée automatiquement un fichier de log dans le répertoire
+  `logs/` si aucun chemin n'est spécifié.
 - Exécution directe des scripts :
   ```bash
   python -m sele_saisie_auto.launcher

--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -17,7 +17,7 @@ L'utilisateur dispose d'un fichier `config.ini` minimal et souhaite renseigner s
 poetry run psatime-auto
 ```
 
-Cette commande lit `config.ini` dans le répertoire courant et lance directement l'automatisation.
+Cette commande lit `config.ini` dans le répertoire courant et lance directement l'automatisation. Un fichier de log est créé automatiquement sous `logs/` si aucun chemin n'est spécifié.
 
 ### Exemple de configuration minimale
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -695,8 +695,20 @@ def afficher_message_insertion(jour, valeur, tentative, message, log_file: str) 
 # ------------------------------------------------------------------------------------------------------------------ #
 
 
-def main(log_file: str) -> None:  # pragma: no cover
-    """Point d'entrée principal du script."""
+def main(log_file: str | None = None) -> None:  # pragma: no cover
+    """Point d'entrée principal du script.
+
+    Parameters
+    ----------
+    log_file : str | None, optional
+        Chemin du fichier log. S'il vaut ``None``, il sera déterminé via
+        :func:`get_log_file`.
+    """
+    if log_file is None:
+        from sele_saisie_auto.shared_utils import get_log_file
+
+        log_file = get_log_file()
+
     cfg = ConfigManager(log_file=log_file).load()
     PSATimeAutomation(log_file, cfg).run()
 
@@ -801,6 +813,4 @@ def wait_for_dom(driver):
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation
-    from sele_saisie_auto.shared_utils import get_log_file
-
-    main(get_log_file())
+    main()


### PR DESCRIPTION
## Contexte
- rendre le paramètre `log_file` optionnel dans `saisie_automatiser_psatime.main`
- adapter le block `__main__` en conséquence
- clarifier la documentation sur la création automatique du log

## Impact
- `poetry run psatime-auto` fonctionne sans fournir explicitement un chemin de log

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run safety auth` *(échoue: besoin réseau)*
- `poetry run safety scan` *(échoue: besoin réseau)*


------
https://chatgpt.com/codex/tasks/task_e_68685ac2d24083219c50d3f628af05a9