### PR TITLE
[PageNavigator] Ajout d'un navigateur de pages

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -27,6 +27,7 @@ Ce fichier décrit le rôle des différents agents qui composent le projet. Pour
 | `LoginHandler`          | Gère la connexion utilisateur                  | `automation/login_handler.py`    | Driver, identifiants  | Aucune (session ouverte) |
 | `DateEntryPage`         | Gère la sélection de période                   | `automation/date_entry_page.py`  | Driver, date cible    | Période validée |
 | `AdditionalInfoPage`    | Remplit la fenêtre d'informations supplémentaires | `automation/additional_info_page.py` | Driver, config        | Données enregistrées |
+| `PageNavigator`         | Orchestration simple des pages                 | `navigation/page_navigator.py`       | Drivers, pages        | Actions séquencées |
 ## 4. Détails par agent
 
 ### `SeleniumFiller`

--- a/src/sele_saisie_auto/navigation/__init__.py
+++ b/src/sele_saisie_auto/navigation/__init__.py
@@ -1,0 +1,3 @@
+from .page_navigator import PageNavigator
+
+__all__ = ["PageNavigator"]

--- a/src/sele_saisie_auto/navigation/page_navigator.py
+++ b/src/sele_saisie_auto/navigation/page_navigator.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from sele_saisie_auto.automation import (
+    AdditionalInfoPage,
+    BrowserSession,
+    DateEntryPage,
+    LoginHandler,
+)
+from sele_saisie_auto.remplir_jours_feuille_de_temps import TimeSheetHelper
+
+
+class PageNavigator:
+    """Coordinate high level navigation between PSA Time pages."""
+
+    def __init__(
+        self,
+        browser_session: BrowserSession,
+        login_handler: LoginHandler,
+        date_entry_page: DateEntryPage,
+        additional_info_page: AdditionalInfoPage,
+        timesheet_helper: TimeSheetHelper,
+    ) -> None:
+        self.browser_session = browser_session
+        self.login_handler = login_handler
+        self.date_entry_page = date_entry_page
+        self.additional_info_page = additional_info_page
+        self.timesheet_helper = timesheet_helper
+
+    # ------------------------------------------------------------------
+    # Delegated actions
+    # ------------------------------------------------------------------
+    def login(
+        self,
+        driver,
+        aes_key: bytes,
+        encrypted_login: bytes,
+        encrypted_password: bytes,
+    ) -> None:
+        """Delegate user login to :class:`LoginHandler`."""
+        self.login_handler.connect_to_psatime(
+            driver, aes_key, encrypted_login, encrypted_password
+        )
+
+    def navigate_to_date_entry(self, driver, date_cible: str | None) -> None:
+        """Navigate to the date entry page and select the period."""
+        if self.date_entry_page.navigate_from_home_to_date_entry_page(driver):
+            self.date_entry_page.process_date(driver, date_cible)
+
+    def fill_timesheet(self, driver) -> None:
+        """Fill the timesheet and additional information."""
+        self.timesheet_helper.run(driver)
+        self.additional_info_page.navigate_from_work_schedule_to_additional_information_page(
+            driver
+        )
+        self.additional_info_page.submit_and_validate_additional_information(driver)
+        self.browser_session.go_to_default_content()
+
+    def submit_timesheet(self, driver) -> None:
+        """Save the draft and trigger validation."""
+        self.additional_info_page.save_draft_and_validate(driver)

--- a/tests/test_page_navigator.py
+++ b/tests/test_page_navigator.py
@@ -1,0 +1,100 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from sele_saisie_auto.navigation.page_navigator import PageNavigator  # noqa: E402
+
+
+class DummyLoginHandler:
+    def __init__(self):
+        self.calls = []
+
+    def connect_to_psatime(self, driver, key, login, pwd):
+        self.calls.append((driver, key, login, pwd))
+
+
+class DummyDatePage:
+    def __init__(self):
+        self.calls = []
+
+    def navigate_from_home_to_date_entry_page(self, driver):
+        self.calls.append("nav")
+        return True
+
+    def process_date(self, driver, date):
+        self.calls.append(("date", date))
+
+
+class DummyInfoPage:
+    def __init__(self):
+        self.calls = []
+
+    def navigate_from_work_schedule_to_additional_information_page(self, driver):
+        self.calls.append("nav_add")
+
+    def submit_and_validate_additional_information(self, driver):
+        self.calls.append("submit_add")
+
+    def save_draft_and_validate(self, driver):
+        self.calls.append("save")
+
+
+class DummyHelper:
+    def __init__(self):
+        self.calls = []
+
+    def run(self, driver):
+        self.calls.append(driver)
+
+
+class DummySession:
+    def __init__(self):
+        self.calls = []
+
+    def go_to_default_content(self):
+        self.calls.append("default")
+
+
+def make_navigator():
+    session = DummySession()
+    login = DummyLoginHandler()
+    date_page = DummyDatePage()
+    info_page = DummyInfoPage()
+    helper = DummyHelper()
+    return (
+        session,
+        login,
+        date_page,
+        info_page,
+        helper,
+        PageNavigator(session, login, date_page, info_page, helper),
+    )
+
+
+def test_login_delegates():
+    session, login, _, _, _, nav = make_navigator()
+    nav.login("drv", b"k", b"u", b"p")
+    assert login.calls == [("drv", b"k", b"u", b"p")]
+
+
+def test_navigate_to_date_entry():
+    _, _, date_page, _, _, nav = make_navigator()
+    nav.navigate_to_date_entry("drv", "2024")
+    assert "nav" in date_page.calls
+    assert ("date", "2024") in date_page.calls
+
+
+def test_fill_timesheet_calls_pages():
+    session, _, _, info_page, helper, nav = make_navigator()
+    nav.fill_timesheet("drv")
+    assert helper.calls == ["drv"]
+    assert "nav_add" in info_page.calls
+    assert "submit_add" in info_page.calls
+    assert "default" in session.calls
+
+
+def test_submit_timesheet():
+    _, _, _, info_page, _, nav = make_navigator()
+    nav.submit_timesheet("drv")
+    assert "save" in info_page.calls


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un nouvel agent `PageNavigator` permettant d'orchestrer la navigation entre les différentes pages Selenium. Ce composant simplifie l'enchainement des étapes (connexion, sélection de date, remplissage et soumission de la feuille de temps).

## Étapes pour tester
1. `poetry install --no-root`
2. `poetry run pre-commit run --all-files`
3. `poetry run pytest`
4. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

## Impact
Nouveau module utilisé pour piloter les pages existantes. Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b6deb60d88321a486404ecdc7ce12