### PR TITLE
[AutomationOrchestrator] injection point for cleanup

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -40,7 +40,8 @@ class PSATimeAutomation:
 - `navigate_from_work_schedule_to_additional_information_page(driver)` – accède aux informations supplémentaires.
 - `submit_and_validate_additional_information(driver)` – remplit puis confirme les données complémentaires.
 - `save_draft_and_validate(driver)` – sauvegarde la feuille et déclenche la validation.
-- `cleanup_resources(driver_manager, mem_key, mem_login, mem_password)` – ferme le navigateur et libère la mémoire.
+- `cleanup_resources(mem_key, mem_login, mem_password)` – fonction injectable pour fermer le navigateur et libérer la mémoire.
+- *Cette propriété peut être redéfinie pour personnaliser la stratégie de nettoyage.*
 - ``run() -> None`` – lance toute la séquence d’automatisation. Désormais, cette méthode délègue à ``AutomationOrchestrator.run()`` pour la logique principale.
 
 ## AutomationOrchestrator

--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -70,6 +70,7 @@ class AutomationOrchestrator:
         choix_user: bool = True,
         *,
         timesheet_helper_cls: type[TimeSheetHelper] = TimeSheetHelper,
+        cleanup_resources=None,
     ) -> None:
         self.config = config
         self.logger = logger
@@ -80,6 +81,11 @@ class AutomationOrchestrator:
         self.context = context
         self.choix_user = choix_user
         self.timesheet_helper_cls = timesheet_helper_cls
+        self.cleanup_resources = (
+            cleanup_resources
+            if cleanup_resources is not None
+            else self._default_cleanup_resources
+        )
 
     def initialize_shared_memory(self):  # pragma: no cover - tested elsewhere
         """Retrieve credentials from shared memory."""
@@ -290,7 +296,7 @@ class AutomationOrchestrator:
                         credentials.mem_password,
                     )
 
-    def cleanup_resources(
+    def _default_cleanup_resources(
         self,
         memoire_cle,
         memoire_nom,


### PR DESCRIPTION
## Contexte
Ajout d'une propriété `cleanup_resources` dans `AutomationOrchestrator` afin de pouvoir injecter une fonction de nettoyage personnalisée. La méthode de nettoyage existante est déplacée en méthode privée et utilisée par défaut.

## Modifications principales
- paramètre optionnel `cleanup_resources` dans le constructeur
- nouvelle méthode privée `_default_cleanup_resources`
- mise à jour de la documentation API

## Tests
- `pre-commit` sur les fichiers modifiés
- `pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d448a98fc8321b835250d3d3b7a48