### PR TITLE
[AutomationOrchestrator] Ajout methode _process_date_entry

### DIFF
--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -96,6 +96,11 @@ class AutomationOrchestrator:
             raise NameError("main_target_win0 not found")
         return switched_to_iframe
 
+    def _process_date_entry(self, driver) -> None:
+        """Renseigne la date cible dans l'interface."""
+
+        self.date_entry_page.process_date(driver, self.config.date_cible)
+
     def run(
         self,
         aes_key: bytes,
@@ -116,7 +121,7 @@ class AutomationOrchestrator:
                 driver, aes_key, encrypted_login, encrypted_password
             )
             if self.date_entry_page.navigate_from_home_to_date_entry_page(driver):
-                self.date_entry_page.process_date(driver, self.config.date_cible)
+                self._process_date_entry(driver)
                 helper = self.timesheet_helper_cls(
                     context_from_app_config(self.config, self.logger.log_file),
                     self.logger,


### PR DESCRIPTION
## Contexte et objectif
Ajout de la méthode `_process_date_entry` dans `AutomationOrchestrator` afin de déléguer le traitement de la date cible via `self.date_entry_page`, comme réalisé dans `PSATimeAutomation`.

## Étapes pour tester
1. `poetry install`
2. `poetry run pre-commit run --files src/sele_saisie_auto/orchestration/automation_orchestrator.py`
3. `poetry run pytest`
4. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

## Impact éventuel
Aucun impact sur les autres agents attendu.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686b931fa4348321bd852b153466f8db