### PR TITLE
[work] Simplify Locators enum

### DIFF
--- a/src/sele_saisie_auto/locators.py
+++ b/src/sele_saisie_auto/locators.py
@@ -1,24 +1,49 @@
-from enum import Enum
+from enum import Enum, auto
+
+_LOCATOR_MAP = {
+    "USERNAME": "userid",
+    "PASSWORD": "pwd",  # nosec B105 - refers to field id, not credentials
+    "MAIN_FRAME": "main_target_win0",
+    "NAV_TO_DATE_ENTRY": "PTNUI_LAND_REC14$0_row_0",
+    "SIDE_MENU_BUTTON": "PT_SIDE$PIMG",
+    "DATE_INPUT": "EX_TIME_ADD_VW_PERIOD_END_DT",
+    "ADD_BUTTON": "PTS_CFG_CL_WRK_PTS_ADD_BTN",
+    "ADDITIONAL_INFO_LINK": "UC_EX_WRK_UC_TI_FRA_LINK",
+    "MODAL_FRAME": "ptModFrame_0",
+    "SAVE_ICON": "#ICSave",
+    "SAVE_DRAFT_BUTTON": "EX_ICLIENT_WRK_SAVE_PB",
+    "CONFIRM_OK": "#ICOK",
+    "OK_BUTTON": "EX_ICLIENT_WRK_OK_PB",
+    "COPY_TIME_BUTTON": "EX_TIME_HDR_WRK_COPY_TIME_RPT",
+    "ALERT_CONTENT_0": "ptModContent_0",
+    "ALERT_CONTENT_1": "ptModContent_1",
+    "ALERT_CONTENT_2": "ptModContent_2",
+    "ALERT_CONTENT_3": "ptModContent_3",
+}
 
 
-class Locators(str, Enum):
+class Locators(Enum):
     """Central Selenium locators used across modules."""
 
-    USERNAME = "userid"
-    PASSWORD = "pwd"  # nosec B105 - refers to field id, not credentials
-    MAIN_FRAME = "main_target_win0"
-    NAV_TO_DATE_ENTRY = "PTNUI_LAND_REC14$0_row_0"
-    SIDE_MENU_BUTTON = "PT_SIDE$PIMG"
-    DATE_INPUT = "EX_TIME_ADD_VW_PERIOD_END_DT"
-    ADD_BUTTON = "PTS_CFG_CL_WRK_PTS_ADD_BTN"
-    ADDITIONAL_INFO_LINK = "UC_EX_WRK_UC_TI_FRA_LINK"
-    MODAL_FRAME = "ptModFrame_0"
-    SAVE_ICON = "#ICSave"
-    SAVE_DRAFT_BUTTON = "EX_ICLIENT_WRK_SAVE_PB"
-    CONFIRM_OK = "#ICOK"
-    OK_BUTTON = "EX_ICLIENT_WRK_OK_PB"
-    COPY_TIME_BUTTON = "EX_TIME_HDR_WRK_COPY_TIME_RPT"
-    ALERT_CONTENT_0 = "ptModContent_0"
-    ALERT_CONTENT_1 = "ptModContent_1"
-    ALERT_CONTENT_2 = "ptModContent_2"
-    ALERT_CONTENT_3 = "ptModContent_3"
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return _LOCATOR_MAP[name]
+
+    USERNAME = auto()
+    PASSWORD = auto()  # nosec B105 - refers to field id, not credentials
+    MAIN_FRAME = auto()
+    NAV_TO_DATE_ENTRY = auto()
+    SIDE_MENU_BUTTON = auto()
+    DATE_INPUT = auto()
+    ADD_BUTTON = auto()
+    ADDITIONAL_INFO_LINK = auto()
+    MODAL_FRAME = auto()
+    SAVE_ICON = auto()
+    SAVE_DRAFT_BUTTON = auto()
+    CONFIRM_OK = auto()
+    OK_BUTTON = auto()
+    COPY_TIME_BUTTON = auto()
+    ALERT_CONTENT_0 = auto()
+    ALERT_CONTENT_1 = auto()
+    ALERT_CONTENT_2 = auto()
+    ALERT_CONTENT_3 = auto()

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -40,9 +40,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time


### PR DESCRIPTION
## Contexte
- évite la redondance des valeurs dans l'enum `Locators`

## Implémentation
- passage à `Enum` simple avec `auto()`
- extraction des valeurs dans un dictionnaire privé
- adaptation automatique des imports

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_686aea881a248321829876dacac144c5