### PR TITLE
[automation] ajout BrowserSession

### DIFF
--- a/src/sele_saisie_auto/automation/__init__.py
+++ b/src/sele_saisie_auto/automation/__init__.py
@@ -1,5 +1,7 @@
 """Subpackage regroupant les automatisations Selenium futures."""
 
+from .browser_session import BrowserSession
+
 __all__ = [
-    # les classes seront exposées ici au fur et à mesure de leur ajout
+    "BrowserSession",
 ]

--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.selenium_driver_manager import SeleniumDriverManager
+
+
+class BrowserSession:
+    """Encapsulate :class:`SeleniumDriverManager` for higher-level automation."""
+
+    def __init__(self, log_file: str) -> None:
+        self.log_file = log_file
+        self._manager = SeleniumDriverManager(log_file)
+        self.driver: Optional[WebDriver] = None
+
+    def __enter__(self) -> "BrowserSession":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        self.close()
+
+    def open(
+        self,
+        url: str,
+        *,
+        fullscreen: bool = False,
+        headless: bool = False,
+        no_sandbox: bool = False,
+    ) -> Optional[WebDriver]:
+        """Open the browser and navigate to ``url``."""
+        write_log("Ouverture du navigateur", self.log_file, "DEBUG")
+        self.driver = self._manager.open(
+            url,
+            fullscreen=fullscreen,
+            headless=headless,
+            no_sandbox=no_sandbox,
+        )
+        return self.driver
+
+    def close(self) -> None:
+        """Close the browser if it was opened."""
+        if self.driver is not None:
+            write_log("Fermeture du navigateur", self.log_file, "DEBUG")
+        self._manager.close()
+        self.driver = None

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -1,0 +1,82 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from sele_saisie_auto.automation.browser_session import BrowserSession  # noqa: E402
+
+
+def test_open_delegates_to_manager(monkeypatch):
+    calls = {}
+
+    class DummyManager:
+        def __init__(self, log_file: str) -> None:
+            calls["init"] = log_file
+
+        def open(self, url, fullscreen=False, headless=False, no_sandbox=False):
+            calls["args"] = (url, fullscreen, headless, no_sandbox)
+            return "driver"
+
+        def close(self):
+            calls["closed"] = True
+
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.SeleniumDriverManager",
+        DummyManager,
+    )
+    session = BrowserSession("log.html")
+    driver = session.open("http://t", fullscreen=True, headless=True)
+
+    assert driver == "driver"  # nosec B101
+    assert session.driver == "driver"  # nosec B101
+    assert calls["args"] == ("http://t", True, True, False)  # nosec B101
+
+
+def test_close_calls_manager(monkeypatch):
+    closed = {}
+
+    class DummyManager:
+        def __init__(self, log_file: str) -> None:
+            pass
+
+        def open(self, *a, **k):
+            return "driver"
+
+        def close(self):
+            closed["called"] = True
+
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.SeleniumDriverManager",
+        DummyManager,
+    )
+    session = BrowserSession("log.html")
+    session.driver = "driver"
+    session._manager = DummyManager("log.html")
+    session.close()
+
+    assert closed.get("called") is True  # nosec B101
+    assert session.driver is None  # nosec B101
+
+
+def test_context_manager(monkeypatch):
+    closed = {}
+
+    class DummyManager:
+        def __init__(self, log_file: str) -> None:
+            pass
+
+        def open(self, *a, **k):
+            return "driver"
+
+        def close(self):
+            closed["called"] = True
+
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.SeleniumDriverManager",
+        DummyManager,
+    )
+
+    with BrowserSession("log.html") as session:
+        assert isinstance(session, BrowserSession)  # nosec B101
+
+    assert closed.get("called") is True  # nosec B101


### PR DESCRIPTION
## Contexte
Ajout d'une nouvelle classe `BrowserSession` permettant de gérer les sessions navigateur via `SeleniumDriverManager`. Elle trace l'ouverture et la fermeture du navigateur avec `write_log` et fournit un gestionnaire de contexte simple. La classe est exportée dans le sous‑package `automation`.

## Test
- `poetry run pre-commit run --files src/sele_saisie_auto/automation/browser_session.py src/sele_saisie_auto/automation/__init__.py tests/test_browser_session.py`
- `poetry run pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6868f8a2df408321b75229de4d0aef7b