### PR TITLE
[tests] couverture du décorateur d'erreurs

### DIFF
--- a/tests/test_error_handling_decorator.py
+++ b/tests/test_error_handling_decorator.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from selenium.common.exceptions import (  # noqa: E402
+    NoSuchElementException,
+    StaleElementReferenceException,
+)
+
+from sele_saisie_auto import messages  # noqa: E402
+from sele_saisie_auto.decorators import handle_selenium_errors  # noqa: E402
+
+
+def test_logs_no_such_element_and_returns_fallback(dummy_logger):
+    @handle_selenium_errors(logger=dummy_logger, default_return="fallback")
+    def failing():
+        raise NoSuchElementException("missing")
+
+    assert failing() == "fallback"
+    assert any(messages.INTROUVABLE in msg for msg in dummy_logger.records["error"])
+
+
+def test_logs_stale_reference_and_returns_fallback(dummy_logger):
+    @handle_selenium_errors(logger=dummy_logger, default_return=42)
+    def failing():
+        raise StaleElementReferenceException("stale")
+
+    assert failing() == 42
+    assert any(
+        messages.REFERENCE_OBSOLETE in msg for msg in dummy_logger.records["error"]
+    )


### PR DESCRIPTION
## Contexte
Ajout d'un test dédié pour vérifier que le décorateur `handle_selenium_errors` logue correctement les exceptions `NoSuchElementException` et `StaleElementReferenceException` tout en renvoyant la valeur de secours.

## Étapes de test
1. `poetry install --no-root`
2. `poetry run pre-commit run --files tests/test_error_handling_decorator.py`
3. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686c32fee2e483218d505837721ae8a1