### PR TITLE
[ElementIdBuilder] couvre plus de motifs

### DIFF
--- a/tests/test_element_id_builder.py
+++ b/tests/test_element_id_builder.py
@@ -3,6 +3,9 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+from sele_saisie_auto.additional_info_locators import (  # noqa: E402
+    AdditionalInfoLocators,
+)
 from sele_saisie_auto.elements.element_id_builder import ElementIdBuilder  # noqa: E402
 
 
@@ -10,6 +13,16 @@ def test_default_pattern():
     assert ElementIdBuilder.build_day_input_id("POL_TIME", 2, 5) == "POL_TIME2$5"
 
 
+def test_uc_dailyrest_pattern():
+    base = AdditionalInfoLocators.DAY_UC_DAILYREST.value
+    assert ElementIdBuilder.build_day_input_id(base, 4, 2) == f"{base}4$2"
+
+
 def test_special_dailyrest_pattern():
-    base = "UC_TIME_LIN_WRK_UC_DAILYREST"
+    base = AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value
     assert ElementIdBuilder.build_day_input_id(base, 1, 3) == f"{base}11$0"
+
+
+def test_uc_location_a_pattern():
+    base = AdditionalInfoLocators.DAY_UC_LOCATION_A.value
+    assert ElementIdBuilder.build_day_input_id(base, 7, 1) == f"{base}7$1"


### PR DESCRIPTION
## Contexte
Ajout de tests unitaires pour vérifier `ElementIdBuilder.build_day_input_id` avec tous les préfixes définis dans `AdditionalInfoLocators` ainsi que le comportement par défaut.

## Test
- `poetry run pre-commit run --files tests/test_element_id_builder.py`
- `poetry run pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686bf1ca47b8832197ed1e5fd17d154d