### PR TITLE
[docs] Ajout explication PSATIME_AES_KEY

### DIFF
--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -58,3 +58,15 @@ lundi = CGI
 [cgi_options_billing_action]
 Facturable = B
 ```
+
+### PSATIME_AES_KEY
+
+Lors du lancement, l'outil génère une clé AES aléatoire de 32 octets avec
+``os.urandom``. Cette clé sert à chiffrer les identifiants et est placée en
+mémoire partagée (segment ``memoire_partagee_cle``). Aucune information n'est
+écrite sur le disque.
+
+Vous pouvez aussi prédéfinir la variable d'environnement ``PSATIME_AES_KEY``
+pour fournir votre propre clé (format hexadécimal ou Base64). Si cette variable
+est absente, la clé est créée à chaque exécution puis effacée à la fermeture
+du programme.


### PR DESCRIPTION
## Contexte
Ajout de la documentation sur la variable `PSATIME_AES_KEY` pour clarifier la génération et le stockage de la clé AES.

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run ruff check`
- `poetry run ruff check . --fix`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run bandit -r src/ -lll -iii`

Aucune régression observée.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a7da7a7408321b1711240daf49db6