### PR TITLE
[ResourceManager] Ajout du gestionnaire de ressources

### DIFF
--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 

--- a/src/sele_saisie_auto/resources/resource_manager.py
+++ b/src/sele_saisie_auto/resources/resource_manager.py
@@ -1,0 +1,58 @@
+# resource_manager.py
+"""Context manager aggregating encryption and driver resources."""
+
+from __future__ import annotations
+
+from sele_saisie_auto.automation import BrowserSession
+from sele_saisie_auto.config_manager import ConfigManager
+from sele_saisie_auto.encryption_utils import Credentials, EncryptionService
+
+
+class ResourceManager:
+    """Centralize heavy resources for PSA Time automation."""
+
+    def __init__(self, log_file: str) -> None:
+        self.log_file = log_file
+        self._config_manager = ConfigManager(log_file)
+        self._encryption_service = EncryptionService(log_file)
+        self._session: BrowserSession | None = None
+        self._credentials: Credentials | None = None
+        self._driver = None
+
+    # ------------------------------------------------------------------
+    # Context manager protocol
+    # ------------------------------------------------------------------
+    def __enter__(self) -> ResourceManager:
+        self._app_config = self._config_manager.load()
+        self._session = BrowserSession(self.log_file, self._app_config)
+        self._enc_ctx = self._encryption_service.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._driver is not None and self._session is not None:
+            self._session.close()
+        self._encryption_service.__exit__(exc_type, exc, tb)
+        self._credentials = None
+        self._driver = None
+        self._session = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def get_credentials(self) -> Credentials:
+        """Retrieve encrypted credentials from shared memory."""
+        if self._credentials is None:
+            self._credentials = self._encryption_service.retrieve_credentials()
+        return self._credentials
+
+    def get_driver(self, *, headless: bool = False, no_sandbox: bool = False):
+        """Return an opened Selenium WebDriver."""
+        if self._session is None:
+            raise RuntimeError("Resource manager not initialized")
+        if self._driver is None:
+            self._driver = self._session.open(
+                self._app_config.url,
+                headless=headless,
+                no_sandbox=no_sandbox,
+            )
+        return self._driver

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -1,13 +1,11 @@
-import types
+import sys
 from pathlib import Path
 
-import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
-
-from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
-from sele_saisie_auto.logging_service import Logger
-from sele_saisie_auto.orchestration import AutomationOrchestrator
+from sele_saisie_auto.app_config import AppConfig, AppConfigRaw  # noqa: E402
+from sele_saisie_auto.logging_service import Logger  # noqa: E402
+from sele_saisie_auto.orchestration import AutomationOrchestrator  # noqa: E402
 
 
 class DummyBrowserSession:


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un gestionnaire `ResourceManager` centralisant l'accès aux identifiants chiffrés et au WebDriver. Le gestionnaire charge la configuration, ouvre les services nécessaires et garantit leur libération à la sortie du contexte.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact éventuel
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b6aebdc2483219cd465c7f89abaeb