### PR TITLE
[shared_utils] exceptions chaînées

### DIFF
--- a/src/sele_saisie_auto/read_or_write_file_config_ini_utils.py
+++ b/src/sele_saisie_auto/read_or_write_file_config_ini_utils.py
@@ -78,7 +78,7 @@ def get_runtime_resource_path(relative_path, log_file=None):
                     log_file,
                     DEFAULT_LOG_LEVEL,
                 )
-            except FileNotFoundError:
+            except FileNotFoundError as e:
                 write_log(
                     f"🔴 Fichier embarqué {messages.INTROUVABLE} : {embedded_resource}",
                     log_file,
@@ -86,8 +86,8 @@ def get_runtime_resource_path(relative_path, log_file=None):
                 )
                 raise FileNotFoundError(
                     f"{messages.IMPOSSIBLE_DE_TROUVER} le fichier embarqué : {embedded_resource}"
-                )
-            except PermissionError:
+                ) from e
+            except PermissionError as e:
                 write_log(
                     f"🔴 Permission refusée pour copier {embedded_resource} vers {current_dir_resource}",
                     log_file,
@@ -95,7 +95,7 @@ def get_runtime_resource_path(relative_path, log_file=None):
                 )
                 raise PermissionError(
                     f"Permission refusée pour copier : {embedded_resource}"
-                )
+                ) from e
     else:
         write_log("🔹 Exécution en mode script.", log_file, DEFAULT_LOG_LEVEL)
 

--- a/src/sele_saisie_auto/shared_utils.py
+++ b/src/sele_saisie_auto/shared_utils.py
@@ -32,9 +32,11 @@ def setup_logs(log_dir=DEFAULT_LOG_DIR, log_format=HTML_FORMAT):
         )
         return log_file
     except OSError as e:
-        raise RuntimeError(f"Erreur liée au système de fichiers : {e}")
+        raise RuntimeError(f"Erreur liée au système de fichiers : {e}") from e
     except Exception as e:
-        raise RuntimeError(f"Erreur inattendue lors de la création des logs : {e}")
+        raise RuntimeError(
+            f"Erreur inattendue lors de la création des logs : {e}"
+        ) from e
 
 
 def get_log_file():


### PR DESCRIPTION
## Contexte
Uniformisation de la gestion des exceptions.

## Impact
- Chaînage des `RuntimeError` dans `shared_utils.setup_logs`.
- Chaînage des exceptions de copie dans `get_runtime_resource_path`.

## Tests
- `poetry run ruff check`
- `poetry run ruff check . --fix`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686aaad708b883218cbd73c14a02a9c3