### PR TITLE
[docs] exemple handle_selenium_errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ Certaines fonctions acceptent les modules Selenium ou Logger en paramètres pour
 ## ❗ Gestion des erreurs
 Les exceptions sont journalisées via `logger_utils.py`. Reportez-vous à la documentation interne pour enrichir le mécanisme.
 
+Voici comment décorer une fonction Selenium avec `handle_selenium_errors` :
+
+```python
+from sele_saisie_auto.decorators import handle_selenium_errors
+
+@handle_selenium_errors(default_return=False)
+def cliquer_bouton(driver):
+    driver.find_element(...).click()
+```
+
 ## 📝 Formats d'entrée
 Les paramètres sont lus depuis `config.ini` (login, mot de passe chiffré, planning, etc.).
 


### PR DESCRIPTION
## Contexte
Ajout d'un exemple dans la documentation pour illustrer l'usage du décorateur `handle_selenium_errors`.

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run bandit -r src/ -lll -iii`

Aucun impact fonctionnel sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686c47be645083218d9cdfacb1624088