### PR TITLE
[docs] ajout section ElementIdBuilder

### DIFF
--- a/docs/guides/advanced-testing.md
+++ b/docs/guides/advanced-testing.md
@@ -63,3 +63,17 @@ poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing
 ```
 
 Atteindre les branches difficiles demande de forcer les chemins rares : options invalides, exceptions volontairement déclenchées et scénarios de timeout. Les assertions de couverture indiquent quelles lignes restent à tester.
+
+## Centraliser la construction des ID
+
+Les pages PSA Time utilisent des identifiants de champs dont le patron varie en fonction du contexte. Pour éviter la duplication de chaînes dans les tests, le module `ElementIdBuilder` expose la méthode
+`build_day_input_id(base_id, day_index, row_index)`.
+
+```python
+from sele_saisie_auto.elements import ElementIdBuilder
+
+input_id = ElementIdBuilder.build_day_input_id("POL_TIME", 3, 0)
+```
+
+Cette fonction applique automatiquement les règles particulières comme l’offset
+des entrées "UC_TIME_LIN_WRK_UC_DAILYREST". Centraliser la construction des ID permet de maintenir un code de test plus lisible et plus robuste.


### PR DESCRIPTION
## Contexte
Ajout d'une section dans `docs/guides/advanced-testing.md` pour expliquer l'utilisation de `ElementIdBuilder` afin de centraliser la génération des identifiants Selenium.

## Étapes pour tester
1. `poetry install --no-root`
2. `poetry run pre-commit run --files docs/guides/advanced-testing.md`
3. `poetry run pytest`
4. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
5. `poetry run ruff check && poetry run ruff check . --fix`
6. `poetry run radon cc src/ -s && poetry run radon mi src/`
7. `poetry run bandit -r src/ && poetry run bandit -r src/ -lll -iii`

## Impact
Aucun impact sur les autres agents : documentation uniquement.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686c07e3f0a0832190076cad5310386b