### PR TITLE
[EncryptionService] centralise la récupération d'identifiants

### DIFF
--- a/tests/test_encryption_service.py
+++ b/tests/test_encryption_service.py
@@ -150,3 +150,18 @@ def test_context_manager_stores_and_cleans():
         assert enc._memoires
     # after context exit memories list should be cleared
     assert enc._memoires == []
+
+
+def test_retrieve_credentials():
+    service = EncryptionService()
+    with service as enc:
+        enc.store_credentials(b"user", b"pass")
+        creds = enc.retrieve_credentials()
+        try:
+            assert creds.login == b"user"
+            assert creds.password == b"pass"
+            assert creds.aes_key == enc.cle_aes
+        finally:
+            creds.mem_key.close()
+            creds.mem_login.close()
+            creds.mem_password.close()

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -19,9 +19,17 @@ pytestmark = pytest.mark.slow
 class DummyEnc:
     def __init__(self):
         self.removed = []
+        self.cle_aes = b"k" * 32
 
-    def recuperer_de_memoire_partagee(self, name, size):
-        return object(), b"k" * size
+    def retrieve_credentials(self):
+        return sap.Credentials(
+            aes_key=self.cle_aes,
+            mem_key=object(),
+            login=b"user",
+            mem_login=object(),
+            password=b"pass",
+            mem_password=object(),
+        )
 
     def dechiffrer_donnees(self, data, key):
         return data.decode() if isinstance(data, bytes) else data

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -24,9 +24,17 @@ from sele_saisie_auto.locators import Locators  # noqa: E402
 class DummyEnc:
     def __init__(self):
         self.removed = []
+        self.cle_aes = b"k" * 32
 
-    def recuperer_de_memoire_partagee(self, name, size):
-        return object(), b"k" * size
+    def retrieve_credentials(self):
+        return sap.Credentials(
+            aes_key=self.cle_aes,
+            mem_key=object(),
+            login=b"user",
+            mem_login=object(),
+            password=b"pass",
+            mem_password=object(),
+        )
 
     def dechiffrer_donnees(self, data, key):
         return data.decode() if isinstance(data, bytes) else data

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -80,9 +80,16 @@ def test_initialize_shared_memory_error(monkeypatch, sample_config):
     sap.context.encryption_service = DummyEnc()
     sap.context.shared_memory_service = DummySHMService()
     monkeypatch.setattr(
-        sap.context.shared_memory_service,
-        "recuperer_de_memoire_partagee",
-        lambda *a, **k: (None, b"k" * 32),
+        sap.context.encryption_service,
+        "retrieve_credentials",
+        lambda: sap.Credentials(
+            aes_key=b"k" * 32,
+            mem_key=None,
+            login=b"u",
+            mem_login=None,
+            password=b"p",
+            mem_password=None,
+        ),
     )
     exit_called = {}
     monkeypatch.setattr(


### PR DESCRIPTION
## Contexte
Ajout d'une méthode dédiée dans `EncryptionService` pour récupérer les identifiants chiffrés depuis la mémoire partagée et simplification de `PSATimeAutomation.initialize_shared_memory`.

## Changements
- création de la dataclass `Credentials` dans `encryption_utils` et implémentation de `retrieve_credentials()`
- utilisation de cette méthode dans `PSATimeAutomation`
- mise à jour des doubles de tests et ajout d'un test unitaire

## Tests
- `poetry run ruff check` et `poetry run ruff check . --fix`
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run radon cc src/ -s` et `poetry run radon mi src/`
- `poetry run bandit -r src/` et `poetry run bandit -r src/ -lll -iii`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a311fcad08321aa162def83bab9bc