### PR TITLE
[BrowserSession] unifie la gestion du navigateur

### DIFF
--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -3,7 +3,61 @@ from __future__ import annotations
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from sele_saisie_auto.logger_utils import write_log
-from sele_saisie_auto.selenium_driver_manager import SeleniumDriverManager
+from sele_saisie_auto.selenium_utils import (
+    DEFAULT_TIMEOUT,
+    LONG_TIMEOUT,
+    definir_taille_navigateur,
+    ouvrir_navigateur_sur_ecran_principal,
+    wait_for_dom_ready,
+    wait_until_dom_is_stable,
+)
+
+
+class SeleniumDriverManager:
+    """Handle WebDriver lifecycle for the automation."""
+
+    def __init__(self, log_file: str) -> None:
+        self.log_file = log_file
+        self.driver: WebDriver | None = None
+
+    def __enter__(self) -> "SeleniumDriverManager":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        self.close()
+
+    def open(
+        self,
+        url: str,
+        *,
+        fullscreen: bool = False,
+        headless: bool = False,
+        no_sandbox: bool = False,
+    ) -> WebDriver | None:
+        """Launch the WebDriver and load the given URL."""
+        write_log("Ouverture du navigateur", self.log_file, "DEBUG")
+        self.driver = ouvrir_navigateur_sur_ecran_principal(
+            plein_ecran=fullscreen,
+            url=url,
+            headless=headless,
+            no_sandbox=no_sandbox,
+        )
+        if self.driver is not None:
+            self.driver = definir_taille_navigateur(self.driver, 1260, 800)
+            wait_for_dom_ready(self.driver, LONG_TIMEOUT)
+        return self.driver
+
+    def close(self) -> None:
+        """Close the WebDriver if started."""
+        if self.driver is not None:
+            write_log("Fermeture du navigateur", self.log_file, "DEBUG")
+            self.driver.quit()
+            self.driver = None
 
 
 class BrowserSession:
@@ -49,3 +103,11 @@ class BrowserSession:
             write_log("Fermeture du navigateur", self.log_file, "DEBUG")
         self._manager.close()
         self.driver = None
+
+    # ------------------------------------------------------------------
+    # DOM helpers
+    # ------------------------------------------------------------------
+    def wait_for_dom(self, driver) -> None:
+        """Wait until the DOM is stable and fully loaded."""
+        wait_until_dom_is_stable(driver, timeout=DEFAULT_TIMEOUT)
+        wait_for_dom_ready(driver, LONG_TIMEOUT)

--- a/src/sele_saisie_auto/selenium_driver_manager.py
+++ b/src/sele_saisie_auto/selenium_driver_manager.py
@@ -1,60 +1,7 @@
 from __future__ import annotations
 
-from selenium.webdriver.remote.webdriver import WebDriver
+"""Backward compatibility wrapper for ``SeleniumDriverManager``."""
 
-from sele_saisie_auto.logger_utils import write_log
-from sele_saisie_auto.selenium_utils import (
-    LONG_TIMEOUT,
-    definir_taille_navigateur,
-    ouvrir_navigateur_sur_ecran_principal,
-    wait_for_dom_ready,
-)
+from sele_saisie_auto.automation.browser_session import SeleniumDriverManager
 
-
-class SeleniumDriverManager:
-    """Handle WebDriver lifecycle for the automation."""
-
-    def __init__(self, log_file: str) -> None:
-        self.log_file = log_file
-        self.driver: WebDriver | None = None
-
-    def __enter__(self) -> SeleniumDriverManager:
-        """Return itself when used as a context manager."""
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        tb: object | None,
-    ) -> None:
-        """Ensure the driver is closed when leaving a context."""
-        self.close()
-
-    def open(
-        self,
-        url: str,
-        *,
-        fullscreen: bool = False,
-        headless: bool = False,
-        no_sandbox: bool = False,
-    ) -> WebDriver | None:
-        """Launch the WebDriver and load the given URL."""
-        write_log("Ouverture du navigateur", self.log_file, "DEBUG")
-        self.driver = ouvrir_navigateur_sur_ecran_principal(
-            plein_ecran=fullscreen,
-            url=url,
-            headless=headless,
-            no_sandbox=no_sandbox,
-        )
-        if self.driver is not None:
-            self.driver = definir_taille_navigateur(self.driver, 1260, 800)
-            wait_for_dom_ready(self.driver, LONG_TIMEOUT)
-        return self.driver
-
-    def close(self) -> None:
-        """Close the WebDriver if started."""
-        if self.driver is not None:
-            write_log("Fermeture du navigateur", self.log_file, "DEBUG")
-            self.driver.quit()
-            self.driver = None
+__all__ = ["SeleniumDriverManager"]

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -110,3 +110,19 @@ def test_open_and_close_log(monkeypatch):
     assert "Ouverture du navigateur" in logs[0]
     assert "Fermeture du navigateur" in logs[1]
     assert "closed" in logs
+
+
+def test_wait_for_dom(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_until_dom_is_stable",
+        lambda d, timeout=10: calls.append("stable"),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_for_dom_ready",
+        lambda d, timeout: calls.append("ready"),
+    )
+    session = BrowserSession("log.html")
+    session.wait_for_dom("drv")
+
+    assert calls == ["stable", "ready"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -36,7 +36,6 @@ def test_run_invokes_hook(monkeypatch, sample_config):
             mem_password=object(),
         ),
     )
-    monkeypatch.setattr(sap, "SeleniumDriverManager", DummyManager)
 
     monkeypatch.setattr(sap.LoginHandler, "login", lambda *a, **k: None)
     monkeypatch.setattr(sap.DateEntryPage, "handle_date_input", lambda *a, **k: None)
