### PR TITLE
[config] ajout service_configurator

### DIFF
--- a/src/sele_saisie_auto/configuration/__init__.py
+++ b/src/sele_saisie_auto/configuration/__init__.py
@@ -1,0 +1,3 @@
+from .service_configurator import Services, build_services
+
+__all__ = ["Services", "build_services"]

--- a/src/sele_saisie_auto/configuration/service_configurator.py
+++ b/src/sele_saisie_auto/configuration/service_configurator.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sele_saisie_auto.app_config import AppConfig
+from sele_saisie_auto.automation import BrowserSession
+from sele_saisie_auto.encryption_utils import EncryptionService
+from sele_saisie_auto.selenium_utils import Waiter
+
+
+@dataclass
+class Services:
+    """Bundle of commonly used automation services."""
+
+    encryption_service: EncryptionService
+    browser_session: BrowserSession
+    waiter: Waiter
+
+
+def build_services(app_config: AppConfig, log_file: str) -> Services:
+    """Create configured service instances from ``app_config``."""
+    waiter = Waiter(
+        default_timeout=app_config.default_timeout,
+        long_timeout=app_config.long_timeout,
+    )
+    browser_session = BrowserSession(log_file, app_config, waiter=waiter)
+    encryption_service = EncryptionService(log_file)
+    return Services(encryption_service, browser_session, waiter)

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,15 +32,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -40,9 +40,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
+    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_service_configurator.py
+++ b/tests/test_service_configurator.py
@@ -1,0 +1,18 @@
+from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
+from sele_saisie_auto.automation import BrowserSession
+from sele_saisie_auto.configuration import Services, build_services
+from sele_saisie_auto.encryption_utils import EncryptionService
+from sele_saisie_auto.selenium_utils import Waiter
+
+
+def test_build_services(sample_config):
+    app_cfg = AppConfig.from_raw(AppConfigRaw(sample_config))
+    services = build_services(app_cfg, "log.html")
+
+    assert isinstance(services, Services)
+    assert isinstance(services.encryption_service, EncryptionService)
+    assert isinstance(services.browser_session, BrowserSession)
+    assert isinstance(services.waiter, Waiter)
+    assert services.browser_session.app_config is app_cfg
+    assert services.browser_session.waiter is services.waiter
+


### PR DESCRIPTION
## Contexte
- ajout d'un configurateur de services pour générer `EncryptionService`, `BrowserSession` et `Waiter`
- tri des imports via `ruff`
- tests unitaires associés

## Impact
- création du package `configuration`
- ajustement mineur des imports existants

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b70d72c8883219edec275aa7e7dfc