### PR TITLE
[Configuration] Documente build_services et applique isort

### DIFF
--- a/src/sele_saisie_auto/configuration/service_configurator.py
+++ b/src/sele_saisie_auto/configuration/service_configurator.py
@@ -18,7 +18,27 @@ class Services:
 
 
 def build_services(app_config: AppConfig, log_file: str) -> Services:
-    """Create configured service instances from ``app_config``."""
+    """Instancier et retourner les services principaux de l'application.
+
+    Ce constructeur configure un :class:`Waiter` selon les valeurs fournies
+    par ``app_config`` puis initialise ``BrowserSession`` et
+    ``EncryptionService`` avec le même fichier de log. Les instances sont
+    renvoyées regroupées dans la dataclass :class:`Services` afin de partager
+    facilement ces outils entre les différentes étapes de l'automatisation.
+
+    Parameters
+    ----------
+    app_config : AppConfig
+        Configuration de l'application utilisée pour paramétrer les services.
+    log_file : str
+        Chemin vers le fichier de log commun aux services.
+
+    Returns
+    -------
+    Services
+        Objet regroupant ``encryption_service``, ``browser_session`` et
+        ``waiter`` prêt à être utilisé.
+    """
     waiter = Waiter(
         default_timeout=app_config.default_timeout,
         long_timeout=app_config.long_timeout,

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -40,9 +40,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time


### PR DESCRIPTION
## Contexte et objectif
- la fonction `build_services` manquait d'explications sur le rôle des services créés
- passage d'isort via le hook pre-commit a réordonné certains imports

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact
- aucun impact fonctionnel, documentation améliorée

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d224895108321bfc538afdd0a0f4a