### PR TITLE
[orchestration] ajoute context et choix_user

### DIFF
--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.automation import (
     AdditionalInfoPage,
@@ -13,6 +15,9 @@ from sele_saisie_auto.remplir_jours_feuille_de_temps import (
     context_from_app_config,
 )
 
+if TYPE_CHECKING:
+    from sele_saisie_auto.saisie_automatiser_psatime import SaisieContext
+
 
 class AutomationOrchestrator:
     """High level orchestrator composed of smaller automation services."""
@@ -25,6 +30,8 @@ class AutomationOrchestrator:
         login_handler: LoginHandler,
         date_entry_page: DateEntryPage,
         additional_info_page: AdditionalInfoPage,
+        context: "SaisieContext",
+        choix_user: bool = True,
         *,
         timesheet_helper_cls: type[TimeSheetHelper] = TimeSheetHelper,
     ) -> None:
@@ -34,6 +41,8 @@ class AutomationOrchestrator:
         self.login_handler = login_handler
         self.date_entry_page = date_entry_page
         self.additional_info_page = additional_info_page
+        self.context = context
+        self.choix_user = choix_user
         self.timesheet_helper_cls = timesheet_helper_cls
 
     def run(

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -44,9 +44,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -249,6 +249,8 @@ class PSATimeAutomation:
             self.login_handler,
             self.date_entry_page,
             self.additional_info_page,
+            self.context,
+            self.choix_user,
         )
 
         write_log(

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -6,6 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 from sele_saisie_auto.app_config import AppConfig, AppConfigRaw  # noqa: E402
 from sele_saisie_auto.logging_service import Logger  # noqa: E402
 from sele_saisie_auto.orchestration import AutomationOrchestrator  # noqa: E402
+from sele_saisie_auto.saisie_automatiser_psatime import SaisieContext  # noqa: E402
 
 
 class DummyBrowserSession:
@@ -84,6 +85,7 @@ def test_run_calls_services(sample_config):
     login = DummyLoginHandler()
     date_page = DummyDateEntryPage()
     add_page = DummyAddPage()
+    ctx = SaisieContext(app_cfg, None, None, {}, [])
 
     orch = AutomationOrchestrator(
         app_cfg,
@@ -92,6 +94,8 @@ def test_run_calls_services(sample_config):
         login,
         date_page,
         add_page,
+        ctx,
+        True,
         timesheet_helper_cls=DummyHelper,
     )
 


### PR DESCRIPTION
## Contexte
Ajout des paramètres `context` et `choix_user` au constructeur de `AutomationOrchestrator` pour préparer l'injection du contexte d'exécution. Les appels correspondants sont mis à jour dans `PSATimeAutomation` et dans les tests unitaires.

## Validation
- `pre-commit` sur les fichiers modifiés
- `pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b884f0e8083218ae805e3708b4057