### PR TITLE
[tests] note orchestrator

### DIFF
--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -14,6 +14,9 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 from sele_saisie_auto import messages  # noqa: E402
 from sele_saisie_auto import saisie_automatiser_psatime as sap  # noqa: E402
 
+# Les tests de ce module s'appuient sur l'orchestrateur refactorisé
+# `AutomationOrchestrator` afin de valider le nouveau fonctionnement.
+
 pytestmark = pytest.mark.slow
 
 


### PR DESCRIPTION
## Contexte
Ajout d'un rappel dans le test principal de `saisie_automatiser_psatime` sur l'utilisation de l'orchestrateur refactorisé.

## Impact
Aucun impact fonctionnel, juste un commentaire informatif.

## Tests
- `poetry run pre-commit run --all-files`
- `poetry run pytest` *(échec couverture 93% requis)*

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686e190165148321bc0b9bbbbcd8c663