### PR TITLE
[description_processor] simplifie les boucles

### DIFF
--- a/tests/test_description_processor.py
+++ b/tests/test_description_processor.py
@@ -58,3 +58,33 @@ def test_fill_days_integration(monkeypatch):
     cfg = CFG | {"valeurs_a_remplir": {"lundi": "1"}}
     dp.process_description(None, cfg, "log", filling_context=ctx)
     assert "1" in sequence
+
+
+def test_collect_filled_days_no_elements(monkeypatch):
+    monkeypatch.setattr(dp, "_get_element", lambda *a, **k: None)
+    result = dp._collect_filled_days(None, None, "days", 0, "log")
+    assert result == []
+
+
+def test_fill_days_skips(monkeypatch):
+    called = []
+
+    class DummyElement:
+        pass
+
+    monkeypatch.setattr(dp, "_get_element", lambda *a, **k: DummyElement())
+    ctx = ElementFillingContext(InputFillingStrategy())
+    monkeypatch.setattr(ctx, "fill", lambda *a, **k: called.append("filled"))
+
+    dp._fill_days(
+        None,
+        None,
+        "days",
+        0,
+        {"mardi": "1"},
+        ["lundi"],
+        "input",
+        "log",
+        filling_context=ctx,
+    )
+    assert called == ["filled"]


### PR DESCRIPTION
## Contexte et objectif
Simplification de `description_processor` pour alléger l'imbrication dans `_collect_filled_days` et `_fill_days`. Les boucles utilisent désormais des retours anticipés (`continue`).

## Étapes pour tester
1. `poetry install --no-root`
2. `poetry run pre-commit run --files src/sele_saisie_auto/form_processing/description_processor.py tests/test_description_processor.py`
3. `poetry run ruff check src/sele_saisie_auto/form_processing/description_processor.py tests/test_description_processor.py`
4. `poetry run radon cc src/sele_saisie_auto/form_processing/description_processor.py -s`
5. `poetry run bandit -r src/sele_saisie_auto/form_processing/description_processor.py`
6. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing --cov-fail-under=0`

## Impact
Pas d’impact attendu sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686cbb3307bc8321bf14722f0401ce42