### PR TITLE
[Logger] Remplace print par logs

### DIFF
--- a/examples/example_plugin.py
+++ b/examples/example_plugin.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+from sele_saisie_auto import shared_utils
+from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.plugins import hook
 
 
 @hook("before_submit")
 def notify_before_submit(driver) -> None:
     """Simple hook printing a message before submission."""
-    print("Plugin before_submit called")
+    write_log(
+        "Plugin before_submit called",
+        shared_utils.get_log_file(),
+        "DEBUG",
+    )

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -147,7 +147,7 @@ class DateEntryPage:
             1,
             messages.WAIT_STABILISATION,
         )
-        print()
+        write_log(messages.DOM_STABLE, self.log_file, "DEBUG")
         if self.submit_date_cible(driver):
             self._handle_date_alert(driver)
 

--- a/src/sele_saisie_auto/console_ui.py
+++ b/src/sele_saisie_auto/console_ui.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from sele_saisie_auto import shared_utils
+from sele_saisie_auto.logger_utils import write_log
+
 
 def ask_continue(prompt: str) -> None:
     """Prompt the user to continue using ``input``."""
@@ -9,5 +12,9 @@ def ask_continue(prompt: str) -> None:
 
 
 def show_separator() -> None:
-    """Display a separator line in the console."""
-    print("*************************************************************")
+    """Log a separator line."""
+    write_log(
+        "*************************************************************",
+        shared_utils.get_log_file(),
+        "DEBUG",
+    )

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -1,4 +1,3 @@
-# pragma: no cover
 # remplir_jours_feuille_de_temps.py
 
 
@@ -32,15 +31,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 
@@ -254,7 +251,7 @@ def remplir_mission(
             and not est_en_mission(description_cible)
             and jour not in filled_days
         ):
-            jours_remplis = traiter_jour(
+            traiter_jour(
                 driver,
                 jour,
                 description_cible,
@@ -335,7 +332,7 @@ def _insert_value_with_retries(
             program_break_time(
                 1, "Stabilisation du DOM après insertion."
             )  # pragma: no cover
-            print()  # pragma: no cover
+            write_log(messages.DOM_STABLE, LOG_FILE, "DEBUG")  # pragma: no cover
             # pragma: no cover
             if controle_insertion(input_field, value):  # pragma: no cover
                 write_log(  # pragma: no cover

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -394,7 +394,7 @@ class PSATimeAutomation:
             1,
             messages.WAIT_STABILISATION,
         )
-        print()
+        write_log(messages.DOM_STABLE, self.log_file, "DEBUG")
         self._click_action_button(driver)
         self.wait_for_dom(driver)
         ctx = remplir_jours_feuille_de_temps.context_from_app_config(

--- a/src/sele_saisie_auto/utils/misc.py
+++ b/src/sele_saisie_auto/utils/misc.py
@@ -6,13 +6,20 @@ import os
 import subprocess  # nosec B404
 import time
 
+from sele_saisie_auto import shared_utils
+from sele_saisie_auto.logger_utils import write_log
 
-def program_break_time(memorization_time: int, affichage_text: str) -> None:
-    """Display a short countdown in the console."""
-    print(f"{affichage_text} {memorization_time} secondes ", end="", flush=True)
+
+def program_break_time(
+    memorization_time: int, affichage_text: str, *, log_file: str | None = None
+) -> None:
+    """Display a short countdown using logging instead of ``print``."""
+
+    log_file = log_file or shared_utils.get_log_file()
+    write_log(f"{affichage_text} {memorization_time} secondes ", log_file, "DEBUG")
     for _ in range(memorization_time):
         time.sleep(1)
-        print(".", end="", flush=True)
+        write_log(".", log_file, "DEBUG")
 
 
 def clear_screen() -> None:

--- a/tests/test_console_ui.py
+++ b/tests/test_console_ui.py
@@ -3,10 +3,17 @@ import builtins
 from sele_saisie_auto.console_ui import ask_continue, show_separator
 
 
-def test_console_utils(monkeypatch, capsys):
+def test_console_utils(monkeypatch):
     prompts = []
     monkeypatch.setattr(builtins, "input", lambda p: prompts.append(p) or "ok")
+    logged: list[str] = []
+    monkeypatch.setattr(
+        "sele_saisie_auto.console_ui.write_log",
+        lambda msg, log_file, level="INFO", log_format="html", auto_close=False: logged.append(
+            msg
+        ),
+    )
     ask_continue("continue?")
     assert prompts == ["continue?"]
     show_separator()
-    assert "***" in capsys.readouterr().out
+    assert any("***" in m for m in logged)

--- a/tests/test_example_plugin.py
+++ b/tests/test_example_plugin.py
@@ -4,9 +4,15 @@ from examples import example_plugin
 from sele_saisie_auto import plugins
 
 
-def test_example_plugin_hook(capsys):
+def test_example_plugin_hook(monkeypatch):
     plugins.clear()
     importlib.reload(example_plugin)
+    logged: list[str] = []
+    monkeypatch.setattr(
+        "examples.example_plugin.write_log",
+        lambda msg, log_file, level="INFO", log_format="html", auto_close=False: logged.append(
+            msg
+        ),
+    )
     plugins.call("before_submit", object())
-    captured = capsys.readouterr()
-    assert "Plugin before_submit called" in captured.out
+    assert any("Plugin before_submit called" in msg for msg in logged)

--- a/tests/test_shared_utils_program_break_time.py
+++ b/tests/test_shared_utils_program_break_time.py
@@ -7,18 +7,24 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 from sele_saisie_auto.utils.misc import program_break_time  # noqa: E402
 
 
-def test_program_break_time_executes(monkeypatch, capsys):
+def test_program_break_time_executes(monkeypatch):
     calls = []
+    logged: list[str] = []
 
     def fake_sleep(seconds: int) -> None:
         assert seconds == 1
         calls.append(seconds)
 
     monkeypatch.setattr("sele_saisie_auto.utils.misc.time.sleep", fake_sleep)
+    monkeypatch.setattr(
+        "sele_saisie_auto.utils.misc.write_log",
+        lambda msg, log_file, level="INFO", log_format="html", auto_close=False: logged.append(
+            msg
+        ),
+    )
 
     program_break_time(3, "Attente")
 
-    assert len(calls) == 3
-    output = capsys.readouterr().out
-    assert "Attente 3 secondes" in output
-    assert output.count(".") == 3
+    assert calls == [1, 1, 1]
+    assert any(msg.startswith("Attente 3 secondes") for msg in logged)
+    assert logged.count(".") == 3


### PR DESCRIPTION
## Contexte et objectif
Certains modules écrivaient directement sur la sortie standard via `print`. Afin d'uniformiser les traces et de ne plus avoir d'effets de bord dans les tests, ces appels ont été remplacés par l'utilisation de `write_log`.

## Étapes pour tester
1. `poetry install --no-root`
2. `poetry run pre-commit run --files src/sele_saisie_auto/utils/misc.py src/sele_saisie_auto/console_ui.py src/sele_saisie_auto/saisie_automatiser_psatime.py src/sele_saisie_auto/automation/date_entry_page.py src/sele_saisie_auto/remplir_jours_feuille_de_temps.py examples/example_plugin.py tests/test_console_ui.py tests/test_shared_utils_program_break_time.py tests/test_example_plugin.py`
3. `poetry run pytest`
4. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

Aucun impact attendu sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a3625c7c08321931d92c0f9c27124