### PR TITLE
[selenium_utils] ajout d'une Waiter factory

### DIFF
--- a/src/sele_saisie_auto/selenium_utils/__init__.py
+++ b/src/sele_saisie_auto/selenium_utils/__init__.py
@@ -68,6 +68,7 @@ from .wait_helpers import (
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from .waiter_factory import get_waiter
 from .wrapper import Wrapper, is_document_complete
 
 __all__ = [
@@ -86,6 +87,7 @@ __all__ = [
     "find_present",
     "Wrapper",
     "Waiter",
+    "get_waiter",
     "modifier_date_input",
     "switch_to_frame_by_id",
     "switch_to_iframe_by_id_or_name",

--- a/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
+++ b/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
@@ -13,9 +13,6 @@ from . import get_default_logger
 # pragma: no cover
 
 
-
-
-
 class DuplicateDayDetector:
     """Detect if a weekday is filled on multiple lines of the time sheet."""
 

--- a/src/sele_saisie_auto/selenium_utils/waiter_factory.py
+++ b/src/sele_saisie_auto/selenium_utils/waiter_factory.py
@@ -1,0 +1,16 @@
+"""Factory to create configured :class:`Waiter` instances."""
+
+from __future__ import annotations
+
+from sele_saisie_auto.app_config import AppConfig
+from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
+
+
+def get_waiter(app_config: AppConfig | None) -> Waiter:
+    """Return a :class:`Waiter` configured with ``app_config`` timeouts."""
+    if app_config is None:
+        return Waiter()
+    return Waiter(
+        default_timeout=app_config.default_timeout,
+        long_timeout=app_config.long_timeout,
+    )

--- a/tests/test_waiter_factory.py
+++ b/tests/test_waiter_factory.py
@@ -1,0 +1,12 @@
+from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
+from sele_saisie_auto.selenium_utils import Waiter
+from sele_saisie_auto.selenium_utils.waiter_factory import get_waiter
+
+
+def test_get_waiter_returns_configured_waiter(sample_config):
+    cfg = AppConfig.from_raw(AppConfigRaw(sample_config))
+    waiter = get_waiter(cfg)
+
+    assert isinstance(waiter, Waiter)
+    assert waiter.wrapper.default_timeout == cfg.default_timeout
+    assert waiter.wrapper.long_timeout == cfg.long_timeout


### PR DESCRIPTION
## Contexte
Création d'un module dédié pour instancier un `Waiter` configuré à partir de `AppConfig`. Cela simplifie l'initialisation des délais d’attente selon la configuration fournie.

## Impact
- Nouveau fichier `waiter_factory.py` avec la fonction `get_waiter`.
- Export de `get_waiter` dans `selenium_utils.__init__`.
- Tests unitaires ajoutés.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686cd3d0cf708321a711103fb07707b5