### PR TITLE
[BrowserSession] Encapsule switch_to dans BrowserSession

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -78,7 +78,7 @@ class AdditionalInfoPage:
             sap.click_element_without_wait(
                 driver, By.ID, Locators.ADDITIONAL_INFO_LINK.value
             )
-        sap.switch_to_default_content(driver)
+        self._automation.browser_session.go_to_default_content()
         self.wait_for_dom(driver)
 
     @wait_for_dom_after
@@ -93,8 +93,8 @@ class AdditionalInfoPage:
             timeout=self.config.default_timeout,
         )
         if element_present:
-            switched_to_iframe = sap.switch_to_iframe_by_id_or_name(
-                driver, Locators.MODAL_FRAME.value
+            switched_to_iframe = self._automation.browser_session.go_to_iframe(
+                Locators.MODAL_FRAME.value
             )
 
         if switched_to_iframe:
@@ -144,7 +144,7 @@ class AdditionalInfoPage:
         ]
         from sele_saisie_auto import saisie_automatiser_psatime as sap
 
-        sap.switch_to_default_content(driver)
+        self._automation.browser_session.go_to_default_content()
         for alerte in alerts:
             if self.waiter.wait_for_element(
                 driver, By.ID, alerte, timeout=self.config.default_timeout

--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from sele_saisie_auto.app_config import AppConfig
@@ -8,7 +9,6 @@ from sele_saisie_auto.selenium_utils import (
     Waiter,
     definir_taille_navigateur,
     ouvrir_navigateur_sur_ecran_principal,
-    switch_to_iframe_by_id_or_name,
     wait_for_dom_ready,
 )
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
@@ -157,4 +157,22 @@ class BrowserSession:
 
         if self.driver is None:
             return False
-        return switch_to_iframe_by_id_or_name(self.driver, id_or_name)
+
+        try:
+            self.driver.switch_to.frame(self.driver.find_element(By.ID, id_or_name))
+            return True
+        except Exception:  # noqa: BLE001
+            try:
+                self.driver.switch_to.frame(
+                    self.driver.find_element(By.NAME, id_or_name)
+                )
+                return True
+            except Exception:  # noqa: BLE001
+                return False
+
+    def go_to_default_content(self) -> None:
+        """Return to the default document context."""
+
+        if self.driver is None:
+            return
+        self.driver.switch_to.default_content()

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -158,7 +158,7 @@ class DateEntryPage:
         """Close alert if the date already exists."""
         from sele_saisie_auto import saisie_automatiser_psatime as sap
 
-        sap.switch_to_default_content(driver)
+        self._automation.browser_session.go_to_default_content()
         alerte = Locators.ALERT_CONTENT_0.value
         if self.waiter.wait_for_element(
             driver, By.ID, alerte, timeout=self.config.default_timeout

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -34,17 +34,12 @@ from sele_saisie_auto.error_handler import log_error
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import initialize_logger, write_log
 from sele_saisie_auto.logging_service import get_logger
-from sele_saisie_auto.selenium_utils import (
-    Waiter,
-    click_element_without_wait,  # noqa: F401
-    detecter_doublons_jours,
-    modifier_date_input,  # noqa: F401
-    send_keys_to_element,  # noqa: F401
-    switch_to_default_content,
-    switch_to_iframe_by_id_or_name,
-    wait_for_dom_after,
-)
+from sele_saisie_auto.selenium_utils import click_element_without_wait  # noqa: F401
+from sele_saisie_auto.selenium_utils import modifier_date_input  # noqa: F401
+from sele_saisie_auto.selenium_utils import send_keys_to_element  # noqa: F401
+from sele_saisie_auto.selenium_utils import Waiter, detecter_doublons_jours
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -95,7 +90,6 @@ __all__ = [
     "modifier_date_input",
     "send_keys_to_element",
     "click_element_without_wait",
-    "switch_to_iframe_by_id_or_name",
 ]
 
 
@@ -418,7 +412,7 @@ class PSATimeAutomation:
         )
         self.navigate_from_work_schedule_to_additional_information_page(driver)
         self.submit_and_validate_additional_information(driver)
-        switch_to_default_content(driver)
+        self.browser_session.go_to_default_content()
         self.wait_for_dom(driver)
         if self.switch_to_iframe_main_target_win0(driver):
             detecter_doublons_jours(driver)

--- a/tests/test_additional_info_page.py
+++ b/tests/test_additional_info_page.py
@@ -23,6 +23,10 @@ class DummyAutomation:
                 }
             ]
         )
