### PR TITLE
[element_id_builder] ajoute utilitaire pour ids

### DIFF
--- a/src/sele_saisie_auto/elements/element_id_builder.py
+++ b/src/sele_saisie_auto/elements/element_id_builder.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+"""Utilities for building Selenium element identifiers."""
+
+
+def build_day_input_id(base_id: str, day_index: int, row_index: int) -> str:
+    """Return the identifier for a day input field.
+
+    This helper handles specific patterns used in PSA Time where some day inputs
+    follow a different naming scheme. When ``base_id`` contains the substring
+    ``"UC_TIME_LIN_WRK_UC_DAILYREST"`` the index must be offset by ``10`` and
+    the row index is always ``0``.
+    """
+    if "UC_TIME_LIN_WRK_UC_DAILYREST" in base_id:
+        return f"{base_id}{10 + day_index}$0"
+    return f"{base_id}{day_index}${row_index}"

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 from sele_saisie_auto import messages
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.constants import JOURS_SEMAINE
+from sele_saisie_auto.elements.element_id_builder import build_day_input_id
 from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.logging_service import Logger
 from sele_saisie_auto.selenium_utils import (
@@ -30,13 +31,6 @@ if TYPE_CHECKING:  # pragma: no cover
 # ------------------------------------------------------------------------------------------- #
 
 
-def _build_input_id(id_value_days: str, idx: int, row_index: int) -> str:
-    """Construire l'identifiant complet d'un champ jour."""
-    if "UC_TIME_LIN_WRK_UC_DAILYREST" in id_value_days:
-        return f"{id_value_days}{10 + idx}$0"
-    return f"{id_value_days}{idx}${row_index}"
-
-
 def _get_element(driver, waiter: Waiter | None, input_id: str):
     """Récupérer l'élément correspondant à ``input_id``."""
     if waiter:
@@ -51,7 +45,7 @@ def _collect_filled_days(
     filled_days = []
     write_log(messages.CHECK_FILLED_DAYS, log_file, "DEBUG")
     for i in range(1, 8):
-        input_id = _build_input_id(id_value_days, i, row_index)
+        input_id = build_day_input_id(id_value_days, i, row_index)
         element = _get_element(driver, waiter, input_id)
         if element:
             jour = week_days[i]
@@ -93,7 +87,7 @@ def _fill_missing_days(
 ):
     """Complète les jours encore vides."""
     for i in range(1, 8):
-        input_id = _build_input_id(id_value_days, i, row_index)
+        input_id = build_day_input_id(id_value_days, i, row_index)
         element = _get_element(driver, waiter, input_id)
         if element:
             jour = week_days[i]

--- a/tests/test_element_id_builder.py
+++ b/tests/test_element_id_builder.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from sele_saisie_auto.elements.element_id_builder import (  # noqa: E402
+    build_day_input_id,
+)
+
+
+def test_default_pattern():
+    assert build_day_input_id("POL_TIME", 2, 5) == "POL_TIME2$5"
+
+
+def test_special_dailyrest_pattern():
+    base = "UC_TIME_LIN_WRK_UC_DAILYREST"
+    assert build_day_input_id(base, 1, 3) == f"{base}11$0"


### PR DESCRIPTION
## Contexte
- factorisation de la construction des identifiants de champs jour
- mise à jour de `remplir_informations_supp_utils` pour utiliser ce nouvel utilitaire
- ajout de tests dédiés

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/elements/element_id_builder.py src/sele_saisie_auto/remplir_informations_supp_utils.py tests/test_element_id_builder.py`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686be95641788321b75d6671c286b003