### PR TITLE
[SeleniumUtils] gestion logger instance dans le décorateur

### DIFF
--- a/src/sele_saisie_auto/decorators/error_handling.py
+++ b/src/sele_saisie_auto/decorators/error_handling.py
@@ -36,7 +36,10 @@ def handle_selenium_errors(
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            log = logger or get_default_logger()
+            inst_logger = logger
+            if inst_logger is None and args:
+                inst_logger = getattr(args[0], "logger", None)
+            log = inst_logger or get_default_logger()
             try:
                 return func(*args, **kwargs)
             except NoSuchElementException as exc:

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/tests/test_handle_selenium_errors.py
+++ b/tests/test_handle_selenium_errors.py
@@ -3,12 +3,12 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
-from selenium.common.exceptions import (
+from selenium.common.exceptions import (  # noqa: E402
     NoSuchElementException,
     StaleElementReferenceException,
     TimeoutException,
     WebDriverException,
-)  # noqa: E402
+)
 
 from sele_saisie_auto.decorators import handle_selenium_errors  # noqa: E402
 from sele_saisie_auto.logging_service import Logger  # noqa: E402
@@ -70,3 +70,26 @@ def test_decorator_handles_other_exceptions(monkeypatch):
     assert raise_stale() is False
     assert raise_driver() is False
     assert len(calls) == 3
+
+
+def test_decorator_uses_instance_logger(monkeypatch):
+    records: list[str] = []
+
+    class DummyLogger(Logger):
+        def __init__(self) -> None:
+            super().__init__("log")
+
+        def error(self, message: str) -> None:  # type: ignore[override]
+            records.append(message)
+
+    class Dummy:
+        def __init__(self) -> None:
+            self.logger = DummyLogger()
+
+        @handle_selenium_errors(default_return="fallback")
+        def buggy(self):
+            raise NoSuchElementException("oops")
+
+    d = Dummy()
+    assert d.buggy() == "fallback"
+    assert any("introuvable" in m for m in records)


### PR DESCRIPTION
## Contexte
Le décorateur `handle_selenium_errors` devait écrire dans le logger fourni ou, à défaut, dans celui de l'instance appelante. Les tests couvraient uniquement l'utilisation d'un logger passé explicitement.

## Changements
- prise en compte du logger de l'instance dans `handle_selenium_errors`
- ajout d'un test vérifiant cette fonctionnalité
- mise à jour automatique de l'import dans `remplir_jours_feuille_de_temps.py` (isort)

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686c2e89bc888321a5c7ec14237d3cfb