### PR TITLE
[ExtraInfoHelper] retire _build_input_id

### DIFF
--- a/src/sele_saisie_auto/elements/__init__.py
+++ b/src/sele_saisie_auto/elements/__init__.py
@@ -1,0 +1,5 @@
+"""Package exposing helpers for Selenium element IDs."""
+
+from .element_id_builder import ElementIdBuilder
+
+__all__ = ["ElementIdBuilder"]

--- a/src/sele_saisie_auto/elements/element_id_builder.py
+++ b/src/sele_saisie_auto/elements/element_id_builder.py
@@ -3,14 +3,26 @@ from __future__ import annotations
 """Utilities for building Selenium element identifiers."""
 
 
-def build_day_input_id(base_id: str, day_index: int, row_index: int) -> str:
-    """Return the identifier for a day input field.
+class ElementIdBuilder:
+    """Helpers to construct element identifiers used in PSA Time."""
 
-    This helper handles specific patterns used in PSA Time where some day inputs
-    follow a different naming scheme. When ``base_id`` contains the substring
-    ``"UC_TIME_LIN_WRK_UC_DAILYREST"`` the index must be offset by ``10`` and
-    the row index is always ``0``.
-    """
-    if "UC_TIME_LIN_WRK_UC_DAILYREST" in base_id:
-        return f"{base_id}{10 + day_index}$0"
-    return f"{base_id}{day_index}${row_index}"
+    @staticmethod
+    def build_day_input_id(base_id: str, day_index: int, row_index: int) -> str:
+        """Return the identifier for a day input field.
+
+        This helper handles specific patterns used in PSA Time where some day
+        inputs follow a different naming scheme. When ``base_id`` contains the
+        substring ``"UC_TIME_LIN_WRK_UC_DAILYREST"`` the index must be offset by
+        ``10`` and the row index is always ``0``.
+        """
+
+        if "UC_TIME_LIN_WRK_UC_DAILYREST" in base_id:
+            return f"{base_id}{10 + day_index}$0"
+        return f"{base_id}{day_index}${row_index}"
+
+
+def build_day_input_id(base_id: str, day_index: int, row_index: int) -> str:
+    """Backward compatible wrapper around
+    :meth:`ElementIdBuilder.build_day_input_id`."""
+
+    return ElementIdBuilder.build_day_input_id(base_id, day_index, row_index)

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.by import By
 from sele_saisie_auto import messages
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.constants import JOURS_SEMAINE
-from sele_saisie_auto.elements.element_id_builder import build_day_input_id
+from sele_saisie_auto.elements.element_id_builder import ElementIdBuilder
 from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.logging_service import Logger
 from sele_saisie_auto.selenium_utils import (
@@ -45,7 +45,7 @@ def _collect_filled_days(
     filled_days = []
     write_log(messages.CHECK_FILLED_DAYS, log_file, "DEBUG")
     for i in range(1, 8):
-        input_id = build_day_input_id(id_value_days, i, row_index)
+        input_id = ElementIdBuilder.build_day_input_id(id_value_days, i, row_index)
         element = _get_element(driver, waiter, input_id)
         if element:
             jour = week_days[i]
@@ -87,7 +87,7 @@ def _fill_missing_days(
 ):
     """Complète les jours encore vides."""
     for i in range(1, 8):
-        input_id = build_day_input_id(id_value_days, i, row_index)
+        input_id = ElementIdBuilder.build_day_input_id(id_value_days, i, row_index)
         element = _get_element(driver, waiter, input_id)
         if element:
             jour = week_days[i]

--- a/tests/test_element_id_builder.py
+++ b/tests/test_element_id_builder.py
@@ -3,15 +3,13 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from sele_saisie_auto.elements.element_id_builder import (  # noqa: E402
-    build_day_input_id,
-)
+from sele_saisie_auto.elements.element_id_builder import ElementIdBuilder  # noqa: E402
 
 
 def test_default_pattern():
-    assert build_day_input_id("POL_TIME", 2, 5) == "POL_TIME2$5"
+    assert ElementIdBuilder.build_day_input_id("POL_TIME", 2, 5) == "POL_TIME2$5"
 
 
 def test_special_dailyrest_pattern():
     base = "UC_TIME_LIN_WRK_UC_DAILYREST"
-    assert build_day_input_id(base, 1, 3) == f"{base}11$0"
+    assert ElementIdBuilder.build_day_input_id(base, 1, 3) == f"{base}11$0"


### PR DESCRIPTION
## Contexte
Le module `remplir_informations_supp_utils` possédait auparavant une fonction interne `_build_input_id`. Un utilitaire dédié `ElementIdBuilder` a été introduit pour centraliser la construction des identifiants. Cette PR met à jour l'utilisation et supprime la fonction obsolète.

## Changements apportés
- Création de `ElementIdBuilder` avec la méthode statique `build_day_input_id` et exposition dans `elements/__init__`
- Remplacement des appels dans `remplir_informations_supp_utils.py`
- Mise à jour du test associé

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run ruff check`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run bandit -r src/ -lll -iii`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686bed06851c8321bcb495c86bb4ceed