### PR TITLE
[ConfigManager] Ajout AppConfigRaw et adaptation load_config

### DIFF
--- a/src/sele_saisie_auto/app_config.py
+++ b/src/sele_saisie_auto/app_config.py
@@ -30,6 +30,13 @@ from sele_saisie_auto.read_or_write_file_config_ini_utils import read_config_ini
 
 
 @dataclass
+class AppConfigRaw:
+    """Raw configuration container."""
+
+    parser: ConfigParser
+
+
+@dataclass
 class AppConfig:
     """Structured configuration loaded from ``config.ini``."""
 
@@ -187,6 +194,12 @@ class AppConfig:
             raw=parser,
         )
 
+    @classmethod
+    def from_raw(cls, raw: AppConfigRaw) -> AppConfig:
+        """Build ``AppConfig`` from a :class:`AppConfigRaw`."""
+
+        return cls.from_parser(raw.parser)
+
 
 def load_config(log_file: str | None) -> AppConfig:
     """Load ``config.ini`` and return an :class:`AppConfig`.
@@ -213,7 +226,8 @@ def load_config(log_file: str | None) -> AppConfig:
                 parser.add_section(section)
             parser.set(section, option, value)
 
-    cfg = AppConfig.from_parser(parser)
+    raw_cfg = AppConfigRaw(parser=parser)
+    cfg = AppConfig.from_raw(raw_cfg)
     if not cfg.url.strip():
         raise ValueError("L'URL de connexion ne peut pas être vide.")
     if not cfg.encrypted_login.strip() or not cfg.encrypted_mdp.strip():

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -154,9 +154,9 @@ class DummyAdditionalInfoPage:
 
 
 def setup_init(monkeypatch, cfg):
-    from sele_saisie_auto.app_config import AppConfig
+    from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 
-    app_cfg = AppConfig.from_parser(cfg)
+    app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyEnc())
     monkeypatch.setattr(sap, "SharedMemoryService", lambda logger: DummySHMService())

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -73,9 +73,9 @@ class DummyManager:
 
 
 def setup_init(monkeypatch, cfg):
-    from sele_saisie_auto.app_config import AppConfig
+    from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 
-    app_cfg = AppConfig.from_parser(cfg)
+    app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyEnc())
     monkeypatch.setattr(sap, "SharedMemoryService", lambda logger: DummySHMService())

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -108,9 +108,9 @@ def test_submit_and_validate_additional_information_positive(monkeypatch):
 
 def test_initialize_debug_mode_off(monkeypatch, sample_config, tmp_path):
     cfg = sample_config
-    from sele_saisie_auto.app_config import AppConfig
+    from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 
-    app_cfg = AppConfig.from_parser(cfg)
+    app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
     monkeypatch.setattr(
         sap,
         "ConfigManager",

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -18,9 +18,9 @@ pytestmark = pytest.mark.slow
 def test_initialize_date_none(monkeypatch, sample_config):
     cfg = sample_config
     cfg["settings"]["date_cible"] = "none"
-    from sele_saisie_auto.app_config import AppConfig
+    from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 
-    app_cfg = AppConfig.from_parser(cfg)
+    app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyEnc())
     sap.initialize(


### PR DESCRIPTION
## Contexte
Ajout d'une dataclass `AppConfigRaw` contenant uniquement le `ConfigParser` et adaptation de `load_config` pour construire `AppConfig` à partir de cet objet. Les tests ont été mis à jour en conséquence.

## Étapes pour tester
1. `poetry run pre-commit run --files src/sele_saisie_auto/app_config.py tests/test_saisie_automatiser_psatime.py tests/test_saisie_automatiser_psatime_additional.py tests/test_saisie_automatiser_psatime_extra.py tests/test_saisie_automatiser_psatime_cover.py`
2. `poetry run pytest -q`

## Impact
Aucun impact attendu sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a7a89f190832197df73acb06fbeb0