+        self.browser_session = types.SimpleNamespace(
+            go_to_iframe=lambda *a, **k: True,
+            go_to_default_content=lambda *a, **k: None,
+        )
 
     def wait_for_dom(self, driver):
         pass
@@ -38,7 +42,7 @@ def test_navigate_from_work_schedule(monkeypatch):
         lambda *a, **k: clicks.append(True),
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.switch_to_default_content",
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
         lambda *a, **k: None,
     )
     monkeypatch.setattr(AdditionalInfoPage, "wait_for_dom", lambda self, d: None)
@@ -52,7 +56,7 @@ def test_submit_and_validate_additional_information(monkeypatch):
     seq = iter([True, True])
     monkeypatch.setattr(page.waiter, "wait_for_element", lambda *a, **k: next(seq))
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.switch_to_iframe_by_id_or_name",
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_iframe",
         lambda *a, **k: True,
     )
     records = []
@@ -103,7 +107,7 @@ def test_handle_save_alerts(monkeypatch):
         lambda msg, f, level: logs.append(msg),
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.switch_to_default_content",
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
         lambda *a, **k: None,
     )
     page._handle_save_alerts("drv")

--- a/tests/test_date_entry_page.py
+++ b/tests/test_date_entry_page.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,9 @@ from sele_saisie_auto.automation.date_entry_page import DateEntryPage  # noqa: E
 class DummyAutomation:
     def __init__(self):
         self.log_file = "log.html"
+        self.browser_session = types.SimpleNamespace(
+            go_to_default_content=lambda *a, **k: None,
+        )
 
     def wait_for_dom(self, driver):
         pass
@@ -177,7 +181,7 @@ def test_handle_date_alert(monkeypatch):
         lambda msg, f, level: logs.append(msg),
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.switch_to_default_content",
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
         lambda *a, **k: None,
     )
     monkeypatch.setattr(page, "wait_for_dom", lambda d: None)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -60,7 +60,10 @@ def test_run_invokes_hook(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "switch_to_iframe_main_target_win0", lambda *a, **k: True
     )
-    monkeypatch.setattr(sap, "switch_to_default_content", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
+        lambda *a, **k: None,
+    )
     monkeypatch.setattr(
         sap._AUTOMATION.waiter, "wait_for_element", lambda *a, **k: object()
     )

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -98,6 +98,9 @@ class DummyBrowserSession:
         self.go_calls.append(ident)
         return True
 
+    def go_to_default_content(self):
+        self.default_called = True
+
     def close(self):
         self.driver = None
 

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -61,7 +61,8 @@ def test_navigate_from_work_schedule_positive(monkeypatch):
         sap, "click_element_without_wait", lambda *a, **k: actions.append("click")
     )
     monkeypatch.setattr(
-        sap, "switch_to_default_content", lambda *a, **k: actions.append("switch")
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
+        lambda *a, **k: actions.append("switch"),
     )
     sap.navigate_from_work_schedule_to_additional_information_page("drv")
     assert actions.count("click") == 1
@@ -77,8 +78,7 @@ def test_submit_and_validate_additional_information_positive(monkeypatch):
     if sap._AUTOMATION:
         sap._AUTOMATION.browser_session.go_to_iframe = lambda *a, **k: True
     monkeypatch.setattr(
-        sap,
-        "switch_to_iframe_by_id_or_name",
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_iframe",
         lambda *a, **k: True,
     )
     records = []

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -195,7 +195,8 @@ def test_fill_and_save_timesheet(monkeypatch, sample_config):
         lambda d: calls.append("sub"),
     )
     monkeypatch.setattr(
-        sap, "switch_to_default_content", lambda d: calls.append("default")
+        "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
+        lambda *a, **k: calls.append("default"),
     )
     monkeypatch.setattr(
         auto, "save_draft_and_validate", lambda d: calls.append("save") or True


### PR DESCRIPTION
## Contexte
- les modules utilisaient `driver.switch_to.frame` via des helpers
- l'encapsulation est maintenant gérée par `BrowserSession`

## Changements
- ajout de `go_to_default_content` et mise à jour de `go_to_iframe`
- recours à ces méthodes dans `PSATimeAutomation`, `AdditionalInfoPage` et `DateEntryPage`
- ajustement des tests et des stubs

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686ad1b02c14832186076df53ebec423