### PR TITLE
[ExtraInfoHelper] Retrait des pragmas no cover

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -15,7 +15,7 @@ from sele_saisie_auto.remplir_informations_supp_utils import ExtraInfoHelper
 from sele_saisie_auto.selenium_utils import Waiter, wait_for_dom_after
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from sele_saisie_auto.saisie_automatiser_psatime import PSATimeAutomation
 
 
@@ -24,7 +24,7 @@ class AdditionalInfoPage:
 
     def __init__(
         self, automation: PSATimeAutomation, waiter: Waiter | None = None
-    ) -> None:  # pragma: no cover - simple wiring
+    ) -> None:
         self._automation = automation
         ctx = getattr(self._automation, "context", None)
         cfg = getattr(ctx, "config", None)
@@ -45,14 +45,14 @@ class AdditionalInfoPage:
         return self._automation.log_file
 
     @property
-    def config(self) -> AppConfig:  # pragma: no cover - accessor
+    def config(self) -> AppConfig:
         ctx = getattr(self._automation, "context", None)
         cfg = getattr(ctx, "config", None)
         if cfg is None or not hasattr(cfg, "default_timeout"):
             return SimpleNamespace(
                 default_timeout=DEFAULT_TIMEOUT,
                 long_timeout=LONG_TIMEOUT,
-            )  # pragma: no cover - fallback
+            )
         return cfg
 
     # ------------------------------------------------------------------

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -15,7 +15,7 @@ from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 # remplir_informations_supp_france.py
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from sele_saisie_auto.automation.additional_info_page import AdditionalInfoPage
 
 

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -39,9 +39,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time


### PR DESCRIPTION
## Contexte et objectif
Les tests couvrent désormais les anciennes fonctions de saisie des descriptions. Les directives `# pragma: no cover` pour ces parties deviennent inutiles.

## Étapes pour tester
1. `poetry install`
2. `poetry run pre-commit run --all-files`
3. `poetry run pytest`
4. `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing --cov-fail-under=0`

## Impact éventuel
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686cc6f55a34832198582e7f41a94398