### PR TITLE
[alerts] ajout de handle_alerts

### DIFF
--- a/src/sele_saisie_auto/alerts/alert_handler.py
+++ b/src/sele_saisie_auto/alerts/alert_handler.py
@@ -91,3 +91,26 @@ class AlertHandler:
                     "INFO",
                 )
                 break
+
+    def handle_alerts(self, driver, alert_type: str = "save_alerts") -> None:
+        """General wrapper to dispatch alert handling.
+
+        Parameters
+        ----------
+        driver:
+            Selenium driver instance used for the interaction.
+        alert_type:
+            Type of alert to process. ``"save_alerts"`` (default) will
+            look for confirmation alerts after saving. ``"date_alert"``
+            will check for a conflict when submitting a date.
+        """
+
+        handlers = {
+            "save_alerts": self.handle_save_alerts,
+            "date_alert": self.handle_date_alert,
+        }
+
+        handler = handlers.get(alert_type)
+        if handler is None:
+            raise ValueError(f"Unknown alert_type: {alert_type}")
+        handler(driver)

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -38,9 +38,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_alert_handler.py
+++ b/tests/test_alert_handler.py
@@ -19,7 +19,7 @@ class DummyAutomation:
         pass
 
 
-def test_handle_save_alerts(monkeypatch):
+def test_handle_alerts_save(monkeypatch):
     dummy = DummyAutomation()
     handler = AlertHandler(dummy)
     seq = iter([True, False, False])
@@ -33,11 +33,11 @@ def test_handle_save_alerts(monkeypatch):
         "sele_saisie_auto.saisie_automatiser_psatime.write_log",
         lambda msg, f, level: logs.append(msg),
     )
-    handler.handle_save_alerts("drv")
+    handler.handle_alerts("drv")
     assert "click" in logs
 
 
-def test_handle_date_alert(monkeypatch):
+def test_handle_alerts_date(monkeypatch):
     dummy = DummyAutomation()
     handler = AlertHandler(dummy)
     monkeypatch.setattr(handler.waiter, "wait_for_element", lambda *a, **k: True)
@@ -50,4 +50,10 @@ def test_handle_date_alert(monkeypatch):
         lambda *a, **k: None,
     )
     with pytest.raises(SystemExit):
-        handler.handle_date_alert("drv")
+        handler.handle_alerts("drv", alert_type="date_alert")
+
+
+def test_handle_alerts_unknown(monkeypatch):
+    handler = AlertHandler(DummyAutomation())
+    with pytest.raises(ValueError):
+        handler.handle_alerts("drv", alert_type="unknown")


### PR DESCRIPTION
## Contexte
Ajout d'une méthode générique `handle_alerts` pour centraliser la gestion des différentes alertes.

## Étapes de test
- `poetry install`
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

## Impact
Aucun impact majeur sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686bc35585ec8321b33246b1b0cedd47