### PR TITLE
[TimeSheetHelper] inject context

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -414,7 +414,10 @@ class PSATimeAutomation:
         print()
         self._click_action_button(driver)
         self.wait_for_dom(driver)
-        remplir_jours_feuille_de_temps.main(driver, self.log_file)
+        ctx = remplir_jours_feuille_de_temps.context_from_app_config(
+            self.context.config, self.log_file
+        )
+        remplir_jours_feuille_de_temps.TimeSheetHelper(ctx).run(driver)
         self.navigate_from_work_schedule_to_additional_information_page(driver)
         self.submit_and_validate_additional_information(driver)
         switch_to_default_content(driver)

--- a/tests/test_remplir_jours_main_flow.py
+++ b/tests/test_remplir_jours_main_flow.py
@@ -150,8 +150,8 @@ def test_main_invokes_helper(monkeypatch):
     called = {}
 
     class DummyHelper:
-        def __init__(self, log_file):
-            called["init"] = log_file
+        def __init__(self, ctx):
+            called["init"] = ctx.log_file
 
         def run(self, driver):
             called["run"] = True
@@ -229,7 +229,7 @@ def test_main_with_mission(monkeypatch):
     seq = []
 
     class DummyHelper:
-        def __init__(self, log_file):
+        def __init__(self, ctx):
             seq.append("init")
 
         def run(self, driver):

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -265,7 +265,9 @@ def test_main_flow(monkeypatch, sample_config):
     )
     monkeypatch.setattr(sap, "program_break_time", lambda *a, **k: None)
     monkeypatch.setattr(
-        sap.remplir_jours_feuille_de_temps, "main", lambda *a, **k: None
+        sap.remplir_jours_feuille_de_temps.TimeSheetHelper,
+        "run",
+        lambda self, drv: None,
     )
     monkeypatch.setattr(sap, "traiter_description", lambda *a, **k: None)
     monkeypatch.setattr(sap, "detecter_doublons_jours", lambda *a, **k: None)

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -169,7 +169,9 @@ def test_fill_and_save_timesheet(monkeypatch, sample_config):
     )
     monkeypatch.setattr(auto, "_click_action_button", lambda d: calls.append("click"))
     monkeypatch.setattr(
-        sap.remplir_jours_feuille_de_temps, "main", lambda *a, **k: calls.append("fill")
+        sap.remplir_jours_feuille_de_temps.TimeSheetHelper,
+        "run",
+        lambda self, drv: calls.append("fill"),
     )
     monkeypatch.setattr(
         auto,

--- a/tests/test_timesheet_helper.py
+++ b/tests/test_timesheet_helper.py
@@ -73,9 +73,8 @@ def test_remplir_mission_calls_helpers(monkeypatch):
 
 
 def test_timesheethelper_run_sequence(monkeypatch):
-    helper = TimeSheetHelper("log")
+    helper = TimeSheetHelper(TimeSheetContext("log", [], {}, {}))
     seq = []
-    monkeypatch.setattr(helper, "initialize", lambda: seq.append("init"))
     monkeypatch.setattr(
         helper, "fill_standard_days", lambda d, j: seq.append("std") or j
     )
@@ -90,4 +89,4 @@ def test_timesheethelper_run_sequence(monkeypatch):
         lambda *a, **k: None,
     )
     helper.run(None)
-    assert seq == ["init", "std", "work", "extra"]
+    assert seq == ["std", "work", "extra"]


### PR DESCRIPTION
## Summary
- inject context into `TimeSheetHelper`
- handle context in `PSATimeAutomation`
- adjust tests for new `TimeSheetHelper` signature

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6869881d2f988321abea18afc70a25e5