### PR TITLE
[tests] ajout vérif ordre hooks et clear

### DIFF
--- a/tests/test_plugins_hook_order.py
+++ b/tests/test_plugins_hook_order.py
@@ -1,0 +1,40 @@
+from sele_saisie_auto import plugins
+
+
+def test_hooks_called_in_registration_order():
+    plugins.clear()
+    calls: list[str] = []
+
+    def first():
+        calls.append("first")
+
+    def second():
+        calls.append("second")
+
+    plugins.register("before_submit", first)
+    plugins.register("before_submit", second)
+    plugins.call("before_submit")
+
+    assert calls == ["first", "second"]
+
+
+def test_clear_removes_all_hooks():
+    plugins.clear()
+    called: list[str] = []
+
+    def cb():
+        called.append("cb")
+
+    plugins.register("after_run", cb)
+    plugins.call("after_run")
+    assert called == ["cb"]
+
+    plugins.clear()
+    called.clear()
+
+    plugins.call("after_run")
+    assert called == []
+
+    plugins.register("after_run", cb)
+    plugins.call("after_run")
+    assert called == ["cb"]


### PR DESCRIPTION
## Contexte
Ajout de tests unitaires pour garantir que le gestionnaire de plugins exécute les fonctions dans l'ordre d'inscription et que la fonction `clear` vide correctement le registre.

## Impact
Aucun impact sur les autres agents.

## Étapes pour tester
1. `poetry install`
2. `poetry run pre-commit run --all-files`
3. `poetry run pytest`
4. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a65ba7c008321b8408ff9ccb1f7a6