### PR TITLE
[ResourceManager] Ajout d'une méthode de fermeture explicite

### DIFF
--- a/src/sele_saisie_auto/resources/resource_manager.py
+++ b/src/sele_saisie_auto/resources/resource_manager.py
@@ -52,6 +52,11 @@ class ResourceManager:
         self._driver = None
         self._session = None
 
+    def close(self) -> None:
+        """Ferme explicitement les ressources en appelant ``__exit__``."""
+
+        self.__exit__(None, None, None)
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -133,3 +133,25 @@ def test_resource_manager_cleanup(monkeypatch):
     creds.mem_key.close()
     creds.mem_login.close()
     creds.mem_password.close()
+
+
+def test_resource_manager_close_method(monkeypatch):
+    sessions = []
+
+    class SpyBrowserSession(DummyBrowserSession):
+        def __init__(self, log_file, app_config):
+            super().__init__(log_file, app_config)
+            sessions.append(self)
+
+    monkeypatch.setattr(resource_manager, "ConfigManager", DummyConfigManager)
+    monkeypatch.setattr(resource_manager, "BrowserSession", SpyBrowserSession)
+    monkeypatch.setattr(resource_manager, "EncryptionService", DummyEncryption)
+
+    rm = resource_manager.ResourceManager("log.html")
+    rm.__enter__()
+    rm.get_driver()
+    rm.close()
+
+    assert sessions[0].closed is True
+    assert rm._session is None
+    assert rm._driver is None


### PR DESCRIPTION
## Contexte
Ajout d'une méthode `close()` dans `ResourceManager` afin de permettre la libération explicite des ressources sans passer par un contexte `with`.

## Notes de test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d34911f248321b7adbc7db6d11f1e