### PR TITLE
[SeleniumUtils] centralise timeouts

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -8,7 +8,8 @@ from selenium.webdriver.support import expected_conditions as ec
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.remplir_informations_supp_utils import ExtraInfoHelper
-from sele_saisie_auto.selenium_utils import DEFAULT_TIMEOUT, wait_for_dom_after
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 
 if TYPE_CHECKING:  # pragma: no cover
     from sele_saisie_auto.saisie_automatiser_psatime import PSATimeAutomation

--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -4,13 +4,12 @@ from selenium.webdriver.remote.webdriver import WebDriver
 
 from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.selenium_utils import (
-    DEFAULT_TIMEOUT,
-    LONG_TIMEOUT,
     definir_taille_navigateur,
     ouvrir_navigateur_sur_ecran_principal,
     wait_for_dom_ready,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 
 class SeleniumDriverManager:

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -9,8 +9,9 @@ from selenium.webdriver.support import expected_conditions as ec
 
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import write_log
-from sele_saisie_auto.selenium_utils import DEFAULT_TIMEOUT, wait_for_dom_after
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_utils import program_break_time
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 
 if TYPE_CHECKING:  # pragma: no cover
     from sele_saisie_auto.saisie_automatiser_psatime import PSATimeAutomation

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -15,6 +15,7 @@ from sele_saisie_auto.selenium_utils import (
     verifier_champ_jour_rempli,
     wait_for_element,
 )
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 
 # remplir_informations_supp_france.py
 
@@ -32,9 +33,6 @@ def set_log_file(log_file: str) -> None:
     global LOG_FILE
     LOG_FILE = log_file
 
-
-DEFAULT_TIMEOUT = 10  # Délai d'attente par défaut
-LONG_TIMEOUT = 20
 
 # ------------------------------------------------------------------------------------------- #
 # ----------------------------------- FONCTIONS --------------------------------------------- #

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -38,6 +38,7 @@ from sele_saisie_auto.selenium_utils import (
     wait_until_dom_is_stable,
 )
 from sele_saisie_auto.shared_utils import program_break_time
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 # ------------------------------------------------------------------------------------------- #
 # ----------------------------------- CONSTANTE --------------------------------------------- #
@@ -50,8 +51,6 @@ JOURS_DE_TRAVAIL = {}
 INFORMATIONS_PROJET_MISSION = {}
 
 MAX_ATTEMPTS = 5
-DEFAULT_TIMEOUT = 10  # Délai d'attente par défaut
-LONG_TIMEOUT = 20
 
 
 def initialize(log_file: str) -> None:

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -49,6 +49,7 @@ from sele_saisie_auto.selenium_utils import (
 )
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.shared_utils import program_break_time
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 
 # ----------------------------------------------------------------------------- #
 # ------------------------------- CONSTANTE ----------------------------------- #
@@ -468,8 +469,6 @@ class PSATimeAutomation:
 
 
 CHOIX_USER = True  # true pour créer une nouvelle feuille de temps
-DEFAULT_TIMEOUT = 10  # Délai d'attente par défaut
-LONG_TIMEOUT = 20
 
 # Configuration memoire partagée et cryptage
 MEMOIRE_PARTAGEE_CLE = "memoire_partagee_cle"

--- a/src/sele_saisie_auto/selenium_utils/__init__.py
+++ b/src/sele_saisie_auto/selenium_utils/__init__.py
@@ -15,6 +15,7 @@ from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 LOG_FILE: str | None = None
 
@@ -24,9 +25,6 @@ def set_log_file(log_file: str) -> None:
     global LOG_FILE
     LOG_FILE = log_file
 
-
-DEFAULT_TIMEOUT = 10
-LONG_TIMEOUT = 20
 
 from .element_actions import (
     click_element_without_wait,

--- a/src/sele_saisie_auto/selenium_utils/wait_helpers.py
+++ b/src/sele_saisie_auto/selenium_utils/wait_helpers.py
@@ -9,7 +9,9 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 
-from . import DEFAULT_TIMEOUT, LOG_FILE, write_log
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
+
+from . import LOG_FILE, write_log
 
 
 class Waiter:

--- a/src/sele_saisie_auto/timeouts.py
+++ b/src/sele_saisie_auto/timeouts.py
@@ -1,0 +1,7 @@
+"""Timeout configuration for Selenium actions."""
+
+DEFAULT_TIMEOUT = 10
+"""Standard wait time used across the automation."""
+
+LONG_TIMEOUT = 20
+"""Longer wait time for slower pages."""


### PR DESCRIPTION
## Contexte
Les constantes `DEFAULT_TIMEOUT` et `LONG_TIMEOUT` étaient dupliquées dans plusieurs modules.

## Changements
- ajout du fichier `timeouts.py` exposant les valeurs communes
- import de ces constantes depuis les modules concernés
- suppression des définitions redondantes

## Test
- `poetry run pre-commit run --files <modifs>`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68695d99653083218394edfd457d8b2c