### PR TITLE
[docs] Chaîne ExtraInfoHelper

### DIFF
--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -20,3 +20,17 @@ poetry run psatime-launcher
 ```
 
 Pour aller plus loin, référez-vous à [../guides/installation.md](../guides/installation.md) et [../index.md](../index.md).
+
+## Chaîne ExtraInfoHelper -> DescriptionProcessor -> ElementFillingStrategy
+
+Lorsque les informations supplémentaires sont saisies, `ExtraInfoHelper`
+appelle `process_description` du module `DescriptionProcessor`.
+Chaque champ est alors rempli via un `ElementFillingStrategy` adapté
+(`InputFillingStrategy` ou `SelectFillingStrategy`).
+
+```mermaid
+flowchart LR
+    ExtraInfoHelper --> DescriptionProcessor
+    DescriptionProcessor --> ElementFillingStrategy
+```
+


### PR DESCRIPTION
## Contexte
Ajout d'une section dans la documentation d'aperçu pour décrire la chaîne d'appel `ExtraInfoHelper -> DescriptionProcessor -> ElementFillingStrategy`.

## Étapes pour tester
1. Générer la documentation ou ouvrir `docs/overview/overview.md`.
2. Vérifier l'apparition du nouveau paragraphe avec le diagramme Mermaid.

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686cbf411c988321915071bf22a2f68f