### PR TITLE
[scripts] Ajout script d'installation Poetry

### DIFF
--- a/scripts/install_poetry_windows.ps1
+++ b/scripts/install_poetry_windows.ps1
@@ -1,0 +1,7 @@
+# Ce script doit être lancé en mode administrateur.
+
+# Télécharge et installe Poetry à l'aide de la commande officielle
+(Invoke-WebRequest -Uri https://install.python-poetry.org -UseBasicParsing).Content | python -
+
+# Vérifie que Poetry est bien installé
+poetry --version


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un script PowerShell permettant d'installer Poetry sous Windows. Le script exécute la commande officielle puis vérifie l'installation. Un rappel indique que le script doit être lancé en mode administrateur.

## Étapes pour tester
1. Ouvrir une session PowerShell en mode administrateur.
2. Exécuter `scripts/install_poetry_windows.ps1`.
3. Vérifier l'affichage de la version de Poetry.

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6868d36403ac832198765ae0bc6627ff