### PR TITLE
[ExtraInfoHelper] pass log file explicitly

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -73,7 +73,7 @@ class AdditionalInfoPage:
 
         if switched_to_iframe:
             for config in self._automation.context.descriptions:
-                sap.traiter_description(driver, config)
+                sap.traiter_description(driver, config, self.log_file)
             write_log(
                 "Validation des informations supplémentaires terminée.",
                 self.log_file,

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -33,9 +33,7 @@ from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.error_handler import log_error
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import initialize_logger, write_log
-from sele_saisie_auto.remplir_informations_supp_utils import (
-    set_log_file as set_log_file_infos,
-)
+from sele_saisie_auto.remplir_informations_supp_utils import traiter_description
 from sele_saisie_auto.selenium_utils import click_element_without_wait  # noqa: F401
 from sele_saisie_auto.selenium_utils import modifier_date_input  # noqa: F401
 from sele_saisie_auto.selenium_utils import send_keys_to_element  # noqa: F401
@@ -123,7 +121,6 @@ class PSATimeAutomation:
         self.choix_user = choix_user
         self.memory_config = memory_config or MemoryConfig()
         set_log_file_selenium(log_file)
-        set_log_file_infos(log_file)
         initialize_logger(app_config.raw, log_level_override=app_config.debug_mode)
         shm_service = SharedMemoryService(log_file)
         self.context = SaisieContext(

--- a/tests/test_extra_info_helper.py
+++ b/tests/test_extra_info_helper.py
@@ -27,7 +27,7 @@ def test_traiter_description_not_found(monkeypatch):
     messages = []
     monkeypatch.setattr(risu, "write_log", lambda msg, f, level: messages.append(msg))
     monkeypatch.setattr(risu, "trouver_ligne_par_description", lambda *a, **k: None)
-    risu.traiter_description(None, make_config())
+    risu.traiter_description(None, make_config(), "log")
     assert any("non trouv\u00e9e" in m for m in messages)
 
 
@@ -61,7 +61,7 @@ def test_traiter_description_input(monkeypatch):
         risu, "remplir_champ_texte", lambda el, jour, val: filled.append((jour, val))
     )
 
-    risu.traiter_description(None, make_config())
+    risu.traiter_description(None, make_config(), "log")
 
     assert ("lundi", "val_lundi") in filled
     assert ("dimanche", "val_dimanche") not in filled
@@ -94,21 +94,12 @@ def test_traiter_description_select_special(monkeypatch):
         id_value_jours=AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value,
     )
     del cfg["valeurs_a_remplir"]["mardi"]
-    risu.traiter_description(None, cfg)
+    risu.traiter_description(None, cfg, "log")
 
     assert f"{cfg['id_value_jours']}11$0" in ids
     assert selected
     assert any(messages.AUCUNE_VALEUR in m for m in logs)
     assert any(messages.IMPOSSIBLE_DE_TROUVER in m for m in logs)
-
-
-def test_set_log_file(tmp_path, monkeypatch):
-    import importlib
-
-    module = importlib.reload(risu)
-    path = tmp_path / "log.txt"
-    module.set_log_file(str(path))
-    assert module.LOG_FILE == str(path)
 
 
 def test_traiter_description_unknown_type(monkeypatch):
@@ -126,5 +117,5 @@ def test_traiter_description_unknown_type(monkeypatch):
         risu, "remplir_champ_texte", lambda *a, **k: called.append("input")
     )
     cfg = make_config(type_element="other")
-    risu.traiter_description(None, cfg)
+    risu.traiter_description(None, cfg, "log")
     assert not called

--- a/tests/test_remplir_informations_supp_utils.py
+++ b/tests/test_remplir_informations_supp_utils.py
@@ -29,7 +29,7 @@ def test_traiter_description_row_not_found(monkeypatch):
     logs = []
     monkeypatch.setattr(risu, "write_log", lambda msg, f, level: logs.append(msg))
     monkeypatch.setattr(risu, "trouver_ligne_par_description", lambda *a, **k: None)
-    risu.traiter_description(None, make_config())
+    risu.traiter_description(None, make_config(), "log")
     assert any("non trouv" in m for m in logs)
 
 
@@ -69,7 +69,7 @@ def test_traiter_description_fill_input(monkeypatch):
 
     cfg = make_config()
     del cfg["valeurs_a_remplir"]["mardi"]
-    risu.traiter_description(None, cfg)
+    risu.traiter_description(None, cfg, "log")
 
     assert f"{AdditionalInfoLocators.DAY_UC_DAILYREST.value}1$1" in ids
 
@@ -92,5 +92,5 @@ def test_traiter_description_select(monkeypatch):
     )
 
     cfg = make_config(type_element="select")
-    risu.traiter_description(None, cfg)
+    risu.traiter_description(None, cfg, "log")
     assert "val_lundi" in selected

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -143,7 +143,6 @@ def setup_init(monkeypatch, cfg):
 
     app_cfg = AppConfig.from_parser(cfg)
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
-    monkeypatch.setattr(sap, "set_log_file_infos", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyEnc())
     monkeypatch.setattr(sap, "SharedMemoryService", lambda lf: DummySHMService())
     monkeypatch.setattr(sap, "BrowserSession", DummyBrowserSession)

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -69,7 +69,6 @@ def setup_init(monkeypatch, cfg):
 
     app_cfg = AppConfig.from_parser(cfg)
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
-    monkeypatch.setattr(sap, "set_log_file_infos", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyEnc())
     monkeypatch.setattr(sap, "SharedMemoryService", lambda lf: DummySHMService())
     sap.initialize(

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -101,7 +101,6 @@ def test_initialize_debug_mode_off(monkeypatch, sample_config, tmp_path):
     )
     log_path = tmp_path / "log.html"
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
-    monkeypatch.setattr(sap, "set_log_file_infos", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyManager())
     app_cfg.debug_mode = "OFF"
     sap.initialize(

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -22,7 +22,6 @@ def test_initialize_date_none(monkeypatch, sample_config):
 
     app_cfg = AppConfig.from_parser(cfg)
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
-    monkeypatch.setattr(sap, "set_log_file_infos", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyEnc())
     sap.initialize(
         "log.html",


### PR DESCRIPTION
## Summary
- remove module log global and setter
- pass `log_file` to helper functions
- adapt `AdditionalInfoPage` and automation
- update associated tests

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/remplir_informations_supp_utils.py src/sele_saisie_auto/automation/additional_info_page.py src/sele_saisie_auto/saisie_automatiser_psatime.py tests/test_extra_info_helper.py tests/test_remplir_informations_supp_utils.py tests/test_saisie_automatiser_psatime.py tests/test_saisie_automatiser_psatime_cover.py tests/test_saisie_automatiser_psatime_additional.py tests/test_saisie_automatiser_psatime_extra.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869707436d083219bbccfd071aaad17