### PR TITLE
[ExtraInfoHelper] store log_file

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -20,7 +20,7 @@ class AdditionalInfoPage:
 
     def __init__(self, automation: PSATimeAutomation) -> None:
         self._automation = automation
-        self.helper = ExtraInfoHelper(page=self)
+        self.helper = ExtraInfoHelper(log_file=self.log_file, page=self)
         from sele_saisie_auto import saisie_automatiser_psatime as sap
 
         sap.traiter_description = self.helper.traiter_description
@@ -73,7 +73,7 @@ class AdditionalInfoPage:
 
         if switched_to_iframe:
             for config in self._automation.context.descriptions:
-                sap.traiter_description(driver, config, self.log_file)
+                sap.traiter_description(driver, config)
             write_log(
                 "Validation des informations supplémentaires terminée.",
                 self.log_file,

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -182,17 +182,19 @@ class ExtraInfoHelper:
 
     def __init__(
         self,
+        log_file: str,
         waiter: Waiter | None = None,
         page: "AdditionalInfoPage" | None = None,
     ) -> None:
         self.waiter = waiter or Waiter()
         self.page = page
+        self.log_file = log_file
 
     def set_page(self, page: "AdditionalInfoPage") -> None:
         self.page = page
 
-    def traiter_description(self, driver, config, log_file: str):
-        traiter_description(driver, config, log_file, waiter=self.waiter)
+    def traiter_description(self, driver, config):
+        traiter_description(driver, config, self.log_file, waiter=self.waiter)
 
     # ------------------------------------------------------------------
     # Delegation to :class:`AdditionalInfoPage`


### PR DESCRIPTION
## Contexte et objectif
- instancier `ExtraInfoHelper` avec le chemin de log
- simplifier l'appel à `traiter_description`

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact
- `AdditionalInfoPage` utilise désormais un helper initialisé avec `self.log_file`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6869743b18c08321838e5ad231857f44