### PR TITLE
[AdditionalInfoPage] utilise handle_alerts

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -140,4 +140,4 @@ class AdditionalInfoPage:
     def _handle_save_alerts(self, driver) -> None:
         """Dismiss any alert shown after saving."""
 
-        self.alert_handler.handle_save_alerts(driver)
+        self.alert_handler.handle_alerts(driver, "save_alerts")

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,15 +32,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -38,9 +38,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
+    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_additional_info_page.py
+++ b/tests/test_additional_info_page.py
@@ -99,9 +99,9 @@ def test_handle_save_alerts(monkeypatch):
     page = AdditionalInfoPage(dummy)
     calls = []
 
-    def fake_handle(driver):
-        calls.append("handled")
+    def fake_handle(driver, alert_type="save_alerts"):
+        calls.append((driver, alert_type))
 
-    monkeypatch.setattr(page.alert_handler, "handle_save_alerts", fake_handle)
+    monkeypatch.setattr(page.alert_handler, "handle_alerts", fake_handle)
     page._handle_save_alerts("drv")
-    assert "handled" in calls
+    assert ("drv", "save_alerts") in calls

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -143,7 +143,9 @@ class DummyAdditionalInfoPage:
         self.calls = []
         sap.traiter_description = lambda *a, **k: None
         self.alert_handler = types.SimpleNamespace(
-            handle_save_alerts=lambda d: self.calls.append("alert")
+            handle_alerts=lambda d, alert_type="save_alerts": self.calls.append(
+                (d, alert_type)
+            )
         )
 
     def navigate_from_work_schedule_to_additional_information_page(self, driver):
@@ -159,7 +161,7 @@ class DummyAdditionalInfoPage:
         return True
 
     def _handle_save_alerts(self, driver):
-        self.alert_handler.handle_save_alerts(driver)
+        self.alert_handler.handle_alerts(driver, "save_alerts")
 
 
 def setup_init(monkeypatch, cfg):

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -201,12 +201,12 @@ def test_fill_and_save_timesheet(monkeypatch, sample_config):
     monkeypatch.setattr(
         auto, "save_draft_and_validate", lambda d: calls.append("save") or True
     )
-    auto.additional_info_page.alert_handler.handle_save_alerts = lambda d: calls.append(
-        "alert"
+    auto.additional_info_page.alert_handler.handle_alerts = (
+        lambda d, alert_type="save_alerts": calls.append((d, alert_type))
     )
     monkeypatch.setattr(sap, "detecter_doublons_jours", lambda d: calls.append("dup"))
     monkeypatch.setattr(sap.plugins, "call", lambda name, d: calls.append(name))
 
     auto._fill_and_save_timesheet("drv")
 
-    assert "alert" in calls
+    assert ("drv", "save_alerts") in calls


### PR DESCRIPTION
## Contexte et objectif
- simplifier la gestion des alertes dans `AdditionalInfoPage`
- ajuster les tests suite au nouvel appel d'`AlertHandler`

## Étapes pour tester
- `poetry install --no-root`
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686bce231260832180763521547d2295