### PR TITLE
[ExtraInfoHelper] update tests

### DIFF
--- a/tests/test_extra_info_helper.py
+++ b/tests/test_extra_info_helper.py
@@ -8,6 +8,9 @@ from sele_saisie_auto import remplir_informations_supp_utils as risu  # noqa: E4
 from sele_saisie_auto.additional_info_locators import (  # noqa: E402
     AdditionalInfoLocators,
 )
+from sele_saisie_auto.remplir_informations_supp_utils import (  # noqa: E402
+    ExtraInfoHelper,
+)
 
 
 def make_config(**overrides):
@@ -27,7 +30,9 @@ def test_traiter_description_not_found(monkeypatch):
     messages = []
     monkeypatch.setattr(risu, "write_log", lambda msg, f, level: messages.append(msg))
     monkeypatch.setattr(risu, "trouver_ligne_par_description", lambda *a, **k: None)
-    risu.traiter_description(None, make_config(), "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, make_config())
     assert any("non trouv\u00e9e" in m for m in messages)
 
 
@@ -61,7 +66,9 @@ def test_traiter_description_input(monkeypatch):
         risu, "remplir_champ_texte", lambda el, jour, val: filled.append((jour, val))
     )
 
-    risu.traiter_description(None, make_config(), "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, make_config())
 
     assert ("lundi", "val_lundi") in filled
     assert ("dimanche", "val_dimanche") not in filled
@@ -94,7 +101,9 @@ def test_traiter_description_select_special(monkeypatch):
         id_value_jours=AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value,
     )
     del cfg["valeurs_a_remplir"]["mardi"]
-    risu.traiter_description(None, cfg, "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, cfg)
 
     assert f"{cfg['id_value_jours']}11$0" in ids
     assert selected
@@ -117,5 +126,7 @@ def test_traiter_description_unknown_type(monkeypatch):
         risu, "remplir_champ_texte", lambda *a, **k: called.append("input")
     )
     cfg = make_config(type_element="other")
-    risu.traiter_description(None, cfg, "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, cfg)
     assert not called

--- a/tests/test_remplir_informations_supp_utils.py
+++ b/tests/test_remplir_informations_supp_utils.py
@@ -8,6 +8,9 @@ from sele_saisie_auto import remplir_informations_supp_utils as risu  # noqa: E4
 from sele_saisie_auto.additional_info_locators import (  # noqa: E402
     AdditionalInfoLocators,
 )
+from sele_saisie_auto.remplir_informations_supp_utils import (  # noqa: E402
+    ExtraInfoHelper,
+)
 
 # Helper to build config dictionaries
 
@@ -29,7 +32,9 @@ def test_traiter_description_row_not_found(monkeypatch):
     logs = []
     monkeypatch.setattr(risu, "write_log", lambda msg, f, level: logs.append(msg))
     monkeypatch.setattr(risu, "trouver_ligne_par_description", lambda *a, **k: None)
-    risu.traiter_description(None, make_config(), "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, make_config())
     assert any("non trouv" in m for m in logs)
 
 
@@ -69,7 +74,9 @@ def test_traiter_description_fill_input(monkeypatch):
 
     cfg = make_config()
     del cfg["valeurs_a_remplir"]["mardi"]
-    risu.traiter_description(None, cfg, "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, cfg)
 
     assert f"{AdditionalInfoLocators.DAY_UC_DAILYREST.value}1$1" in ids
 
@@ -92,5 +99,7 @@ def test_traiter_description_select(monkeypatch):
     )
 
     cfg = make_config(type_element="select")
-    risu.traiter_description(None, cfg, "log")
+    helper = ExtraInfoHelper(log_file="log")
+    helper.waiter = None
+    helper.traiter_description(None, cfg)
     assert "val_lundi" in selected


### PR DESCRIPTION
## Contexte
Les tests utilisaient encore la fonction `traiter_description` sans tenir compte
du nouvel objet `ExtraInfoHelper`.

## Changements
- instanciation d'`ExtraInfoHelper(log_file="log")` dans les tests
- désactivation du `waiter` afin d'utiliser les fonctions patchées
- appel mis à jour de `traiter_description`

## Impact
Pas d'impact sur les autres agents. Les tests passent de nouveau.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686976139f8c8321aafea3b8521c042b