### PR TITLE
[ExtraInfoHelper] Ajout de vérification des IDs générés

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,15 +32,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -38,9 +38,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
+    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_extra_info_helper.py
+++ b/tests/test_extra_info_helper.py
@@ -8,6 +8,7 @@ from sele_saisie_auto import remplir_informations_supp_utils as risu  # noqa: E4
 from sele_saisie_auto.additional_info_locators import (  # noqa: E402
     AdditionalInfoLocators,
 )
+from sele_saisie_auto.elements.element_id_builder import ElementIdBuilder  # noqa: E402
 from sele_saisie_auto.logging_service import Logger  # noqa: E402
 from sele_saisie_auto.remplir_informations_supp_utils import (  # noqa: E402
     ExtraInfoHelper,
@@ -55,7 +56,10 @@ def test_traiter_description_input(monkeypatch):
         def send_keys(self, val):
             self.value = val
 
+    ids = []
+
     def fake_wait(driver, by, ident, timeout):
+        ids.append(ident)
         return DummyElement()
 
     monkeypatch.setattr(risu, "wait_for_element", fake_wait)
@@ -70,6 +74,11 @@ def test_traiter_description_input(monkeypatch):
     helper = ExtraInfoHelper(Logger("log"))
     helper.waiter = None
     helper.traiter_description(None, make_config())
+
+    base = AdditionalInfoLocators.DAY_UC_DAILYREST.value
+    expected = [ElementIdBuilder.build_day_input_id(base, i, 2) for i in range(1, 8)]
+    for eid in expected:
+        assert ids.count(eid) == 2
 
     assert ("lundi", "val_lundi") in filled
     assert ("dimanche", "val_dimanche") not in filled
@@ -106,7 +115,11 @@ def test_traiter_description_select_special(monkeypatch):
     helper.waiter = None
     helper.traiter_description(None, cfg)
 
-    assert f"{cfg['id_value_jours']}11$0" in ids
+    base = AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value
+    expected = [ElementIdBuilder.build_day_input_id(base, i, 0) for i in range(1, 8)]
+    for eid in expected:
+        assert ids.count(eid) == 2
+
     assert selected
     assert any(messages.AUCUNE_VALEUR in m for m in logs)
     assert any(messages.IMPOSSIBLE_DE_TROUVER in m for m in logs)


### PR DESCRIPTION
## Contexte et objectif
Les tests de `ExtraInfoHelper` ne validaient pas que les identifiants des champs
sélectionnés étaient bien construits via `ElementIdBuilder`. Les nouvelles vérifications
s'assurent que les IDs transmis à Selenium correspondent à ceux générés par
`ElementIdBuilder`. Les imports ont été réordonnés automatiquement par `ruff`.

## Étapes pour tester
1. `poetry install`
2. `poetry run pre-commit run --all-files`
3. `poetry run ruff check && poetry run ruff check . --fix`
4. `poetry run radon cc src/ -s`
5. `poetry run radon mi src/`
6. `poetry run bandit -r src/ && poetry run bandit -r src/ -lll -iii`
7. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686bf4eeaa1c8321bc84119d220fa38a