### PR TITLE
[SeleniumUtils] ajout wrapper d'attente

### DIFF
--- a/src/sele_saisie_auto/selenium_utils/__init__.py
+++ b/src/sele_saisie_auto/selenium_utils/__init__.py
@@ -53,12 +53,12 @@ from .wait_helpers import (
     find_clickable,
     find_present,
     find_visible,
-    is_document_complete,
     wait_for_dom_after,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from .wrapper import Wrapper, is_document_complete
 
 __all__ = [
     "set_log_file",
@@ -73,6 +73,7 @@ __all__ = [
     "find_clickable",
     "find_visible",
     "find_present",
+    "Wrapper",
     "Waiter",
     "modifier_date_input",
     "switch_to_frame_by_id",

--- a/src/sele_saisie_auto/selenium_utils/wait_helpers.py
+++ b/src/sele_saisie_auto/selenium_utils/wait_helpers.py
@@ -7,58 +7,41 @@ from functools import wraps
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
-from selenium.webdriver.support.ui import WebDriverWait
 
-from sele_saisie_auto import messages
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
-from . import LOG_FILE, write_log
+from . import wrapper as _wrapper
+from . import write_log
+
+Wrapper = _wrapper.Wrapper
+is_document_complete = _wrapper.is_document_complete
+# ensure wrapper shares the same time module for monkeypatching in tests
+_wrapper.time = time
 
 
 class Waiter:
     """Utility object encapsulating explicit wait helpers."""
 
     def __init__(
-        self, default_timeout: int = DEFAULT_TIMEOUT, long_timeout: int = LONG_TIMEOUT
+        self,
+        default_timeout: int = DEFAULT_TIMEOUT,
+        long_timeout: int = LONG_TIMEOUT,
+        wrapper: Wrapper | None = None,
     ) -> None:  # pragma: no cover - simple initializer
         """Configure les délais d'attente par défaut."""
-        self.default_timeout = default_timeout
-        self.long_timeout = long_timeout
+        self.wrapper = wrapper or Wrapper(
+            default_timeout,
+            long_timeout,
+            writer=write_log,
+        )
 
     def wait_for_dom_ready(self, driver, timeout: int | None = None):
         """Wait until the DOM is fully loaded."""
-        timeout = timeout or self.long_timeout
-        WebDriverWait(driver, timeout).until(is_document_complete)
-        write_log("DOM chargé avec succès.", LOG_FILE, "DEBUG")
+        self.wrapper.wait_for_dom_ready(driver, timeout)
 
     def wait_until_dom_is_stable(self, driver, timeout: int | None = None) -> bool:
         """Return True when the DOM remains unchanged for ``timeout`` seconds."""
-        previous_dom_snapshot = ""
-        unchanged_count = 0
-        required_stability_count = 3
-
-        timeout = timeout or self.default_timeout
-        for _ in range(timeout):
-            current_dom_snapshot = driver.page_source
-
-            if current_dom_snapshot == previous_dom_snapshot:
-                unchanged_count += 1
-            else:
-                unchanged_count = 0
-
-            if unchanged_count >= required_stability_count:
-                write_log(messages.DOM_STABLE, LOG_FILE, "DEBUG")
-                return True
-
-            previous_dom_snapshot = current_dom_snapshot
-            time.sleep(1)
-
-        write_log(
-            messages.DOM_NOT_STABLE,
-            LOG_FILE,
-            "WARNING",
-        )
-        return False
+        return self.wrapper.wait_until_dom_is_stable(driver, timeout)
 
     def wait_for_element(
         self,
@@ -69,60 +52,29 @@ class Waiter:
         timeout: int | None = None,
     ):
         """Wait for an element to satisfy ``condition`` or return ``None``."""
-        if locator_value is None:
-            write_log(
-                messages.LOCATOR_VALUE_REQUIRED,
-                LOG_FILE,
-                "ERROR",
-            )
-            return None
-
-        timeout = timeout or self.default_timeout
-        found_elements = driver.find_elements(by, locator_value)
-        if found_elements:
-            matched_element = WebDriverWait(driver, timeout).until(
-                condition((by, locator_value))
-            )
-            write_log(
-                f"Élément avec {by}='{locator_value}' trouvé et condition '{condition.__name__}' validée.",
-                LOG_FILE,
-                "DEBUG",
-            )
-            return matched_element
-
-        write_log(
-            f"Élément avec {by}='{locator_value}' non trouvé dans le délai imparti ({timeout}s).",
-            LOG_FILE,
-            "WARNING",
+        return self.wrapper.wait_for_element(
+            driver,
+            by,
+            locator_value,
+            condition,
+            timeout,
         )
-        return None
 
     # Convenience wrappers -------------------------------------------------
     def find_clickable(self, driver, by, locator_value, timeout: int | None = None):
         """Return element when it becomes clickable."""
-        return self.wait_for_element(
-            driver, by, locator_value, ec.element_to_be_clickable, timeout
-        )
+        return self.wrapper.find_clickable(driver, by, locator_value, timeout)
 
     def find_visible(self, driver, by, locator_value, timeout: int | None = None):
         """Return element when it is visible."""
-        return self.wait_for_element(
-            driver, by, locator_value, ec.visibility_of_element_located, timeout
-        )
+        return self.wrapper.find_visible(driver, by, locator_value, timeout)
 
     def find_present(self, driver, by, locator_value, timeout: int | None = None):
         """Return element when it is present in the DOM."""
-        return self.wait_for_element(
-            driver, by, locator_value, ec.presence_of_element_located, timeout
-        )
+        return self.wrapper.find_present(driver, by, locator_value, timeout)
 
 
 DEFAULT_WAITER = Waiter()
-
-
-def is_document_complete(driver):
-    """Return True when the DOM is fully loaded."""
-    return driver.execute_script("return document.readyState") == "complete"
 
 
 def wait_for_dom_ready(
@@ -130,6 +82,7 @@ def wait_for_dom_ready(
 ):
     """Wait until the DOM is fully loaded."""
     w = waiter or DEFAULT_WAITER
+    w.wrapper.writer = write_log
     w.wait_for_dom_ready(driver, timeout)
 
 
@@ -138,6 +91,7 @@ def wait_until_dom_is_stable(
 ) -> bool:
     """Retourne ``True`` si le DOM reste inchangé pendant ``timeout`` secondes."""
     w = waiter or DEFAULT_WAITER
+    w.wrapper.writer = write_log
     return w.wait_until_dom_is_stable(driver, timeout)
 
 
@@ -151,6 +105,7 @@ def wait_for_element(
 ):
     """Attend qu'un élément réponde à ``condition``."""
     w = waiter or DEFAULT_WAITER
+    w.wrapper.writer = write_log
     return w.wait_for_element(driver, by, locator_value, condition, timeout)
 
 
@@ -163,6 +118,7 @@ def find_clickable(
 ):
     """Retourne l'élément lorsqu'il devient cliquable."""
     w = waiter or DEFAULT_WAITER
+    w.wrapper.writer = write_log
     return w.find_clickable(driver, by, locator_value, timeout)
 
 
@@ -175,6 +131,7 @@ def find_visible(
 ):
     """Retourne l'élément lorsqu'il est visible."""
     w = waiter or DEFAULT_WAITER
+    w.wrapper.writer = write_log
     return w.find_visible(driver, by, locator_value, timeout)
 
 
@@ -187,6 +144,7 @@ def find_present(
 ):
     """Retourne l'élément dès qu'il est présent dans le DOM."""
     w = waiter or DEFAULT_WAITER
+    w.wrapper.writer = write_log
     return w.find_present(driver, by, locator_value, timeout)
 
 

--- a/src/sele_saisie_auto/selenium_utils/wrapper.py
+++ b/src/sele_saisie_auto/selenium_utils/wrapper.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+"""High level wrapper around WebDriver wait helpers."""
+
+import time
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as ec
+from selenium.webdriver.support.ui import WebDriverWait
+
+from sele_saisie_auto import messages
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
+
+from . import LOG_FILE, write_log
+
+
+def is_document_complete(driver):
+    """Return ``True`` when the DOM is fully loaded."""
+    return driver.execute_script("return document.readyState") == "complete"
+
+
+class Wrapper:
+    """Utility object exposing common waiting helpers."""
+
+    def __init__(
+        self,
+        default_timeout: int = DEFAULT_TIMEOUT,
+        long_timeout: int = LONG_TIMEOUT,
+        writer=write_log,
+    ) -> None:
+        self.default_timeout = default_timeout
+        self.long_timeout = long_timeout
+        self.writer = writer
+
+    # ------------------------------------------------------------------
+    # DOM helpers
+    # ------------------------------------------------------------------
+    def wait_for_dom_ready(self, driver, timeout: int | None = None) -> None:
+        """Wait until the DOM is fully loaded."""
+        timeout = timeout or self.long_timeout
+        WebDriverWait(driver, timeout).until(is_document_complete)
+        self.writer("DOM chargé avec succès.", LOG_FILE, "DEBUG")
+
+    def wait_until_dom_is_stable(self, driver, timeout: int | None = None) -> bool:
+        """Return ``True`` if the DOM remains unchanged for ``timeout`` seconds."""
+        previous_dom_snapshot = ""
+        unchanged_count = 0
+        required_stability_count = 3
+
+        timeout = timeout or self.default_timeout
+        for _ in range(timeout):
+            current_dom_snapshot = driver.page_source
+
+            if current_dom_snapshot == previous_dom_snapshot:
+                unchanged_count += 1
+            else:
+                unchanged_count = 0
+
+            if unchanged_count >= required_stability_count:
+                self.writer(messages.DOM_STABLE, LOG_FILE, "DEBUG")
+                return True
+
+            previous_dom_snapshot = current_dom_snapshot
+            time.sleep(1)
+
+        self.writer(messages.DOM_NOT_STABLE, LOG_FILE, "WARNING")
+        return False
+
+    # ------------------------------------------------------------------
+    # Element helpers
+    # ------------------------------------------------------------------
+    def wait_for_element(
+        self,
+        driver,
+        by=By.ID,
+        locator_value=None,
+        condition=ec.presence_of_element_located,
+        timeout: int | None = None,
+    ):
+        """Wait for an element to satisfy ``condition`` or return ``None``."""
+        if locator_value is None:
+            self.writer(messages.LOCATOR_VALUE_REQUIRED, LOG_FILE, "ERROR")
+            return None
+
+        timeout = timeout or self.default_timeout
+        found_elements = driver.find_elements(by, locator_value)
+        if found_elements:
+            matched_element = WebDriverWait(driver, timeout).until(
+                condition((by, locator_value))
+            )
+            self.writer(
+                f"Élément avec {by}='{locator_value}' trouvé et condition '{condition.__name__}' validée.",
+                LOG_FILE,
+                "DEBUG",
+            )
+            return matched_element
+
+        self.writer(
+            f"Élément avec {by}='{locator_value}' non trouvé dans le délai imparti ({timeout}s).",
+            LOG_FILE,
+            "WARNING",
+        )
+        return None
+
+    def find_clickable(self, driver, by, locator_value, timeout: int | None = None):
+        """Return the element when it becomes clickable."""
+        return self.wait_for_element(
+            driver, by, locator_value, ec.element_to_be_clickable, timeout
+        )
+
+    def find_visible(self, driver, by, locator_value, timeout: int | None = None):
+        """Return the element when it is visible."""
+        return self.wait_for_element(
+            driver, by, locator_value, ec.visibility_of_element_located, timeout
+        )
+
+    def find_present(self, driver, by, locator_value, timeout: int | None = None):
+        """Return the element once it is present in the DOM."""
+        return self.wait_for_element(
+            driver, by, locator_value, ec.presence_of_element_located, timeout
+        )
+
+
+DEFAULT_WRAPPER = Wrapper()


### PR DESCRIPTION
## Contexte
Ajout d'un nouveau module `wrapper.py` dans `selenium_utils` fournissant les méthodes `find_clickable`, `find_visible` et associées. Ce wrapper centralise les attentes Selenium et permet d'injecter la fonction de log.

`wait_helpers.py` délègue désormais ces opérations au wrapper et met à jour le writer pour conserver la compatibilité des tests. Les importations dans `__init__.py` sont ajustées pour exposer la nouvelle classe.

## Tests
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run ruff check`
- `poetry run ruff check . --fix`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run bandit -r src/ -lll -iii`


------
https://chatgpt.com/codex/tasks/task_e_686a589410cc832180baba9fe4ade8ac