### PR TITLE
[docs] vérification de Poetry dans contribution

### DIFF
--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -9,6 +9,15 @@ Pour la description des différents agents, consultez [AGENT.md](../../AGENT.md)
 
 ## 🔧 Configuration de l’environnement
 
+Vérifie d’abord que Poetry est disponible :
+
+```bash
+poetry --version
+```
+
+Si la commande est introuvable, lance `scripts/install_poetry_windows.ps1` ou
+consulte le [guide d’installation](installation.md).
+
 Installe les dépendances et les hooks Git :
 
 ```bash


### PR DESCRIPTION
## Contexte
Ajout d'une précision dans la section _Configuration de l’environnement_ du guide de contribution. L'objectif est de rappeler de vérifier la présence de Poetry avant d'installer les dépendances.

## Modifications
- nouvelle sous‑section indiquant d’exécuter `poetry --version` et redirection vers `scripts/install_poetry_windows.ps1` ou le guide d’installation si nécessaire.

## Impact
Aucun impact sur le code. Documentation uniquement.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6868df04bd308321bc25b80b681def54