### PR TITLE
[selenium_utils] migration vers WaiterFactory

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 
+import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory
 from sele_saisie_auto.alerts import AlertHandler
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.decorators import handle_selenium_errors
@@ -28,7 +29,13 @@ class AdditionalInfoPage:
         self._automation = automation
         ctx = getattr(self._automation, "context", None)
         cfg = getattr(ctx, "config", None)
-        self.waiter = waiter or getattr(automation, "waiter", None) or Waiter()
+        self.waiter = (
+            waiter
+            or getattr(automation, "waiter", None)
+            or WaiterFactory.get_waiter(
+                cfg if hasattr(cfg, "default_timeout") else None
+            )
+        )
         self.alert_handler = AlertHandler(automation, waiter=self.waiter)
         self.helper = ExtraInfoHelper(
             logger=self._automation.logger,

--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
+import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.logger_utils import format_message, write_log
@@ -82,9 +83,7 @@ class BrowserSession:
         self.log_file = log_file
         self.app_config = app_config
         if waiter is None:
-            timeout = app_config.default_timeout if app_config else DEFAULT_TIMEOUT
-            long_timeout = app_config.long_timeout if app_config else LONG_TIMEOUT
-            self.waiter = Waiter(default_timeout=timeout, long_timeout=long_timeout)
+            self.waiter = WaiterFactory.get_waiter(app_config)
         else:
             self.waiter = waiter
         if app_config is not None:

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as ec
 
+import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory
 from sele_saisie_auto import messages
 from sele_saisie_auto.alerts import AlertHandler
 from sele_saisie_auto.app_config import AppConfig
@@ -28,7 +29,11 @@ class DateEntryPage:
         self, automation: PSATimeAutomation, waiter: Waiter | None = None
     ) -> None:
         self._automation = automation
-        self.waiter = waiter or getattr(automation, "waiter", None) or Waiter()
+        self.waiter = (
+            waiter
+            or getattr(automation, "waiter", None)
+            or WaiterFactory.get_waiter(self.config)
+        )
         self.alert_handler = AlertHandler(automation, waiter=self.waiter)
 
     @property

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.form_processing.description_processor import process_description
 from sele_saisie_auto.logging_service import Logger
@@ -11,7 +12,6 @@ from sele_saisie_auto.strategies import (
     InputFillingStrategy,
     SelectFillingStrategy,
 )
-from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 # remplir_informations_supp_france.py
 
@@ -65,9 +65,7 @@ class ExtraInfoHelper:
     ) -> None:
         """Initialise l'assistant avec ``Logger`` et ``Waiter``."""
         if waiter is None:
-            timeout = app_config.default_timeout if app_config else DEFAULT_TIMEOUT
-            long_timeout = app_config.long_timeout if app_config else LONG_TIMEOUT
-            self.waiter = Waiter(default_timeout=timeout, long_timeout=long_timeout)
+            self.waiter = WaiterFactory.get_waiter(app_config)
         else:
             self.waiter = waiter
         self.page = page

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -11,6 +11,7 @@ from multiprocessing import shared_memory
 
 from selenium.webdriver.common.by import By
 
+import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory
 from sele_saisie_auto import (
     console_ui,
     messages,
@@ -126,9 +127,7 @@ class PSATimeAutomation:
         set_log_file_selenium(log_file)
         initialize_logger(app_config.raw, log_level_override=app_config.debug_mode)
         self.logger = logger or get_logger(log_file)
-        self.waiter = waiter or Waiter(
-            app_config.default_timeout, app_config.long_timeout
-        )
+        self.waiter = waiter or WaiterFactory.get_waiter(app_config)
         self.shared_memory_service = shared_memory_service or SharedMemoryService(
             self.logger
         )


### PR DESCRIPTION
## Contexte
Remplacement des instanciations directes de `Waiter()` dans plusieurs modules pour utiliser la fabrique `WaiterFactory.get_waiter(app_config)` ajoutée récemment.

## Modifications
- ajout de l'import du module `waiter_factory` dans les fichiers concernés
- instanciation du `Waiter` via `WaiterFactory.get_waiter`

## Tests
- `poetry run pre-commit run --files src/sele_saisie_auto/automation/browser_session.py src/sele_saisie_auto/automation/date_entry_page.py src/sele_saisie_auto/automation/additional_info_page.py src/sele_saisie_auto/remplir_informations_supp_utils.py src/sele_saisie_auto/saisie_automatiser_psatime.py`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686cded71b6483219eac91f85255594c