### PR TITLE
[ConsoleUI] add basic tests

### DIFF
--- a/tests/test_console_ui_basic.py
+++ b/tests/test_console_ui_basic.py
@@ -1,0 +1,23 @@
+import builtins
+
+from sele_saisie_auto import console_ui
+from sele_saisie_auto.console_ui import ask_continue, show_separator
+
+
+def test_console_ui_basic(monkeypatch):
+    prompts: list[str] = []
+    monkeypatch.setattr(builtins, "input", lambda p: prompts.append(p) or "ok")
+
+    printed: list[str] = []
+
+    def fake_print(*args, **kwargs):
+        printed.append(" ".join(str(a) for a in args))
+
+    monkeypatch.setattr(builtins, "print", fake_print)
+    monkeypatch.setattr(console_ui, "write_log", lambda msg, *a, **k: fake_print(msg))
+
+    ask_continue("continue?")
+    assert prompts == ["continue?"]
+
+    show_separator()
+    assert any("***" in msg for msg in printed)


### PR DESCRIPTION
## Contexte
Ajout d'un test basique pour `ask_continue` et `show_separator` dans `tests/test_console_ui_basic.py`. Ce test utilise `monkeypatch` pour intercepter les appels à `input` et `print`.

## Étapes pour tester
1. `poetry run pre-commit run --files tests/test_console_ui_basic.py`
2. `poetry run pytest`

Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686ae72683248321bc148c79dd7ed3ef