### PR TITLE
[TimeSheetHelper] Ajout dataclass pour le contexte

### DIFF
--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -184,13 +184,13 @@ class ExtraInfoHelper:
         self,
         log_file: str,
         waiter: Waiter | None = None,
-        page: "AdditionalInfoPage" | None = None,
+        page: AdditionalInfoPage | None = None,
     ) -> None:
         self.waiter = waiter or Waiter()
         self.page = page
         self.log_file = log_file
 
-    def set_page(self, page: "AdditionalInfoPage") -> None:
+    def set_page(self, page: AdditionalInfoPage) -> None:
         self.page = page
 
     def traiter_description(self, driver, config):

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -33,7 +33,6 @@ from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.error_handler import log_error
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import initialize_logger, write_log
-from sele_saisie_auto.remplir_informations_supp_utils import traiter_description
 from sele_saisie_auto.selenium_utils import click_element_without_wait  # noqa: F401
 from sele_saisie_auto.selenium_utils import modifier_date_input  # noqa: F401
 from sele_saisie_auto.selenium_utils import send_keys_to_element  # noqa: F401

--- a/tests/test_remplir_jours_main_flow.py
+++ b/tests/test_remplir_jours_main_flow.py
@@ -1,4 +1,3 @@
-import importlib
 import sys
 from pathlib import Path
 
@@ -177,12 +176,11 @@ def test_initialize_sets_globals(monkeypatch):
         lambda lf: None,
     )
 
-    initialize("logfile")
+    ctx = initialize("logfile")
 
-    mod = importlib.import_module("sele_saisie_auto.remplir_jours_feuille_de_temps")
-    assert ["d1", "d2"] == mod.LISTE_ITEMS_DESCRIPTIONS
-    assert {"lun": ("En mission", "8")} == mod.JOURS_DE_TRAVAIL
-    assert {"billing_action": "B"} == mod.INFORMATIONS_PROJET_MISSION
+    assert ["d1", "d2"] == ctx.liste_items_descriptions
+    assert {"lun": ("En mission", "8")} == ctx.jours_de_travail
+    assert {"billing_action": "B"} == ctx.informations_projet_mission
 
 
 def test_traiter_champs_mission_insert(monkeypatch):


### PR DESCRIPTION
## Contexte et objectif
- simplification de l'initialisation de `remplir_jours_feuille_de_temps`
- création d'un dataclass `TimeSheetContext` pour encapsuler la configuration
- adaptation des tests unitaires

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/remplir_jours_feuille_de_temps.py tests/test_remplir_jours_main_flow.py src/sele_saisie_auto/remplir_informations_supp_utils.py src/sele_saisie_auto/saisie_automatiser_psatime.py`
- `poetry run pytest`

## Impact éventuel
- aucun autre agent impacté

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6869793caf948321accb01dc29f4f5e2