### PR TITLE
[SeleniumUtils] decorator search driver name

### DIFF
--- a/src/sele_saisie_auto/selenium_utils/wait_helpers.py
+++ b/src/sele_saisie_auto/selenium_utils/wait_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import time
 from functools import wraps
 
@@ -184,7 +185,13 @@ def wait_for_dom_after(func):
         result = func(*args, **kwargs)
         if args:
             instance = args[0]
-            driver = args[1] if len(args) > 1 else kwargs.get("driver")
+            driver = kwargs.get("driver")
+            if driver is None:
+                signature = inspect.signature(func)
+                if "driver" in signature.parameters:
+                    index = list(signature.parameters).index("driver")
+                    if len(args) > index:
+                        driver = args[index]
             if driver is not None and hasattr(instance, "wait_for_dom"):
                 instance.wait_for_dom(driver)
         return result

--- a/tests/test_wait_for_dom_after.py
+++ b/tests/test_wait_for_dom_after.py
@@ -12,5 +12,5 @@ def test_wait_for_dom_after_decorator(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: calls.append("dom")
     )
-    sap.submit_date_cible("drv")
+    sap.submit_date_cible(driver="drv")
     assert calls.count("dom") == 2


### PR DESCRIPTION
## Contexte
- le décorateur `wait_for_dom_after` détectait le driver par position
- on veut référencer l'argument `driver` par son nom

## Changements
- recherche du paramètre `driver` via `inspect.signature`
- tri automatique des imports
- appel du test avec `driver=` en mot-clé

## Impact
- pas d'impact sur les autres agents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686a8ae6751883218b5ca30790eb6491