### PR TITLE
[docs] clarifie rôle AutomationOrchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Une interface graphique Tkinter permet de renseigner vos identifiants chiffrés 
   python -m sele_saisie_auto.launcher
   python -m sele_saisie_auto.saisie_automatiser_psatime
   python -m sele_saisie_auto.remplir_jours_feuille_de_temps
+> **Note :** la logique principale réside désormais dans ``AutomationOrchestrator.run()``. ``PSATimeAutomation.run()`` se contente de l'appeler.
   ```
 
 ## 🔌 Injection de dépendances

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -41,7 +41,16 @@ class PSATimeAutomation:
 - `submit_and_validate_additional_information(driver)` – remplit puis confirme les données complémentaires.
 - `save_draft_and_validate(driver)` – sauvegarde la feuille et déclenche la validation.
 - `cleanup_resources(driver_manager, mem_key, mem_login, mem_password)` – ferme le navigateur et libère la mémoire.
-- ``run() -> None`` – lance toute la séquence d’automatisation.
+- ``run() -> None`` – lance toute la séquence d’automatisation. Désormais, cette méthode délègue à ``AutomationOrchestrator.run()`` pour la logique principale.
+
+## AutomationOrchestrator
+
+```python
+class AutomationOrchestrator:
+    def run(self, *, headless=False, no_sandbox=False) -> None:
+        """Exécute l'automatisation complète."""
+```
+Classe centrale d'orchestration de l'automatisation. Sa méthode ``run()`` exécute désormais l'ensemble de la logique.
 
 ## TimeSheetHelper
 


### PR DESCRIPTION
## Contexte et objectif
- mise à jour de la référence API
- note sur le README au sujet de l'orchestrateur

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686babefcb64832187f22486c1688957