### PR TITLE
[AutomationOrchestrator] copy shared mem initializer

### DIFF
--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING
 
 from selenium.webdriver.common.by import By
@@ -49,6 +50,22 @@ class AutomationOrchestrator:
         self.context = context
         self.choix_user = choix_user
         self.timesheet_helper_cls = timesheet_helper_cls
+
+    def initialize_shared_memory(self):
+        """Retrieve credentials from shared memory."""
+        credentials = self.context.encryption_service.retrieve_credentials()
+
+        if (
+            credentials.mem_login is None
+            or credentials.mem_password is None
+            or credentials.mem_key is None
+        ):
+            self.logger.error(
+                "🚨 La mémoire partagée n'a pas été initialisée correctement. Assurez-vous que les identifiants ont été chiffrés"
+            )
+            sys.exit(1)
+
+        return credentials
 
     # ------------------------------------------------------------------
     # DOM & iframe helpers


### PR DESCRIPTION
## Contexte et objectif
Ajout de la méthode `initialize_shared_memory` dans `automation_orchestrator.py` pour harmoniser la récupération des identifiants chiffrés en utilisant `self.context.encryption_service` et la journalisation via `self.logger`.

## Étapes pour tester
1. Vérifier le style et l'analyse statique :
   ```bash
   poetry run pre-commit run --files src/sele_saisie_auto/orchestration/automation_orchestrator.py
   ```
2. Lancer la suite de tests :
   ```bash
   poetry run pytest
   ```

## Impact éventuel
Cette méthode permet de centraliser la récupération des identifiants chiffrés dans l'orchestrateur.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b8e9d85dc83218bd5f06744b3e590