### PR TITLE
[AppConfig] validation des champs obligatoires

### DIFF
--- a/src/sele_saisie_auto/app_config.py
+++ b/src/sele_saisie_auto/app_config.py
@@ -213,4 +213,10 @@ def load_config(log_file: str | None) -> AppConfig:
                 parser.add_section(section)
             parser.set(section, option, value)
 
-    return AppConfig.from_parser(parser)
+    cfg = AppConfig.from_parser(parser)
+    if not cfg.url.strip():
+        raise ValueError("L'URL de connexion ne peut pas être vide.")
+    if not cfg.encrypted_login.strip() or not cfg.encrypted_mdp.strip():
+        raise ValueError("Le login et le mot de passe doivent être renseignés.")
+
+    return cfg

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -31,13 +31,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -34,17 +34,17 @@ from sele_saisie_auto.error_handler import log_error
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import initialize_logger, write_log
 from sele_saisie_auto.logging_service import Logger
+from sele_saisie_auto.selenium_utils import click_element_without_wait  # noqa: F401
+from sele_saisie_auto.selenium_utils import modifier_date_input  # noqa: F401
+from sele_saisie_auto.selenium_utils import send_keys_to_element  # noqa: F401
+from sele_saisie_auto.selenium_utils import detecter_doublons_jours
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils import (
-    click_element_without_wait,  # noqa: F401
-    detecter_doublons_jours,
-    modifier_date_input,  # noqa: F401
-    send_keys_to_element,  # noqa: F401
     switch_to_default_content,
     switch_to_iframe_by_id_or_name,
     wait_for_dom_after,
     wait_for_element,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+import pytest  # noqa: E402
+
 from sele_saisie_auto.app_config import AppConfig, load_config  # noqa: E402
 
 
@@ -71,3 +73,43 @@ Facturable = B
     assert app_cfg.debug_mode == "DEBUG"
     assert app_cfg.liste_items_planning == ["env1", "env2"]
     assert app_cfg.raw.get("credentials", "login") == "env_login"
+
+
+def test_load_config_fails_on_empty_url(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text(
+        """[credentials]
+login=enc
+mdp=enc
+[settings]
+url=
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sele_saisie_auto.read_or_write_file_config_ini_utils.write_log",
+        lambda *a, **k: None,
+    )
+    with pytest.raises(ValueError):
+        load_config(str(tmp_path / "log.html"))
+
+
+def test_load_config_fails_on_missing_credentials(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text(
+        """[credentials]
+login=
+mdp=
+[settings]
+url=http://t
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sele_saisie_auto.read_or_write_file_config_ini_utils.write_log",
+        lambda *a, **k: None,
+    )
+    with pytest.raises(ValueError):
+        load_config(str(tmp_path / "log.html"))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -11,7 +11,17 @@ from sele_saisie_auto.config_manager import ConfigManager  # noqa: E402
 
 def test_load_and_save(tmp_path, monkeypatch):
     config_file = tmp_path / "config.ini"
-    config_file.write_text("[section]\nkey=value\n", encoding="utf-8")
+    config_file.write_text(
+        """[credentials]
+login=enc
+mdp=enc
+[settings]
+url=http://t
+[section]
+key=value
+""",
+        encoding="utf-8",
+    )
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
@@ -46,7 +56,17 @@ def test_save_without_load(tmp_path):
 
 def test_config_property_after_load(tmp_path, monkeypatch):
     config_file = tmp_path / "config.ini"
-    config_file.write_text("[section]\nkey=value\n", encoding="utf-8")
+    config_file.write_text(
+        """[credentials]
+login=enc
+mdp=enc
+[settings]
+url=http://t
+[section]
+key=value
+""",
+        encoding="utf-8",
+    )
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(
@@ -75,7 +95,17 @@ def test_load_missing_config(tmp_path, monkeypatch):
 
 def test_is_loaded_property(tmp_path, monkeypatch):
     cfg_file = tmp_path / "config.ini"
-    cfg_file.write_text("[section]\nkey=value\n", encoding="utf-8")
+    cfg_file.write_text(
+        """[credentials]
+login=enc
+mdp=enc
+[settings]
+url=http://t
+[section]
+key=value
+""",
+        encoding="utf-8",
+    )
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(


### PR DESCRIPTION
## Contexte et objectif
Ajout de validations dans `load_config` afin de s'assurer que l'URL, le login et le mot de passe soient renseignés. Des `ValueError` explicites sont maintenant levées en cas de configuration incomplète.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a489940ec8321b1892fc588e3f583