### PR TITLE
[docs] mention du décorateur handle_selenium_errors

### DIFF
--- a/docs/guides/logging-and-errors.md
+++ b/docs/guides/logging-and-errors.md
@@ -54,6 +54,19 @@ except (DriverError, InvalidConfigError) as exc:
     logger.error("operation failed: %s", exc)
 ```
 
+## Décorateur `handle_selenium_errors`
+
+Ce décorateur capture les exceptions Selenium courantes et écrit un message
+dans le journal. Il renvoie la valeur indiquée par `default_return` lorsqu'une
+erreur est interceptée. Le logger passé en argument est utilisé ; à défaut, le
+logger de l'instance ou celui par défaut est choisi.
+
+```python
+@handle_selenium_errors(default_return=False)
+def cliquer_bouton(driver):
+    driver.find_element(...).click()
+```
+
 ## Fichier de log
 Les messages sont enregistres dans le dossier `logs/` sous forme de fichier HTML. Chaque execution ajoute de nouvelles entrees au meme fichier afin de conserver l'historique complet.
 


### PR DESCRIPTION
## Contexte
Ajout d'une précision dans la documentation sur la journalisation et la gestion des erreurs.

## Modifications
- ajout d'un paragraphe décrivant l'usage du décorateur `handle_selenium_errors` dans `logging-and-errors.md`.

## Test
- `poetry run pre-commit run --files docs/guides/logging-and-errors.md`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686c3fe549f48321a3b09b9d40e69001