### PR TITLE
[BrowserSession] assure delegation to driver manager

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -40,9 +40,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_browser_session.py
+++ b/tests/test_browser_session.py
@@ -35,6 +35,7 @@ def test_open_delegates_to_manager(monkeypatch):
     assert driver == "driver"  # nosec B101
     assert session.driver == "driver"  # nosec B101
     assert calls["args"] == ("http://t", True, True, False)  # nosec B101
+    assert calls["init"] == "log.html"  # nosec B101
 
 
 def test_close_calls_manager(monkeypatch):


### PR DESCRIPTION
## Contexte
Ajout d'un test pour vérifier que `BrowserSession` transmet bien le fichier de log au `SeleniumDriverManager` lors de l'ouverture du navigateur. Les imports ont été réordonnés par *isort* suite au passage de `pre-commit`.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d03f7006c8321954d89120ca9ca98