### PR TITLE
[AdditionalInfoPage] appel AlertHandler

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -135,6 +135,7 @@ class AdditionalInfoPage:
                 driver, By.ID, Locators.SAVE_DRAFT_BUTTON.value
             )
             self.wait_for_dom(driver)
+            self._handle_save_alerts(driver)
         return element_present
 
     def _handle_save_alerts(self, driver) -> None:

--- a/tests/test_additional_info_page.py
+++ b/tests/test_additional_info_page.py
@@ -90,8 +90,15 @@ def test_save_draft_and_validate(monkeypatch):
         lambda *a, **k: clicks.append(True),
     )
     monkeypatch.setattr(AdditionalInfoPage, "wait_for_dom", lambda self, d: None)
+    calls = []
+    monkeypatch.setattr(
+        page.alert_handler,
+        "handle_alerts",
+        lambda d, alert_type="save_alerts": calls.append((d, alert_type)),
+    )
     assert page.save_draft_and_validate("drv") is True
     assert clicks
+    assert ("drv", "save_alerts") in calls
 
 
 def test_handle_save_alerts(monkeypatch):


### PR DESCRIPTION
## Contexte
Adaptation du test `test_additional_info_page.py` pour vérifier que l'appel à `AlertHandler` est bien déclenché à la sauvegarde. La méthode `save_draft_and_validate` déclenche désormais `_handle_save_alerts` après le clic sur "Sauvegarder".

## Impact
- Mise à jour du fichier `additional_info_page.py` pour appeler l'alerte.
- Mise à jour du test pour épingler cet appel.

## Tests
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686bd9a719c88321a18c9672b4e2a8b0