### PR TITLE
[plugins] collecte des retours de hooks

### DIFF
--- a/docs/guides/advanced-usage-example.md
+++ b/docs/guides/advanced-usage-example.md
@@ -50,3 +50,27 @@ DEBUG:root:debut
 DEBUG:root:mouvements ['U']
 duree 0.00s, taille 1
 ```
+
+## Récupérer le résultat des hooks
+
+`sele_saisie_auto` expose un petit système de plugins. Toutes les fonctions
+enregistrées pour un hook sont exécutées via `plugins.call` et leurs retours sont
+désormais collectés dans une liste :
+
+```python
+from sele_saisie_auto import plugins
+
+@plugins.hook("after_run")
+def plus_un(val):
+    return val + 1
+
+@plugins.hook("after_run")
+def fois_deux(val):
+    return val * 2
+
+resultats = plugins.call("after_run", 3)
+print(resultats)  # [4, 6]
+```
+
+Cette fonctionnalité permet de récupérer facilement les valeurs produites par
+chaque plugin.

--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -8,7 +8,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.padding import PKCS7
 
 from sele_saisie_auto.logger_utils import write_log
-from sele_saisie_auto.logging_service import Logger, get_logger
+from sele_saisie_auto.logging_service import get_logger
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 
 

--- a/src/sele_saisie_auto/plugins.py
+++ b/src/sele_saisie_auto/plugins.py
@@ -26,10 +26,12 @@ def hook(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     return decorator
 
 
-def call(name: str, *args: Any, **kwargs: Any) -> None:
-    """Invoke all functions registered for *name*."""
+def call(name: str, *args: Any, **kwargs: Any) -> list[Any]:
+    """Invoke all functions registered for *name* and collect their results."""
+    results: list[Any] = []
     for func in list(_HOOKS.get(name, [])):
-        func(*args, **kwargs)
+        results.append(func(*args, **kwargs))
+    return results
 
 
 def clear() -> None:

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -31,15 +31,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -33,18 +33,18 @@ from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.error_handler import log_error
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import initialize_logger, write_log
-from sele_saisie_auto.logging_service import Logger, get_logger
-from sele_saisie_auto.selenium_utils import click_element_without_wait  # noqa: F401
-from sele_saisie_auto.selenium_utils import modifier_date_input  # noqa: F401
-from sele_saisie_auto.selenium_utils import send_keys_to_element  # noqa: F401
-from sele_saisie_auto.selenium_utils import Waiter, detecter_doublons_jours
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.logging_service import get_logger
 from sele_saisie_auto.selenium_utils import (
+    Waiter,
+    click_element_without_wait,  # noqa: F401
+    detecter_doublons_jours,
+    modifier_date_input,  # noqa: F401
+    send_keys_to_element,  # noqa: F401
     switch_to_default_content,
     switch_to_iframe_by_id_or_name,
     wait_for_dom_after,
-    wait_for_element,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -95,6 +95,7 @@ __all__ = [
     "modifier_date_input",
     "send_keys_to_element",
     "click_element_without_wait",
+    "switch_to_iframe_by_id_or_name",
 ]
 
 

--- a/src/sele_saisie_auto/selenium_utils/wait_helpers.py
+++ b/src/sele_saisie_auto/selenium_utils/wait_helpers.py
@@ -7,7 +7,6 @@ from functools import wraps
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
-from selenium.webdriver.support.ui import WebDriverWait as _WebDriverWait
 
 from sele_saisie_auto.logging_service import Logger
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -130,3 +130,18 @@ def test_hook_decorator_registers():
 
     plugins.call("after_run", 123)
     assert calls == [123]
+
+
+def test_call_returns_list_of_results():
+    plugins.clear()
+
+    @plugins.hook("after_run")
+    def plus_one(x):
+        return x + 1
+
+    @plugins.hook("after_run")
+    def times_two(x):
+        return x * 2
+
+    results = plugins.call("after_run", 3)
+    assert results == [4, 6]


### PR DESCRIPTION
## Contexte
- `plugins.call` ne renvoyait rien, ce qui empêchait de récupérer les valeurs calculées par les plugins.
- La documentation d'usage avancé n'expliquait pas comment récupérer ces résultats.

## Changements
- `plugins.call` retourne désormais la liste des valeurs renvoyées par chaque fonction enregistrée
- ajout d'un test illustrant ce comportement
- documentation mise à jour avec un exemple d'appel

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run ruff check`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run bandit -r src/ -lll -iii`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a776c1da48321a3596fae1e4ff132