### PR TITLE
[docs] Ajout guide commandes outils qualité

### DIFF
--- a/docs/guides/commandes-outils-qualite.md
+++ b/docs/guides/commandes-outils-qualite.md
@@ -1,0 +1,147 @@
+# Commandes pour les outils de qualité de code Python
+
+Cette page récapitule les commandes utiles pour sept outils courants de formatage, de linting et d'analyse de code. Chaque tableau sépare les commandes fréquemment utilisées des options avancées. Les liens vers PyPI permettent d'accéder rapidement à la documentation de chaque outil.
+
+## Black
+
+**PyPI :** <https://pypi.org/project/black/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `black .` | Formate tout le code du répertoire courant | N/A |
+| `black --check . > reports/black/black_check.txt` | Vérifie la mise en forme sans modifier les fichiers | `reports/black/black_check.txt` |
+| `black --diff . > reports/black/black_diff.txt` | Affiche le diff des modifications éventuelles | `reports/black/black_diff.txt` |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `black --exclude "migrations|venv" .` | Exclut les dossiers correspondant au motif regex | N/A |
+| `black --line-length 100 .` | Utilise 100 caractères par ligne | N/A |
+| `black --config pyproject.toml .` | Lit les options depuis `pyproject.toml` | N/A |
+
+## isort
+
+**PyPI :** <https://pypi.org/project/isort/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `isort .` | Trie et formate les imports en place | N/A |
+| `isort --check-only . > reports/isort/isort_check.txt` | Vérifie le tri des imports sans modifier | `reports/isort/isort_check.txt` |
+| `isort --diff . > reports/isort/isort_diff.txt` | Montre le diff des corrections possibles | `reports/isort/isort_diff.txt` |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `isort --profile black .` | Adapte le tri des imports au style Black | N/A |
+| `isort --atomic .` | Applique les changements de manière atomique | N/A |
+| `isort --recursive .` | Recherche récursivement tous les fichiers Python | N/A |
+
+## Bandit
+
+**PyPI :** <https://pypi.org/project/bandit/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `bandit -r . -f txt -o reports/bandit/bandit_report.txt` | Analyse de sécurité et rapport texte | `reports/bandit/bandit_report.txt` |
+| `bandit -r . -f html -o reports/bandit/bandit_report.html` | Rapport HTML interactif | `reports/bandit/bandit_report.html` |
+| `bandit -r . -f json -o reports/bandit/bandit_report.json` | Rapport JSON utilisable en CI | `reports/bandit/bandit_report.json` |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `bandit -r . -b baseline.json -f html -o reports/bandit/bandit_after_baseline.html` | Ignore les vulnérabilités présentes dans `baseline.json` | `reports/bandit/bandit_after_baseline.html` |
+| `bandit -r . -lll -iii` | Filtre sur la sévérité **Haute** et la confiance **Haute** | N/A |
+| `bandit -r . -c bandit.yaml -f txt -o reports/bandit/bandit_custom.txt` | Utilise un fichier de configuration personnalisé | `reports/bandit/bandit_custom.txt` |
+
+## Radon
+
+**PyPI :** <https://pypi.org/project/radon/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `radon cc . -s -a` | Calcule la complexité cyclomatique et la moyenne du projet | N/A |
+| `radon mi .` | Calcule l'indice de maintenabilité | N/A |
+| `radon raw .` | Affiche les métriques brutes de chaque fichier | N/A |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `radon cc src/ -j -O reports/radon/cc_report.json` | Rapport JSON de la complexité cyclomatique | `reports/radon/cc_report.json` |
+| `radon mi src/ -j -O reports/radon/mi_report.json` | Rapport JSON de l'indice de maintenabilité | `reports/radon/mi_report.json` |
+| `radon raw src/ -j -O reports/radon/raw_report.json` | Rapport JSON des métriques brutes | `reports/radon/raw_report.json` |
+| `radon hal src/ -j -O reports/radon/hal_report.json` | Rapport JSON des métriques de Halstead | `reports/radon/hal_report.json` |
+
+## Ruff
+
+**PyPI :** <https://pypi.org/project/ruff/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `ruff check . > reports/ruff/ruff_check.txt` | Lint complet du code et rapport texte | `reports/ruff/ruff_check.txt` |
+| `ruff check --fix . > reports/ruff/ruff_fix.txt` | Applique les correctifs automatiques disponibles | `reports/ruff/ruff_fix.txt` |
+| `ruff format . --check --diff > reports/ruff/ruff_diff.txt` | Vérifie le formatage Black et montre le diff | `reports/ruff/ruff_diff.txt` |
+| `ruff check . --output-format=json > reports/ruff/ruff_check.json` | Produit un rapport JSON | `reports/ruff/ruff_check.json` |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `ruff rule F401` | Affiche le détail de la règle `F401` | N/A |
+| `ruff check . --statistics` | Montre un résumé par règle après l'analyse | N/A |
+| `ruff clean` | Vide le cache de Ruff | N/A |
+| `ruff check --select E,F .` | Ne lance que les règles commençant par **E** et **F** | N/A |
+
+## Flake8
+
+**PyPI :** <https://pypi.org/project/flake8/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `flake8 .` | Analyse le code selon PEP8 et PyFlakes | N/A |
+| `flake8 --statistics --count .` | Résumé final du nombre d'erreurs | N/A |
+| `flake8 --output-file=reports/flake8/flake8_report.txt .` | Exporte le rapport complet dans un fichier | `reports/flake8/flake8_report.txt` |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `flake8 . --max-complexity=10` | Signale les fonctions dépassant une complexité de 10 | N/A |
+| `flake8 . --exit-zero` | Retourne toujours un code de sortie 0 | N/A |
+| `flake8 . --ignore=E501,W503` | Ignore les règles `E501` et `W503` | N/A |
+| `flake8 . --select=F,E` | Ne rapporte que les catégories **F** et **E** | N/A |
+
+## MyPy
+
+**PyPI :** <https://pypi.org/project/mypy/>
+
+### Commandes courantes
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `mypy .` | Vérifie les annotations de type sur tout le projet | N/A |
+| `mypy . --ignore-missing-imports` | Ignore les imports sans stubs de type | N/A |
+| `mypy . --strict` | Active toutes les vérifications supplémentaires | N/A |
+
+### Commandes avancées
+
+| Commande | Description | Chemin de sortie |
+| --- | --- | --- |
+| `mypy . --show-error-codes --pretty \`<br>`--html-report=reports/mypy/html \`<br>`--xml-report=reports/mypy/xml \`<br>`--txt-report=reports/mypy/txt \`<br>`--cobertura-xml-report=reports/mypy/cobertura \`<br>`--linecoverage-report=reports/mypy/linecoverage` | Génère plusieurs rapports (HTML, XML, texte, Cobertura, couverture de lignes) | `reports/mypy/{html,xml,txt,cobertura,linecoverage}` |
+| `mypy . --junit-xml=reports/mypy/junit.xml` | Produit un rapport au format JUnit | `reports/mypy/junit.xml` |
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ La documentation est organisée dans les dossiers suivants :
 - [`guides/deployment.md`](guides/deployment.md) – Construire et lancer l'application avec Docker.
 - [`guides/installation.md`](guides/installation.md) – Instructions d’installation locale.
 - [`guides/logging-and-errors.md`](guides/logging-and-errors.md) – Journaliser les actions et afficher des messages d’erreur sûrs.
+- [`guides/commandes-outils-qualite.md`](guides/commandes-outils-qualite.md) – Récapitulatif des commandes des outils de qualité.
 - [`guides/async-class-example.md`](guides/async-class-example.md) – Petit exemple de classe asynchrone.
 - [`guides/usage-example.md`](guides/usage-example.md) – Exemple de workflow
 

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -31,13 +31,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -34,17 +34,16 @@ from sele_saisie_auto.error_handler import log_error
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import initialize_logger, write_log
 from sele_saisie_auto.logging_service import get_logger
+from sele_saisie_auto.selenium_utils import click_element_without_wait  # noqa: F401
+from sele_saisie_auto.selenium_utils import modifier_date_input  # noqa: F401
+from sele_saisie_auto.selenium_utils import send_keys_to_element  # noqa: F401
+from sele_saisie_auto.selenium_utils import Waiter, detecter_doublons_jours
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils import (
-    Waiter,
-    click_element_without_wait,  # noqa: F401
-    detecter_doublons_jours,
-    modifier_date_input,  # noqa: F401
-    send_keys_to_element,  # noqa: F401
     switch_to_default_content,
     switch_to_iframe_by_id_or_name,
     wait_for_dom_after,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time


### PR DESCRIPTION
## Contexte
Ajout d'une nouvelle page listant les commandes essentielles pour les outils de qualité de code Python (Black, isort, Bandit, Radon, Ruff, Flake8, MyPy). Le sommaire de la documentation est mis à jour en conséquence.

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact
Aucun impact sur les agents existants.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686ad1b7adc48321a3f8142c43712804