### PR TITLE
[TimeSheetHelper] rename french variables

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -61,7 +61,7 @@ class SaisieContext:
     config: "AppConfig"
     encryption_service: EncryptionService
     shared_memory_service: SharedMemoryService
-    informations_projet_mission: dict[str, str]
+    project_mission_info: dict[str, str]
     descriptions: list[dict[str, object]]
 
 
@@ -127,7 +127,7 @@ class PSATimeAutomation:
             config=app_config,
             encryption_service=EncryptionService(log_file, shm_service),
             shared_memory_service=shm_service,
-            informations_projet_mission={
+            project_mission_info={
                 item_projet: {
                     opt.label.lower(): opt.code
                     for opt in app_config.cgi_options_billing_action
@@ -531,11 +531,11 @@ def est_en_mission(description):
     return description == "En mission"
 
 
-def ajouter_jour_a_jours_remplis(jour, jours_remplis):
+def ajouter_jour_a_jours_remplis(jour, filled_days):
     """Ajoute un jour à la liste jours_remplis si ce n'est pas déjà fait."""
-    if jour not in jours_remplis:
-        jours_remplis.append(jour)
-    return jours_remplis
+    if jour not in filled_days:
+        filled_days.append(jour)
+    return filled_days
 
 
 def afficher_message_insertion(jour, valeur, tentative, message, log_file: str) -> None:

--- a/tests/test_remplir_jours_main_flow.py
+++ b/tests/test_remplir_jours_main_flow.py
@@ -190,9 +190,9 @@ def test_initialize_sets_globals(monkeypatch):
 
     ctx = initialize("logfile")
 
-    assert ["d1", "d2"] == ctx.liste_items_descriptions
-    assert {"lun": ("En mission", "8")} == ctx.jours_de_travail
-    assert {"billing_action": "B"} == ctx.informations_projet_mission
+    assert ["d1", "d2"] == ctx.item_descriptions
+    assert {"lun": ("En mission", "8")} == ctx.work_days
+    assert {"billing_action": "B"} == ctx.project_mission_info
 
 
 def test_traiter_champs_mission_insert(monkeypatch):

--- a/tests/test_remplir_jours_utils.py
+++ b/tests/test_remplir_jours_utils.py
@@ -21,9 +21,9 @@ def test_utilities(monkeypatch):
     jours = {"lun": ("En mission", "8")}
     assert est_en_mission_presente(jours) is True
 
-    jours_remplis = []
-    assert ajouter_jour_a_jours_remplis("lun", jours_remplis) == ["lun"]
-    assert ajouter_jour_a_jours_remplis("lun", jours_remplis) == ["lun"]
+    filled_days = []
+    assert ajouter_jour_a_jours_remplis("lun", filled_days) == ["lun"]
+    assert ajouter_jour_a_jours_remplis("lun", filled_days) == ["lun"]
 
     logs = []
     monkeypatch.setattr(

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -169,8 +169,8 @@ def test_helpers(monkeypatch, sample_config):
     assert sap.get_next_saturday_if_not_saturday("01/07/2024") == "06/07/2024"
     assert sap.get_next_saturday_if_not_saturday("06/07/2024") == "06/07/2024"
     assert sap.est_en_mission("En mission") is True
-    jours = []
-    assert sap.ajouter_jour_a_jours_remplis("lundi", jours) == ["lundi"]
+    filled_days = []
+    assert sap.ajouter_jour_a_jours_remplis("lundi", filled_days) == ["lundi"]
     sap.afficher_message_insertion(
         "lundi", "8", 0, messages.TENTATIVE_INSERTION, "log.html"
     )
@@ -193,7 +193,7 @@ def test_initialize_sets_globals(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
     assert sap.context.config.url == "http://test"
     assert sap.context.config.work_schedule["lundi"] == ("En mission", "8")
-    assert sap.context.informations_projet_mission["billing_action"] == "B"
+    assert sap.context.project_mission_info["billing_action"] == "B"
     assert sap._AUTOMATION.choix_user is True
     assert isinstance(sap._AUTOMATION.memory_config, sap.MemoryConfig)
 

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -55,8 +55,8 @@ def test_clear_screen_windows(monkeypatch):
 
 
 def test_ajouter_jour_a_jours_remplis_existing():
-    jours = ["lundi"]
-    assert sap.ajouter_jour_a_jours_remplis("lundi", jours) == ["lundi"]
+    filled_days = ["lundi"]
+    assert sap.ajouter_jour_a_jours_remplis("lundi", filled_days) == ["lundi"]
 
 
 def test_afficher_message_insertion_other(monkeypatch):

--- a/tests/test_timesheet_helper.py
+++ b/tests/test_timesheet_helper.py
@@ -14,8 +14,8 @@ from sele_saisie_auto.remplir_jours_feuille_de_temps import (  # noqa: E402
 
 def test_remplir_jours_collects_filled_days(monkeypatch):
     liste_items = ["desc1"]
-    jours_semaine = {1: "lundi", 2: "mardi"}
-    jours_remplis = []
+    week_days = {1: "lundi", 2: "mardi"}
+    filled_days = []
 
     monkeypatch.setattr(
         "sele_saisie_auto.remplir_jours_feuille_de_temps.trouver_ligne_par_description",
@@ -35,16 +35,16 @@ def test_remplir_jours_collects_filled_days(monkeypatch):
     )
 
     ctx = TimeSheetContext("log", liste_items, {}, {})
-    result = remplir_jours(None, liste_items, jours_semaine, jours_remplis, ctx)
+    result = remplir_jours(None, liste_items, week_days, filled_days, ctx)
     assert result == ["lundi"]
 
 
 def test_remplir_mission_calls_helpers(monkeypatch):
-    jours_de_travail = {
+    work_days = {
         "lundi": ("desc1", "8"),
         "mardi": ("En mission", "8"),
     }
-    jours_remplis = []
+    filled_days = []
     calls = {"traiter": [], "specifique": []}
 
     def fake_traiter(driver, jour, desc, val, jours, ctx):
@@ -65,7 +65,7 @@ def test_remplir_mission_calls_helpers(monkeypatch):
     )
 
     ctx = TimeSheetContext("log", [], {}, {})
-    result = remplir_mission(None, jours_de_travail, jours_remplis, ctx)
+    result = remplir_mission(None, work_days, filled_days, ctx)
 
     assert result == ["lundi", "mission_mardi"]
     assert calls["traiter"] == [("lundi", "desc1", "8")]


### PR DESCRIPTION
## Contexte et objectif
- Traduction des noms de variables en anglais dans `src/sele_saisie_auto`
- Mise à jour des tests pour refléter ces nouveaux noms

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest -q`

## Impact
- Refactor interne sans changement d’API externe

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6869bb7aea888321b7b5612a7382dcf4