### PR TITLE
[SharedUtils] gestion OSError dossier logs

### DIFF
--- a/src/sele_saisie_auto/shared_utils.py
+++ b/src/sele_saisie_auto/shared_utils.py
@@ -32,7 +32,7 @@ def setup_logs(log_dir=DEFAULT_LOG_DIR, log_format=HTML_FORMAT):
         )
         return log_file
     except OSError as e:
-        raise RuntimeError(f"Erreur liée au système de fichiers : {e}") from e
+        raise RuntimeError(f"Impossible de créer le dossier '{log_dir}': {e}") from e
     except Exception as e:
         raise RuntimeError(
             f"Erreur inattendue lors de la création des logs : {e}"

--- a/tests/test_shared_utils.py
+++ b/tests/test_shared_utils.py
@@ -35,7 +35,7 @@ def test_setup_logs_oserror(monkeypatch):
         raise OSError("boom")
 
     monkeypatch.setattr("sele_saisie_auto.shared_utils.os.makedirs", raise_oserror)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="Impossible de créer le dossier"):
         setup_logs()
 
 


### PR DESCRIPTION
## Contexte
- améliorer la robustesse de `setup_logs`
- test de l'erreur lors de la création du dossier

## Implémentation
- lever un `RuntimeError` explicite avec le nom du dossier
- tester le scénario en simulant `OSError`

## Impact
- pas d'impact sur les autres agents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686ae9889f2c8321af83ec359616adfc