### PR TITLE
[LoginHandler] intégrer connect_to_psatime

### DIFF
--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -20,7 +20,7 @@ class SeleniumDriverManager:
         self.log_file = log_file
         self.driver: WebDriver | None = None
 
-    def __enter__(self) -> "SeleniumDriverManager":
+    def __enter__(self) -> SeleniumDriverManager:
         return self
 
     def __exit__(

--- a/src/sele_saisie_auto/automation/login_handler.py
+++ b/src/sele_saisie_auto/automation/login_handler.py
@@ -1,30 +1,61 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.remote.webdriver import WebDriver
 
+from sele_saisie_auto.automation.browser_session import BrowserSession
+from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import write_log
-from sele_saisie_auto.selenium_utils import send_keys_to_element
+from sele_saisie_auto.selenium_utils import send_keys_to_element, wait_for_dom_after
 
 
 class LoginHandler:
     """Handle login steps for PSA Time."""
 
-    def __init__(self, log_file: str | None = None) -> None:
+    def __init__(
+        self,
+        log_file: str | None,
+        encryption_service: EncryptionService,
+        browser_session: BrowserSession,
+    ) -> None:
         self.log_file = log_file
+        self.encryption_service = encryption_service
+        self.browser_session = browser_session
 
-    def login(self, driver: WebDriver, credentials, encryption_service) -> None:
+    def wait_for_dom(self, driver: WebDriver) -> None:
+        """Delegate DOM wait to :class:`BrowserSession`."""
+        self.browser_session.wait_for_dom(driver)
+
+    def login(self, driver: WebDriver, credentials) -> None:
         """Fill username and password fields using decrypted credentials."""
         write_log("Déchiffrement des identifiants", self.log_file, "DEBUG")
-        username = encryption_service.dechiffrer_donnees(
+        username = self.encryption_service.dechiffrer_donnees(
             credentials.login, credentials.aes_key
         )
-        password = encryption_service.dechiffrer_donnees(
+        password = self.encryption_service.dechiffrer_donnees(
             credentials.password, credentials.aes_key
         )
         write_log("Envoi des identifiants", self.log_file, "DEBUG")
         send_keys_to_element(driver, By.ID, Locators.USERNAME.value, username)
         send_keys_to_element(driver, By.ID, Locators.PASSWORD.value, password)
         send_keys_to_element(driver, By.ID, Locators.PASSWORD.value, Keys.RETURN)
+
+    @wait_for_dom_after
+    def connect_to_psatime(
+        self,
+        driver: WebDriver,
+        cle_aes: bytes,
+        nom_utilisateur_chiffre: bytes,
+        mot_de_passe_chiffre: bytes,
+    ) -> None:
+        """Connecte l'utilisateur au portail PSATime."""
+        creds = SimpleNamespace(
+            aes_key=cle_aes,
+            login=nom_utilisateur_chiffre,
+            password=mot_de_passe_chiffre,
+        )
+        self.login(driver, creds)

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -28,15 +28,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.shared_utils import program_break_time
 
 # ------------------------------------------------------------------------------------------- #

--- a/tests/test_login_handler.py
+++ b/tests/test_login_handler.py
@@ -23,15 +23,23 @@ class DummyCreds:
         self.aes_key = b"key"
 
 
+class DummySession:
+    def __init__(self):
+        self.wait_calls = []
+
+    def wait_for_dom(self, driver):
+        self.wait_calls.append(driver)
+
+
 def test_login_calls_send_keys(monkeypatch):
     actions = []
     monkeypatch.setattr(
         "sele_saisie_auto.automation.login_handler.send_keys_to_element",
         lambda driver, by, ident, value: actions.append((ident, value)),
     )
-    handler = LoginHandler("log.html")
     enc = DummyEnc()
-    handler.login("driver", DummyCreds(), enc)
+    handler = LoginHandler("log.html", enc, DummySession())
+    handler.login("driver", DummyCreds())
 
     assert (Locators.USERNAME.value, "user") in actions
     assert (Locators.PASSWORD.value, "pass") in actions
@@ -45,9 +53,9 @@ def test_login_presses_return(monkeypatch):
         "sele_saisie_auto.automation.login_handler.send_keys_to_element",
         lambda driver, by, ident, value: actions.append(value),
     )
-    handler = LoginHandler("log.html")
     enc = DummyEnc()
-    handler.login("driver", DummyCreds(), enc)
+    handler = LoginHandler("log.html", enc, DummySession())
+    handler.login("driver", DummyCreds())
 
     from selenium.webdriver.common.keys import Keys
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -4,7 +4,7 @@ import pytest
 
 from sele_saisie_auto import console_ui, plugins
 from sele_saisie_auto import saisie_automatiser_psatime as sap
-from tests.test_saisie_automatiser_psatime import DummyManager, setup_init
+from tests.test_saisie_automatiser_psatime import setup_init
 
 pytestmark = pytest.mark.slow
 
@@ -37,7 +37,7 @@ def test_run_invokes_hook(monkeypatch, sample_config):
         ),
     )
 
-    monkeypatch.setattr(sap.LoginHandler, "login", lambda *a, **k: None)
+    monkeypatch.setattr(sap.LoginHandler, "connect_to_psatime", lambda *a, **k: None)
     monkeypatch.setattr(sap.DateEntryPage, "handle_date_input", lambda *a, **k: None)
     monkeypatch.setattr(
         sap.PSATimeAutomation, "submit_date_cible", lambda *a, **k: False

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -94,12 +94,12 @@ class DummyBrowserSession:
 
 
 class DummyLoginHandler:
-    def __init__(self, log_file):
+    def __init__(self, log_file, enc, session):
         self.log_file = log_file
         self.calls = []
 
-    def login(self, driver, creds, enc):
-        self.calls.append((driver, creds, enc))
+    def connect_to_psatime(self, driver, key, login, pwd):
+        self.calls.append((driver, key, login, pwd))
 
 
 class DummyDateEntryPage:

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -91,10 +91,13 @@ def test_connect_to_psatime(monkeypatch, sample_config):
         lambda driver, by, ident, value: actions.append((ident, value)),
     )
     sap.context.encryption_service = DummyEnc()
-    creds = types.SimpleNamespace(aes_key=b"key", login=b"user", password=b"pass")
-    sap._AUTOMATION.login_handler.login("drv", creds, sap.context.encryption_service)
+    sap._AUTOMATION.login_handler.browser_session.wait_for_dom = (
+        lambda d: actions.append("dom")
+    )
+    sap._AUTOMATION.login_handler.connect_to_psatime("drv", b"key", b"user", b"pass")
     assert (Locators.USERNAME.value, "user") in actions
     assert (Locators.PASSWORD.value, "pass") in actions
+    assert "dom" in actions
 
 
 def test_switch_to_iframe(monkeypatch):


### PR DESCRIPTION
## Contexte et objectif
- centraliser la connexion à PSA Time dans `LoginHandler`
- injection des dépendances `EncryptionService` et `BrowserSession`
- mise à jour des tests pour cette nouvelle interface

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`
3. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686950d2d384832190ded7a33d2a175d