### PR TITLE
[logger] ajout format_message

### DIFF
--- a/docs/guides/logging-and-errors.md
+++ b/docs/guides/logging-and-errors.md
@@ -69,6 +69,25 @@ Les messages sont enregistres dans le dossier `logs/` sous forme de fichier HTML
 | `RuntimeError` | État inattendu de l'application |
 | `NameError` | Objet ou identifiant manquant dans le code |
 
+## Codes de messages
+
+Les fonctions de log acceptent un identifiant court permettant de composer le
+texte final. Voici la liste des codes actuellement utilisés :
+
+| Code | Message |
+| ---- | ------- |
+| `BROWSER_OPEN` | Ouverture du navigateur |
+| `BROWSER_CLOSE` | Fermeture du navigateur |
+| `DECRYPT_CREDENTIALS` | Déchiffrement des identifiants |
+| `SEND_CREDENTIALS` | Envoi des identifiants |
+| `ADDITIONAL_INFO_DONE` | Validation des informations supplémentaires terminée. |
+| `SAVE_ALERT_WARNING` | ⚠️ Alerte rencontrée lors de la sauvegarde. |
+| `DOM_STABLE` | Le DOM est stable. |
+| `NO_DATE_CHANGE` | Aucune modification de la date nécessaire. |
+| `TIME_SHEET_EXISTS_ERROR` | Feuille de temps déjà existante pour la période. |
+| `MODIFY_DATE_MESSAGE` | Changer la date dans `config.ini` puis relancer. |
+| `DATE_VALIDATED` | Date validée avec succès. |
+
 ## Exemple de sortie de log
 
 ```

--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -6,10 +6,9 @@ from typing import TYPE_CHECKING
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 
-from sele_saisie_auto import messages
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.locators import Locators
-from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logger_utils import format_message, write_log
 from sele_saisie_auto.remplir_informations_supp_utils import ExtraInfoHelper
 from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
@@ -100,7 +99,7 @@ class AdditionalInfoPage:
             for config in self._automation.context.descriptions:
                 sap.traiter_description(driver, config)
             write_log(
-                messages.ADDITIONAL_INFO_DONE,
+                format_message("ADDITIONAL_INFO_DONE", {}),
                 self.log_file,
                 "INFO",
             )
@@ -150,7 +149,7 @@ class AdditionalInfoPage:
             ):
                 sap.click_element_without_wait(driver, By.ID, Locators.CONFIRM_OK.value)
                 write_log(
-                    messages.SAVE_ALERT_WARNING,
+                    format_message("SAVE_ALERT_WARNING", {}),
                     self.log_file,
                     "INFO",
                 )

--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from sele_saisie_auto.app_config import AppConfig
-from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logger_utils import format_message, write_log
 from sele_saisie_auto.selenium_utils import (
     definir_taille_navigateur,
     ouvrir_navigateur_sur_ecran_principal,
@@ -42,7 +42,7 @@ class SeleniumDriverManager:
         no_sandbox: bool = False,
     ) -> WebDriver | None:
         """Launch the WebDriver and load the given URL."""
-        write_log("Ouverture du navigateur", self.log_file, "DEBUG")
+        write_log(format_message("BROWSER_OPEN", {}), self.log_file, "DEBUG")
         self.driver = ouvrir_navigateur_sur_ecran_principal(
             plein_ecran=fullscreen,
             url=url,
@@ -62,7 +62,7 @@ class SeleniumDriverManager:
     def close(self) -> None:
         """Close the WebDriver if started."""
         if self.driver is not None:
-            write_log("Fermeture du navigateur", self.log_file, "DEBUG")
+            write_log(format_message("BROWSER_CLOSE", {}), self.log_file, "DEBUG")
             self.driver.quit()
             self.driver = None
 
@@ -101,7 +101,7 @@ class BrowserSession:
         no_sandbox: bool = False,
     ) -> WebDriver | None:
         """Open the browser and navigate to ``url``."""
-        write_log("Ouverture du navigateur", self.log_file, "DEBUG")
+        write_log(format_message("BROWSER_OPEN", {}), self.log_file, "DEBUG")
         self.driver = self._manager.open(
             url,
             fullscreen=fullscreen,
@@ -113,7 +113,7 @@ class BrowserSession:
     def close(self) -> None:
         """Close the browser if it was opened."""
         if self.driver is not None:
-            write_log("Fermeture du navigateur", self.log_file, "DEBUG")
+            write_log(format_message("BROWSER_CLOSE", {}), self.log_file, "DEBUG")
         self._manager.close()
         self.driver = None
 

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -11,7 +11,7 @@ from selenium.webdriver.support import expected_conditions as ec
 from sele_saisie_auto import messages
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.locators import Locators
-from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logger_utils import format_message, write_log
 from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -114,7 +114,7 @@ class DateEntryPage:
                     )
                 else:
                     sap.write_log(
-                        messages.NO_DATE_CHANGE,
+                        format_message("NO_DATE_CHANGE", {}),
                         self.log_file,
                         "DEBUG",
                     )
@@ -147,7 +147,7 @@ class DateEntryPage:
             1,
             messages.WAIT_STABILISATION,
         )
-        write_log(messages.DOM_STABLE, self.log_file, "DEBUG")
+        write_log(format_message("DOM_STABLE", {}), self.log_file, "DEBUG")
         if self.submit_date_cible(driver):
             self._handle_date_alert(driver)
 
@@ -162,18 +162,18 @@ class DateEntryPage:
         ):
             sap.click_element_without_wait(driver, By.ID, Locators.CONFIRM_OK.value)
             write_log(
-                messages.TIME_SHEET_EXISTS_ERROR,
+                format_message("TIME_SHEET_EXISTS_ERROR", {}),
                 self.log_file,
                 "INFO",
             )
             write_log(
-                messages.MODIFY_DATE_MESSAGE,
+                format_message("MODIFY_DATE_MESSAGE", {}),
                 self.log_file,
                 "INFO",
             )
             sys.exit()
         else:
-            write_log(messages.DATE_VALIDATED, self.log_file, "DEBUG")
+            write_log(format_message("DATE_VALIDATED", {}), self.log_file, "DEBUG")
 
     def _click_action_button(self, driver, create_new: bool) -> None:
         """Click the appropriate action button on the page."""

--- a/src/sele_saisie_auto/automation/login_handler.py
+++ b/src/sele_saisie_auto/automation/login_handler.py
@@ -9,7 +9,7 @@ from selenium.webdriver.remote.webdriver import WebDriver
 from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.locators import Locators
-from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logger_utils import format_message, write_log
 from sele_saisie_auto.selenium_utils import send_keys_to_element, wait_for_dom_after
 
 
@@ -32,14 +32,14 @@ class LoginHandler:
 
     def login(self, driver: WebDriver, credentials) -> None:
         """Fill username and password fields using decrypted credentials."""
-        write_log("Déchiffrement des identifiants", self.log_file, "DEBUG")
+        write_log(format_message("DECRYPT_CREDENTIALS", {}), self.log_file, "DEBUG")
         username = self.encryption_service.dechiffrer_donnees(
             credentials.login, credentials.aes_key
         )
         password = self.encryption_service.dechiffrer_donnees(
             credentials.password, credentials.aes_key
         )
-        write_log("Envoi des identifiants", self.log_file, "DEBUG")
+        write_log(format_message("SEND_CREDENTIALS", {}), self.log_file, "DEBUG")
         send_keys_to_element(driver, By.ID, Locators.USERNAME.value, username)
         send_keys_to_element(driver, By.ID, Locators.PASSWORD.value, password)
         send_keys_to_element(driver, By.ID, Locators.PASSWORD.value, Keys.RETURN)

--- a/src/sele_saisie_auto/logger_utils.py
+++ b/src/sele_saisie_auto/logger_utils.py
@@ -24,6 +24,21 @@ LOG_LEVELS = {
 DEFAULT_LOG_LEVEL = "INFO"
 LOG_LEVEL_FILTER = DEFAULT_LOG_LEVEL
 
+# Mapping between short codes and user-facing log messages.
+MESSAGE_TEMPLATES = {
+    "BROWSER_OPEN": "Ouverture du navigateur",
+    "BROWSER_CLOSE": "Fermeture du navigateur",
+    "DECRYPT_CREDENTIALS": "Déchiffrement des identifiants",
+    "SEND_CREDENTIALS": "Envoi des identifiants",
+    "ADDITIONAL_INFO_DONE": "Validation des informations supplémentaires terminée.",
+    "SAVE_ALERT_WARNING": "⚠️ Alerte rencontrée lors de la sauvegarde.",
+    "DOM_STABLE": "Le DOM est stable.",
+    "NO_DATE_CHANGE": "Aucune modification de la date nécessaire.",
+    "TIME_SHEET_EXISTS_ERROR": "ERREUR : Vous avez déjà créé une feuille de temps pour cette période. (10502,125)",
+    "MODIFY_DATE_MESSAGE": "--> Modifier la date du PSATime dans le fichier ini. Le programme va s'arrêter.",
+    "DATE_VALIDATED": "Date validée avec succès.",
+}
+
 # ------------------------------------------------------------------------------------------- #
 # ----------------------------------- FONCTIONS --------------------------------------------- #
 # ------------------------------------------------------------------------------------------- #
@@ -59,6 +74,17 @@ def is_log_level_allowed(current_level, configured_level):
         bool: True si le niveau est autorisé, False sinon.
     """
     return LOG_LEVELS[current_level] >= LOG_LEVELS[configured_level]
+
+
+def format_message(code: str, details: dict | None = None) -> str:
+    """Return the message associated with ``code`` formatted with ``details``."""
+
+    template = MESSAGE_TEMPLATES.get(code)
+    if template is None:
+        raise KeyError(f"Unknown message code: {code}")
+    if details is None:
+        details = {}
+    return template.format(**details)
 
 
 def get_html_style():

--- a/tests/test_logger_utils.py
+++ b/tests/test_logger_utils.py
@@ -23,6 +23,15 @@ def test_is_log_level_allowed():
     assert logger_utils.is_log_level_allowed("INFO", "ERROR") is False
 
 
+def test_format_message():
+    assert logger_utils.format_message("BROWSER_OPEN", {}) == "Ouverture du navigateur"
+
+
+def test_format_message_unknown():
+    with pytest.raises(KeyError):
+        logger_utils.format_message("BOGUS", {})
+
+
 def test_write_and_close_html_log(tmp_path):
     log_file = tmp_path / "log.html"
     logger_utils.write_log("msg", str(log_file), level="INFO", log_format="html")


### PR DESCRIPTION
## Contexte
Ajout d'une fonction utilitaire permettant de formater les messages de log à partir d'un code. Les principaux modules utilisent désormais ces codes. La documentation présente la liste des codes disponibles.

## Impact
- nouvelle fonction `format_message` dans `logger_utils.py`
- mise à jour des appels de log dans les modules d'automatisation
- documentation des codes de messages
- tests adaptés

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a62b6fb2083218962f64e571e2656