### PR TITLE
[Automation] add full automation flow test

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,13 +32,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -38,9 +38,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time

--- a/tests/test_full_automation.py
+++ b/tests/test_full_automation.py
@@ -1,0 +1,174 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
+
+from sele_saisie_auto.app_config import AppConfig, AppConfigRaw  # noqa: E402
+from sele_saisie_auto.logging_service import Logger  # noqa: E402
+from sele_saisie_auto.orchestration import AutomationOrchestrator  # noqa: E402
+from sele_saisie_auto.navigation import PageNavigator  # noqa: E402
+from sele_saisie_auto.resources import resource_manager  # noqa: E402
+from sele_saisie_auto.automation import (  # noqa: E402
+    BrowserSession,
+    LoginHandler,
+    DateEntryPage,
+    AdditionalInfoPage,
+)
+from sele_saisie_auto.remplir_jours_feuille_de_temps import context_from_app_config  # noqa: E402
+from sele_saisie_auto.saisie_automatiser_psatime import SaisieContext  # noqa: E402
+
+
+class DummyConfigManager:
+    def __init__(self, log_file: str) -> None:
+        self.log_file = log_file
+
+    def load(self):
+        return APP_CFG
+
+
+class DummyEncryption:
+    def __init__(self, log_file: str) -> None:
+        self.log_file = log_file
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+    def retrieve_credentials(self):
+        return CREDS
+
+    def dechiffrer_donnees(self, data, key):
+        return data.decode() if isinstance(data, bytes) else data
+
+
+class DummyManager:
+    def __init__(self, log_file: str, app_config=None) -> None:
+        self.log_file = log_file
+        self.open_calls = []
+
+    def open(self, url, fullscreen=False, headless=False, no_sandbox=False):
+        self.open_calls.append((url, fullscreen, headless, no_sandbox))
+        return "drv"
+
+    def close(self):
+        pass
+
+
+class DummyWaiter:
+    def __init__(self):
+        self.calls = []
+
+    def wait_for_element(self, *a, **k):
+        self.calls.append(("wait", a, k))
+        return True
+
+    def wait_for_dom_ready(self, *a, **k):
+        self.calls.append("ready")
+
+    def wait_until_dom_is_stable(self, *a, **k):
+        self.calls.append("stable")
+        return True
+
+
+dummy_waiter = DummyWaiter()
+
+
+class DummyHelper:
+    def __init__(self, ctx, logger, waiter=None):
+        self.calls = []
+
+    def run(self, driver):
+        self.calls.append(driver)
+
+
+class DummySHMService:
+    def __init__(self):
+        self.removed = []
+
+    def supprimer_memoire_partagee_securisee(self, mem):
+        self.removed.append(mem)
+
+
+CREDS = types.SimpleNamespace(
+    aes_key=b"k" * 32,
+    mem_key=object(),
+    login=b"user",
+    mem_login=object(),
+    password=b"pwd",
+    mem_password=object(),
+)
+
+
+class DummyAutomation:
+    def __init__(self, log_file, ctx, session, logger):
+        self.log_file = log_file
+        self.context = ctx
+        self.browser_session = session
+        self.logger = logger
+
+    def wait_for_dom(self, driver):
+        pass
+
+    def switch_to_iframe_main_target_win0(self, driver):
+        return True
+
+
+def test_full_automation(monkeypatch, sample_config):
+    global APP_CFG
+    APP_CFG = AppConfig.from_raw(AppConfigRaw(sample_config))
+    log_file = "log.html"
+    logger = Logger(log_file)
+
+    monkeypatch.setattr(resource_manager, "ConfigManager", DummyConfigManager)
+    monkeypatch.setattr(resource_manager, "EncryptionService", DummyEncryption)
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.browser_session.SeleniumDriverManager",
+        DummyManager,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.selenium_utils.waiter_factory.get_waiter",
+        lambda cfg: dummy_waiter,
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.automation.additional_info_page.ExtraInfoHelper",
+        lambda *a, **k: types.SimpleNamespace(traiter_description=lambda *a, **k: None),
+    )
+
+    with resource_manager.ResourceManager(log_file) as rm:
+        session = rm.get_driver()
+        ctx = SaisieContext(APP_CFG, rm._encryption_service, DummySHMService(), {}, [])
+        automation = DummyAutomation(log_file, ctx, rm._session, logger)
+        login = LoginHandler(log_file, rm._encryption_service, rm._session)
+        date_page = DateEntryPage(automation)
+        add_page = AdditionalInfoPage(automation)
+        helper = DummyHelper(context_from_app_config(APP_CFG, log_file), logger, waiter=dummy_waiter)
+        navigator = PageNavigator(rm._session, login, date_page, add_page, helper)
+        orch = AutomationOrchestrator.from_components(
+            rm,
+            navigator,
+            types.SimpleNamespace(app_config=APP_CFG),
+            ctx,
+            logger,
+            choix_user=True,
+            timesheet_helper_cls=DummyHelper,
+        )
+
+        calls = []
+        monkeypatch.setattr(orch.login_handler, "connect_to_psatime", lambda *a, **k: calls.append("login"))
+        monkeypatch.setattr(orch, "navigate_from_home_to_date_entry_page", lambda *a, **k: calls.append("navigate") or True)
+        monkeypatch.setattr(orch, "_process_date_entry", lambda *a, **k: calls.append("process"))
+        monkeypatch.setattr(orch, "_fill_and_save_timesheet", lambda *a, **k: calls.extend(["fill", "submit"]))
+        monkeypatch.setattr(orch, "initialize_shared_memory", lambda: CREDS)
+        monkeypatch.setattr(orch, "wait_for_dom", lambda *a, **k: None)
+        monkeypatch.setattr(orch, "switch_to_iframe_main_target_win0", lambda *a, **k: None)
+        monkeypatch.setattr(orch, "cleanup_resources", lambda *a, **k: calls.append("cleanup"))
+        monkeypatch.setattr("sele_saisie_auto.console_ui.ask_continue", lambda *a, **k: None)
+
+        orch.run(headless=True, no_sandbox=True)
+
+        assert calls == ["login", "navigate", "process", "fill", "submit", "cleanup"]


### PR DESCRIPTION
## Contexte et objectif
Ajout d’un test `test_full_automation.py` simulant l’exécution complète de l’orchestrateur sans accès réseau. Le test instancie `ResourceManager`, `PageNavigator`, `AutomationOrchestrator` et leurs dépendances en remplaçant les appels Selenium par des stubs.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686d95e8888c83219e08bf6514ab1fd5