### PR TITLE
[PSATimeAutomation] Orchestrator handles browser lifecycle

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -38,9 +38,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -534,11 +534,6 @@ class PSATimeAutomation:
             self.context,
             self.logger,
             choix_user=self.choix_user,
-        )
-        self.orchestrator.cleanup_resources = (
-            lambda mkey, mlogin, mpwd: self.cleanup_resources(
-                self.orchestrator.browser_session, mkey, mlogin, mpwd
-            )
         )
         self.orchestrator.run(headless=headless, no_sandbox=no_sandbox)
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -113,14 +113,14 @@ def test_run_invokes_hook(monkeypatch, sample_config):
 
     monkeypatch.setattr(sap.PSATimeAutomation, "save_draft_and_validate", fake_save)
     monkeypatch.setattr(
-        sap.PSATimeAutomation,
-        "cleanup_resources",
-        lambda self, *a, **k: calls.append("cleanup"),
+        sap.BrowserSession,
+        "close",
+        lambda self: calls.append("close"),
     )
 
     sap.main("log.html")
 
-    assert "cleanup" in calls
+    assert "close" in calls
 
 
 def test_hook_decorator_registers():

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -329,11 +329,11 @@ def test_main_flow(monkeypatch, sample_config):
     monkeypatch.setattr(sap, "traiter_description", lambda *a, **k: None)
     monkeypatch.setattr(sap, "detecter_doublons_jours", lambda *a, **k: None)
     monkeypatch.setattr(sap, "sys", types.SimpleNamespace(exit=lambda: None))
-    cleanup_called = {}
+    close_called = {}
     monkeypatch.setattr(
-        sap.PSATimeAutomation,
-        "cleanup_resources",
-        lambda self, *a, **k: cleanup_called.setdefault("done", True),
+        sap.BrowserSession,
+        "close",
+        lambda self: close_called.setdefault("done", True),
     )
     monkeypatch.setattr(sap, "seprateur_menu_affichage_console", lambda: None)
     monkeypatch.setattr(console_ui, "ask_continue", lambda *a, **k: None)
@@ -341,7 +341,7 @@ def test_main_flow(monkeypatch, sample_config):
 
     sap.main("log.html")
 
-    assert cleanup_called["done"] is True
+    assert close_called["done"] is True
 
 
 def test_run_delegates_to_orchestrator(monkeypatch, sample_config):

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -261,9 +261,9 @@ def test_main_exceptions(monkeypatch, sample_config):
     )
     cleanup = {}
     monkeypatch.setattr(
-        sap.PSATimeAutomation,
-        "cleanup_resources",
-        lambda self, *a, **k: cleanup.setdefault("done", True),
+        sap.BrowserSession,
+        "close",
+        lambda self: cleanup.setdefault("done", True),
     )
     for exc in EXCEPTIONS:
         monkeypatch.setattr(


### PR DESCRIPTION
## Contexte et objectif
Le pilote d'automatisation gérait encore l’ouverture et la fermeture du navigateur dans `PSATimeAutomation.run`. Ces opérations sont désormais assurées par l’orchestrateur. La méthode `run` se contente d’instancier l’orchestrateur et de lui déléguer l’exécution.

Les tests vérifiaient l’appel de `cleanup_resources`. Ils suivent maintenant la fermeture du navigateur via `BrowserSession.close`.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d653290108321b703c4ec18f4c8eb