### PR TITLE
[orchestrator] Ajout du nettoyage de ressources

### DIFF
--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -131,3 +131,27 @@ class AutomationOrchestrator:
                 )
                 session.go_to_default_content()
                 self.additional_info_page.save_draft_and_validate(driver)
+
+    def cleanup_resources(
+        self,
+        memoire_cle,
+        memoire_nom,
+        memoire_mdp,
+    ) -> None:
+        """Ferme le navigateur et libère les mémoires partagées."""
+        if memoire_cle:
+            self.context.shared_memory_service.supprimer_memoire_partagee_securisee(
+                memoire_cle
+            )
+        if memoire_nom:
+            self.context.shared_memory_service.supprimer_memoire_partagee_securisee(
+                memoire_nom
+            )
+        if memoire_mdp:
+            self.context.shared_memory_service.supprimer_memoire_partagee_securisee(
+                memoire_mdp
+            )
+        self.browser_session.close()
+        self.logger.info(
+            "🏁 [FIN] Clé et données supprimées de manière sécurisée, des mémoires partagées du fichier automation_orchestrator."
+        )


### PR DESCRIPTION
## Contexte et objectif
Ajout d'une méthode `cleanup_resources` dans `AutomationOrchestrator` pour fermer correctement le navigateur et libérer la mémoire partagée.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing --cov-fail-under=0`

## Impact sur les autres agents
Aucun impact attendu; uniquement l'orchestrateur est modifié.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b90c4bf788321a56aaedd61f86c02