### PR TITLE
[tests] compléter program_break_time

### DIFF
--- a/tests/test_shared_utils_program_break_time.py
+++ b/tests/test_shared_utils_program_break_time.py
@@ -1,13 +1,16 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # add project root to sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 from sele_saisie_auto.utils.misc import program_break_time  # noqa: E402
 
 
-def test_program_break_time_executes(monkeypatch):
+@pytest.mark.parametrize("delay", [0, 1, 3])
+def test_program_break_time_executes(monkeypatch, delay):
     calls = []
     logged: list[str] = []
 
@@ -23,8 +26,8 @@ def test_program_break_time_executes(monkeypatch):
         ),
     )
 
-    program_break_time(3, "Attente")
+    program_break_time(delay, "Attente")
 
-    assert calls == [1, 1, 1]
-    assert any(msg.startswith("Attente 3 secondes") for msg in logged)
-    assert logged.count(".") == 3
+    assert calls == [1] * delay
+    assert any(msg.startswith(f"Attente {delay} secondes") for msg in logged)
+    assert logged.count(".") == delay


### PR DESCRIPTION
## Contexte
Ajout de cas supplémentaires pour `program_break_time` en utilisant `monkeypatch` afin de simuler `time.sleep`.

## Étapes pour tester
1. `poetry run pre-commit run --files tests/test_shared_utils_program_break_time.py`
2. `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a6e3d7d608321a7ff903a09796323