@@ -71,8 +70,14 @@ def test_run_invokes_hook(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    monkeypatch.setattr(sap, "wait_until_dom_is_stable", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "wait_for_dom_ready", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_until_dom_is_stable",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_for_dom_ready",
+        lambda *a, **k: None,
+    )
     monkeypatch.setattr(sap, "program_break_time", lambda *a, **k: None)
     monkeypatch.setattr(
         sap.remplir_jours_feuille_de_temps, "main", lambda *a, **k: None

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -224,7 +224,6 @@ def test_main_flow(monkeypatch, sample_config):
             mem_password=object(),
         ),
     )
-    monkeypatch.setattr(sap, "SeleniumDriverManager", DummyManager)
 
     def fake_wait(driver, by, ident, *a, **k):
         class Elem:
@@ -250,8 +249,14 @@ def test_main_flow(monkeypatch, sample_config):
     monkeypatch.setattr(sap, "click_element_without_wait", lambda *a, **k: None)
     monkeypatch.setattr(sap, "send_keys_to_element", lambda *a, **k: None)
     monkeypatch.setattr(sap, "wait_for_dom", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "wait_until_dom_is_stable", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "wait_for_dom_ready", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_until_dom_is_stable",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_for_dom_ready",
+        lambda *a, **k: None,
+    )
     monkeypatch.setattr(sap, "program_break_time", lambda *a, **k: None)
     monkeypatch.setattr(
         sap.remplir_jours_feuille_de_temps, "main", lambda *a, **k: None

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -201,15 +201,20 @@ def test_main_exceptions(monkeypatch, sample_config):
             mem_password=object(),
         ),
     )
-    monkeypatch.setattr(sap, "SeleniumDriverManager", DummyManager)
     monkeypatch.setattr(sap, "wait_for_element", lambda *a, **k: True)
     monkeypatch.setattr(sap, "modifier_date_input", lambda *a, **k: None)
     monkeypatch.setattr(sap, "switch_to_iframe_by_id_or_name", lambda *a, **k: True)
     monkeypatch.setattr(sap, "click_element_without_wait", lambda *a, **k: None)
     monkeypatch.setattr(sap, "send_keys_to_element", lambda *a, **k: None)
     monkeypatch.setattr(sap, "wait_for_dom", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "wait_until_dom_is_stable", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "wait_for_dom_ready", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_until_dom_is_stable",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.wait_for_dom_ready",
+        lambda *a, **k: None,
+    )
     monkeypatch.setattr(sap, "program_break_time", lambda *a, **k: None)
     monkeypatch.setattr(
         sap.remplir_jours_feuille_de_temps, "main", lambda *a, **k: None

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -32,12 +32,12 @@ class DummyManager:
 def test_wait_for_dom(monkeypatch):
     calls = []
     monkeypatch.setattr(
-        sap,
-        "wait_until_dom_is_stable",
+        "sele_saisie_auto.automation.browser_session.wait_until_dom_is_stable",
         lambda driver, timeout=10: calls.append("stable"),
     )
     monkeypatch.setattr(
-        sap, "wait_for_dom_ready", lambda driver, timeout: calls.append("ready")
+        "sele_saisie_auto.automation.browser_session.wait_for_dom_ready",
+        lambda driver, timeout: calls.append("ready"),
     )
     sap.wait_for_dom("driver")
     assert calls == ["stable", "ready"]

--- a/tests/test_selenium_driver_manager.py
+++ b/tests/test_selenium_driver_manager.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from sele_saisie_auto.selenium_driver_manager import SeleniumDriverManager  # noqa: E402
+from sele_saisie_auto.automation.browser_session import (  # noqa: E402
+    SeleniumDriverManager,
+)
 
 
 def test_open_calls_utils(monkeypatch):
@@ -19,15 +21,16 @@ def test_open_calls_utils(monkeypatch):
         return Dummy()
 
     monkeypatch.setattr(
-        "sele_saisie_auto.selenium_driver_manager.ouvrir_navigateur_sur_ecran_principal",
+        "sele_saisie_auto.automation.browser_session.ouvrir_navigateur_sur_ecran_principal",
         fake_open,
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.selenium_driver_manager.definir_taille_navigateur",
+        "sele_saisie_auto.automation.browser_session.definir_taille_navigateur",
         lambda driver, w, h: driver,
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.selenium_driver_manager.wait_for_dom_ready", lambda d, t: None
+        "sele_saisie_auto.automation.browser_session.wait_for_dom_ready",
+        lambda d, t: None,
     )
 
     manager = SeleniumDriverManager("log.html")
@@ -54,7 +57,7 @@ def test_close_quits_driver(monkeypatch):
 
 def test_open_returns_none(monkeypatch):
     monkeypatch.setattr(
-        "sele_saisie_auto.selenium_driver_manager.ouvrir_navigateur_sur_ecran_principal",
+        "sele_saisie_auto.automation.browser_session.ouvrir_navigateur_sur_ecran_principal",
         lambda *a, **k: None,
     )
     manager = SeleniumDriverManager("log.html")


### PR DESCRIPTION
## Contexte et objectif
- intégration complète de `SeleniumDriverManager` dans `BrowserSession`
- ajout de l'aide `wait_for_dom` et exposition via `BrowserSession`
- mise à jour de `PSATimeAutomation` pour utiliser la nouvelle API
- adaptation des tests unitaires

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
- centralise l'ouverture/fermeture du navigateur et l'attente du DOM dans `BrowserSession`
- les appels externes utilisent désormais `BrowserSession` directement

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68692274355c8321b1f071a9c3631fe1