### PR TITLE
[ConfigManager] expose ENV_VAR_MAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Les valeurs de `config.ini` peuvent être surchargées via ces variables :
 - `PSATIME_MDP` — mot de passe chiffré
 - `PSATIME_DEBUG_MODE` — niveau de log (`INFO`, `DEBUG`, …)
 - `PSATIME_LISTE_ITEMS_PLANNING` — liste d'items de planning séparés par des virgules
+- `PSATIME_DEFAULT_TIMEOUT` — délai d'attente par défaut pour Selenium
+- `PSATIME_LONG_TIMEOUT` — délai prolongé pour certaines opérations
 Les variables d'environnement ont priorité sur le fichier de configuration.
 Un fichier `.env` peut être utilisé pour définir ces variables mais sera
 écrasé si le même nom est déjà présent dans l'environnement système.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -21,6 +21,19 @@ Les paramètres de sécurité sont définis dans `src/`.
 
 Modifiez ces valeurs dans `config.ini` ou via des variables d’environnement si besoin.
 
+## Variables d'environnement prises en charge
+
+Les paramètres du fichier peuvent être surchargés avec :
+
+- `PSATIME_URL` — URL du portail PSA Time
+- `PSATIME_DATE_CIBLE` — date cible au format `JJ/MM/AAAA`
+- `PSATIME_LOGIN` — identifiant chiffré
+- `PSATIME_MDP` — mot de passe chiffré
+- `PSATIME_DEBUG_MODE` — niveau de log (`INFO`, `DEBUG`, …)
+- `PSATIME_LISTE_ITEMS_PLANNING` — liste d'items séparés par des virgules
+- `PSATIME_DEFAULT_TIMEOUT` — délai d'attente par défaut pour Selenium
+- `PSATIME_LONG_TIMEOUT` — délai prolongé pour certaines opérations
+
 ## 3. Exemple de fichier `.env`
 
 ```dotenv

--- a/docs/overview/limitations.md
+++ b/docs/overview/limitations.md
@@ -37,6 +37,8 @@ suivantes :
 - `PSATIME_MDP` — mot de passe chiffré
 - `PSATIME_DEBUG_MODE` — niveau de log (`INFO`, `DEBUG`, …)
 - `PSATIME_LISTE_ITEMS_PLANNING` — liste d'items séparés par des virgules
+- `PSATIME_DEFAULT_TIMEOUT` — délai d'attente par défaut pour Selenium
+- `PSATIME_LONG_TIMEOUT` — délai prolongé pour certaines opérations
 
 Les variables d'environnement ont priorité sur le fichier `config.ini`.
 Un fichier `.env` peut également être présent ; ses valeurs sont chargées mais

--- a/src/sele_saisie_auto/app_config.py
+++ b/src/sele_saisie_auto/app_config.py
@@ -285,6 +285,18 @@ class AppConfig:
         return cls.from_parser(raw.parser)
 
 
+ENV_VAR_MAP: dict[tuple[str, str], str] = {
+    ("credentials", "login"): "PSATIME_LOGIN",
+    ("credentials", "mdp"): "PSATIME_MDP",
+    ("settings", "url"): "PSATIME_URL",
+    ("settings", "date_cible"): "PSATIME_DATE_CIBLE",
+    ("settings", "debug_mode"): "PSATIME_DEBUG_MODE",
+    ("settings", "liste_items_planning"): "PSATIME_LISTE_ITEMS_PLANNING",
+    ("settings", "default_timeout"): "PSATIME_DEFAULT_TIMEOUT",
+    ("settings", "long_timeout"): "PSATIME_LONG_TIMEOUT",
+}
+
+
 def load_config(log_file: str | None) -> AppConfig:
     """Load ``config.ini`` and return an :class:`AppConfig`.
 
@@ -293,17 +305,7 @@ def load_config(log_file: str | None) -> AppConfig:
     """
     parser = read_config_ini(log_file=log_file)
 
-    env_map = {
-        ("credentials", "login"): "PSATIME_LOGIN",
-        ("credentials", "mdp"): "PSATIME_MDP",
-        ("settings", "url"): "PSATIME_URL",
-        ("settings", "date_cible"): "PSATIME_DATE_CIBLE",
-        ("settings", "debug_mode"): "PSATIME_DEBUG_MODE",
-        ("settings", "liste_items_planning"): "PSATIME_LISTE_ITEMS_PLANNING",
-        ("settings", "default_timeout"): "PSATIME_DEFAULT_TIMEOUT",
-        ("settings", "long_timeout"): "PSATIME_LONG_TIMEOUT",
-    }
-    for (section, option), env_var in env_map.items():
+    for (section, option), env_var in ENV_VAR_MAP.items():
         value = os.getenv(env_var)
         if value is not None:
             if not parser.has_section(section):


### PR DESCRIPTION
## Contexte
- centraliser les variables d'environnement utilisées pour la configuration
- améliorer la documentation sur les variables disponibles

## Changements
- extraire ENV_VAR_MAP de `load_config`
- utiliser la constante lors du chargement
- lister toutes les variables d'environnement dans la doc

## Impact
- aucune régression détectée
- permet d'ajouter ou de modifier facilement les variables reconnues

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686ac2589d18832185a32d74a5c61137