### PR TITLE
[SeleniumFiller] injection du choix utilisateur

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -18,7 +18,13 @@ le navigateur Selenium pour remplir la feuille de temps.
 
 ```python
 class PSATimeAutomation:
-    def __init__(self, log_file: str, app_config: AppConfig) -> None:
+    def __init__(
+        self,
+        log_file: str,
+        app_config: AppConfig,
+        choix_user: bool = True,
+        memory_config: MemoryConfig | None = None,
+    ) -> None:
         """Prépare la configuration et les services nécessaires."""
 ```
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -110,11 +110,18 @@ __all__ = [
 class PSATimeAutomation:
     """Automatise la saisie de la feuille de temps PSA Time."""
 
-    def __init__(self, log_file: str, app_config: AppConfig) -> None:
+    def __init__(
+        self,
+        log_file: str,
+        app_config: AppConfig,
+        choix_user: bool = True,
+        memory_config: MemoryConfig | None = None,
+    ) -> None:
         """Initialise la configuration et les dépendances."""
 
         self.log_file = log_file
-        self.memory_config = MemoryConfig()
+        self.choix_user = choix_user
+        self.memory_config = memory_config or MemoryConfig()
         set_log_file_selenium(log_file)
         set_log_file_infos(log_file)
         initialize_logger(app_config.raw, log_level_override=app_config.debug_mode)
@@ -396,7 +403,7 @@ class PSATimeAutomation:
         self.date_entry_page._handle_date_alert(driver)
 
     def _click_action_button(self, driver) -> None:
-        self.date_entry_page._click_action_button(driver, CHOIX_USER)
+        self.date_entry_page._click_action_button(driver, self.choix_user)
 
     def _process_date_entry(self, driver) -> None:
         self.date_entry_page.process_date(driver, self.context.config.date_cible)
@@ -478,9 +485,6 @@ class PSATimeAutomation:
                         credentials.mem_login,
                         credentials.mem_password,
                     )
-
-
-CHOIX_USER = True  # true pour créer une nouvelle feuille de temps
 
 
 # ------------------------------------------------------------------------------------------------- #
@@ -576,10 +580,20 @@ context: SaisieContext | None = None
 LOG_FILE: str | None = None
 
 
-def initialize(log_file: str, app_config: AppConfig) -> None:
+def initialize(
+    log_file: str,
+    app_config: AppConfig,
+    choix_user: bool = True,
+    memory_config: MemoryConfig | None = None,
+) -> None:
     """Instancie l'automatisation."""
     global _AUTOMATION, context, LOG_FILE
-    _AUTOMATION = PSATimeAutomation(log_file, app_config)
+    _AUTOMATION = PSATimeAutomation(
+        log_file,
+        app_config,
+        choix_user=choix_user,
+        memory_config=memory_config,
+    )
     context = _AUTOMATION.context
     LOG_FILE = log_file
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -21,7 +21,7 @@ def test_run_invokes_hook(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
     sap.context.config.url = "http://test"
     sap.context.config.date_cible = "06/07/2024"
-    sap.CHOIX_USER = True
+    sap._AUTOMATION.choix_user = True
 
     monkeypatch.setattr(sap, "log_initialisation", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -209,7 +209,7 @@ def test_main_flow(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
     sap.context.config.url = "http://test"
     sap.context.config.date_cible = "06/07/2024"
-    sap.CHOIX_USER = True
+    sap._AUTOMATION.choix_user = True
 
     monkeypatch.setattr(sap, "log_initialisation", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -190,7 +190,7 @@ EXCEPTIONS = [
 
 def test_main_exceptions(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
-    sap.CHOIX_USER = True
+    sap._AUTOMATION.choix_user = True
     monkeypatch.setattr(sap, "log_initialisation", lambda: None)
     monkeypatch.setattr(
         sap.PSATimeAutomation,


### PR DESCRIPTION
## Contexte
- passage du paramètre `choix_user` et de la configuration mémoire dans `PSATimeAutomation`
- retrait de la constante globale `CHOIX_USER`

## Changements
- injection des nouveaux paramètres dans `PSATimeAutomation.__init__`
- mise à jour des tests utilisant cette constante
- ajustement de la documentation API

## Test
- `poetry run pre-commit run --files src/sele_saisie_auto/saisie_automatiser_psatime.py docs/reference/api-reference.md tests/test_saisie_automatiser_psatime.py tests/test_plugins.py tests/test_saisie_automatiser_psatime_additional.py`
- `poetry run pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68696c8ed3908321a7886000dfce1334