### PR TITLE
[BrowserSession] go_to_iframe helper

### DIFF
--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -7,6 +7,7 @@ from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.selenium_utils import (
     definir_taille_navigateur,
     ouvrir_navigateur_sur_ecran_principal,
+    switch_to_iframe_by_id_or_name,
     wait_for_dom_ready,
     wait_until_dom_is_stable,
 )
@@ -133,3 +134,13 @@ class BrowserSession:
         )
         wait_until_dom_is_stable(driver, timeout=default_timeout)
         wait_for_dom_ready(driver, long_timeout)
+
+    # ------------------------------------------------------------------
+    # Iframe helpers
+    # ------------------------------------------------------------------
+    def go_to_iframe(self, id_or_name: str) -> bool:
+        """Switch to the iframe identified by ``id_or_name``."""
+
+        if self.driver is None:
+            return False
+        return switch_to_iframe_by_id_or_name(self.driver, id_or_name)

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -320,8 +320,8 @@ class PSATimeAutomation:
             driver, By.ID, Locators.MAIN_FRAME.value, timeout=DEFAULT_TIMEOUT
         )
         if element_present:
-            switched_to_iframe = switch_to_iframe_by_id_or_name(
-                driver, Locators.MAIN_FRAME.value
+            switched_to_iframe = self.browser_session.go_to_iframe(
+                Locators.MAIN_FRAME.value
             )
         self.wait_for_dom(driver)
         if switched_to_iframe is None:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -63,7 +63,7 @@ def test_run_invokes_hook(monkeypatch, sample_config):
     monkeypatch.setattr(sap, "switch_to_default_content", lambda *a, **k: None)
     monkeypatch.setattr(sap, "wait_for_element", lambda *a, **k: object())
     monkeypatch.setattr(sap, "modifier_date_input", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "switch_to_iframe_by_id_or_name", lambda *a, **k: True)
+    monkeypatch.setattr(sap.BrowserSession, "go_to_iframe", lambda *a, **k: True)
     monkeypatch.setattr(sap, "click_element_without_wait", lambda *a, **k: None)
     monkeypatch.setattr(sap, "send_keys_to_element", lambda *a, **k: None)
     monkeypatch.setattr(sap, "wait_for_dom", lambda *a, **k: None)

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -92,6 +92,11 @@ class DummyBrowserSession:
         self.open_calls.append((url, fullscreen, headless, no_sandbox))
         return self.driver
 
+    def go_to_iframe(self, ident):
+        self.go_calls = getattr(self, "go_calls", [])
+        self.go_calls.append(ident)
+        return True
+
     def close(self):
         self.driver = None
 
@@ -260,7 +265,7 @@ def test_main_flow(monkeypatch, sample_config):
 
     monkeypatch.setattr(sap, "wait_for_element", fake_wait)
     monkeypatch.setattr(sap, "modifier_date_input", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "switch_to_iframe_by_id_or_name", lambda *a, **k: True)
+    monkeypatch.setattr(sap.BrowserSession, "go_to_iframe", lambda *a, **k: True)
     monkeypatch.setattr(sap, "click_element_without_wait", lambda *a, **k: None)
     monkeypatch.setattr(sap, "send_keys_to_element", lambda *a, **k: None)
     monkeypatch.setattr(sap, "wait_for_dom", lambda *a, **k: None)

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -116,8 +116,8 @@ def test_switch_to_iframe(monkeypatch):
     calls = []
     monkeypatch.setattr(sap, "wait_for_element", lambda *a, **k: True)
     monkeypatch.setattr(
-        sap,
-        "switch_to_iframe_by_id_or_name",
+        sap.BrowserSession,
+        "go_to_iframe",
         lambda *a, **k: calls.append("sw") or True,
     )
     monkeypatch.setattr(
@@ -218,7 +218,7 @@ def test_main_exceptions(monkeypatch, sample_config):
     )
     monkeypatch.setattr(sap, "wait_for_element", lambda *a, **k: True)
     monkeypatch.setattr(sap, "modifier_date_input", lambda *a, **k: None)
-    monkeypatch.setattr(sap, "switch_to_iframe_by_id_or_name", lambda *a, **k: True)
+    monkeypatch.setattr(sap.BrowserSession, "go_to_iframe", lambda *a, **k: True)
     monkeypatch.setattr(sap, "click_element_without_wait", lambda *a, **k: None)
     monkeypatch.setattr(sap, "send_keys_to_element", lambda *a, **k: None)
     monkeypatch.setattr(sap, "wait_for_dom", lambda *a, **k: None)

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -63,7 +63,14 @@ def test_navigate_from_work_schedule_positive(monkeypatch):
 def test_submit_and_validate_additional_information_positive(monkeypatch):
     seq = iter([True, True, True])
     monkeypatch.setattr(sap, "wait_for_element", lambda *a, **k: next(seq))
-    monkeypatch.setattr(sap, "switch_to_iframe_by_id_or_name", lambda *a, **k: True)
+    monkeypatch.setattr(sap.BrowserSession, "go_to_iframe", lambda *a, **k: True)
+    if sap._AUTOMATION:
+        sap._AUTOMATION.browser_session.go_to_iframe = lambda *a, **k: True
+    monkeypatch.setattr(
+        sap,
+        "switch_to_iframe_by_id_or_name",
+        lambda *a, **k: True,
+    )
     records = []
     monkeypatch.setattr(
         sap, "traiter_description", lambda *a, **k: records.append("desc")

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -102,7 +102,9 @@ def test_initialize_shared_memory_error(monkeypatch, sample_config):
 
 def test_switch_to_iframe_main_target_win0_false(monkeypatch):
     monkeypatch.setattr(sap, "wait_for_element", lambda *a, **k: True)
-    monkeypatch.setattr(sap, "switch_to_iframe_by_id_or_name", lambda *a, **k: False)
+    monkeypatch.setattr(sap.BrowserSession, "go_to_iframe", lambda *a, **k: False)
+    if sap._AUTOMATION:
+        sap._AUTOMATION.browser_session.go_to_iframe = lambda *a, **k: False
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )


### PR DESCRIPTION
## Contexte
Ajout d'une méthode de navigation dans les iframes et mise à jour des appels correspondants.

## Changements
- nouvelle méthode `BrowserSession.go_to_iframe`
- utilisation dans `saisie_automatiser_psatime.switch_to_iframe_main_target_win0`
- ajustement des tests

## Tests
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a531b8c508321be92cdf27ffef725