### PR TITLE
[AutomationOrchestrator] Adapt wrappers to orchestrator

### DIFF
--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -132,7 +132,9 @@ def test_switch_to_iframe(monkeypatch):
         lambda *a, **k: calls.append("sw") or True,
     )
     monkeypatch.setattr(
-        sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: calls.append("dom")
+        sap._ORCHESTRATOR,
+        "wait_for_dom",
+        lambda *a, **k: calls.append("dom"),
     )
     assert sap.switch_to_iframe_main_target_win0("drv") is True
     assert "sw" in calls
@@ -198,6 +200,7 @@ def test_cleanup_resources(monkeypatch):
     sap.context.encryption_service = enc
     shm_service = DummySHMService()
     sap.context.shared_memory_service = shm_service
+    sap._ORCHESTRATOR.browser_session = manager
     sap.cleanup_resources(manager, "c", "n", "p")
     assert shm_service.removed == ["c", "n", "p"]
     assert "close" in called

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -182,5 +182,6 @@ def test_cleanup_resources_none(monkeypatch):
     monkeypatch.setattr(sap, "write_log", lambda *a, **k: None)
     sap.context.encryption_service = DummyManager()
     sap.context.shared_memory_service = DummySHMService()
+    sap._ORCHESTRATOR.browser_session = mgr
     sap.cleanup_resources(mgr, None, None, None)
     assert mgr.closed is True

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -164,6 +164,7 @@ def test_cleanup_resources_calls():
     sap.context.encryption_service = enc
     shm_service = DummySHMService()
     sap.context.shared_memory_service = shm_service
+    sap._ORCHESTRATOR.browser_session = manager
     sap.cleanup_resources(manager, "c", "n", None)
     assert shm_service.removed == ["c", "n"]
     assert manager.driver is None


### PR DESCRIPTION
## Contexte et objectif
- mise à jour des wrappers dans `saisie_automatiser_psatime.py`
- intégration directe de `AutomationOrchestrator` lors de l'initialisation
- ajustement des tests pour refléter la nouvelle architecture

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest -q`

## Impact éventuel
- les appels de wrappers utilisent désormais l'orchestrateur

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d6c800b3c832185a29c0e9c93cf8e