### PR TITLE
[SeleniumUtils] Harmonise ordre docstrings/imports

### DIFF
--- a/src/sele_saisie_auto/selenium_driver_manager.py
+++ b/src/sele_saisie_auto/selenium_driver_manager.py
@@ -1,7 +1,6 @@
-# pragma: no cover
-from __future__ import annotations
-
 """Backward compatibility wrapper for ``SeleniumDriverManager``."""  # pragma: no cover
+
+from __future__ import annotations
 
 from sele_saisie_auto.automation.browser_session import (
     SeleniumDriverManager,  # pragma: no cover

--- a/src/sele_saisie_auto/selenium_utils/wrapper.py
+++ b/src/sele_saisie_auto/selenium_utils/wrapper.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """High level wrapper around WebDriver wait helpers."""
+
+from __future__ import annotations
 
 import time
 


### PR DESCRIPTION
## Contexte et objectif
Réorganisation de l'en-tête des modules pour respecter les conventions du projet.

## Étapes pour tester
1. `poetry install --no-interaction`
2. `poetry run pre-commit run --files src/sele_saisie_auto/selenium_driver_manager.py src/sele_saisie_auto/selenium_utils/wrapper.py`
3. `poetry run pytest`

## Impact
Aucun impact fonctionnel, uniquement le style des imports dans deux modules.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686aad3b6ffc83218bfd68e4d71e8ef2