### PR TITLE
[TimeSheetHelper] add generic insert util

### DIFF
--- a/tests/test_remplir_jours_feuille_de_temps_additional.py
+++ b/tests/test_remplir_jours_feuille_de_temps_additional.py
@@ -74,6 +74,10 @@ def test_traiter_jour_failure(monkeypatch):
         lambda *a, **k: object(),
     )
     monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
         lambda *a, **k: (_ for _ in ()).throw(
             __import__("selenium").common.exceptions.StaleElementReferenceException()
@@ -127,6 +131,10 @@ def test_remplir_mission_specifique_failure(monkeypatch):
         lambda *a, **k: object(),
     )
     monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
         lambda *a, **k: (_ for _ in ()).throw(
             __import__("selenium").common.exceptions.StaleElementReferenceException()
@@ -149,6 +157,10 @@ def test_remplir_mission_specifique_insertion_fail(monkeypatch):
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
         lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
     )
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
@@ -253,6 +265,10 @@ def test_traiter_jour_controle_insertion_fail(monkeypatch):
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
         lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
     )
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",

--- a/tests/test_remplir_jours_main_flow.py
+++ b/tests/test_remplir_jours_main_flow.py
@@ -40,6 +40,10 @@ def test_traiter_jour_paths(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
         lambda *a, **k: object(),
     )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
     calls = {}
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
@@ -79,6 +83,10 @@ def test_remplir_mission_specifique(monkeypatch):
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
         lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
     )
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",

--- a/tests/test_remplir_jours_utils.py
+++ b/tests/test_remplir_jours_utils.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
@@ -8,6 +9,7 @@ from sele_saisie_auto.remplir_jours_feuille_de_temps import (  # noqa: E402
     ajouter_jour_a_jours_remplis,
     est_en_mission,
     est_en_mission_presente,
+    insert_with_retries,
 )
 from sele_saisie_auto.shared_utils import clear_screen  # noqa: E402
 
@@ -38,3 +40,127 @@ def test_utilities(monkeypatch):
     )
     clear_screen()
     assert called["cmd"] in {"cls", "clear"}
+
+
+def test_insert_with_retries(monkeypatch):
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
+        lambda *a, **k: (object(), True),
+    )
+
+    assert insert_with_retries(None, "ID", "8", None) is True
+
+
+def test_insert_with_retries_fail(monkeypatch):
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    assert insert_with_retries(None, "ID", "8", None) is False
+
+
+def test_insert_with_retries_insert(monkeypatch):
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
+        lambda *a, **k: (object(), False),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.effacer_et_entrer_valeur",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.program_break_time",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.controle_insertion",
+        lambda *a, **k: True,
+    )
+    assert insert_with_retries(None, "ID", "8", None) is True
+
+
+def test_insert_with_retries_stale(monkeypatch):
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_element",
+        lambda *a, **k: object(),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
+        lambda *a, **k: (_ for _ in ()).throw(
+            __import__("selenium").common.exceptions.StaleElementReferenceException()
+        ),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.MAX_ATTEMPTS", 1
+    )
+    logs = []
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.write_log",
+        lambda msg, *_: logs.append(msg),
+    )
+    assert insert_with_retries(None, "ID", "8", None) is False
+    assert logs
+
+
+def test_insert_with_retries_waiter(monkeypatch):
+    dummy = types.SimpleNamespace(
+        wait_for_element=lambda *a, **k: object(),
+        wait_until_dom_is_stable=lambda *a, **k: None,
+        wait_for_dom_ready=lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.wait_for_dom",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
+        lambda *a, **k: (object(), True),
+    )
+    assert insert_with_retries(None, "ID", "8", dummy) is True
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.detecter_et_verifier_contenu",
+        lambda *a, **k: (object(), False),
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.effacer_et_entrer_valeur",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.program_break_time",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.controle_insertion",
+        lambda *a, **k: False,
+    )
+    assert insert_with_retries(None, "ID", "8", dummy) is False
+
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.controle_insertion",
+        lambda *a, **k: True,
+    )
+    assert insert_with_retries(None, "ID", "8", dummy) is True


### PR DESCRIPTION
## Summary
- add `insert_with_retries` helper
- refactor mission handlers to use it
- extend tests for retry utility

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest` *(fails: Required test coverage of 95% not reached. Total coverage: 95.00%)*

------
https://chatgpt.com/codex/tasks/task_e_68698f0b000c8321832a8620e405eef0