### PR TITLE
[PSATimeAutomation] factorise log configuration

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -32,15 +32,13 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
-)
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -38,9 +38,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
+    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
-from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -218,6 +218,11 @@ class PSATimeAutomation:
         )
         self.resource_manager = ResourceManager(log_file)  # pragma: no cover
         self.orchestrator: AutomationOrchestrator | None = None
+
+        self.log_configuration_details()
+
+    def log_configuration_details(self) -> None:
+        """Enregistre les détails de la configuration dans les logs."""
 
         write_log(
             "📌 Chargement des configurations...", self.log_file, "DEBUG"


### PR DESCRIPTION
## Contexte
Refactorisation mineure pour rendre le constructeur de `PSATimeAutomation` plus lisible. Les boucles d'écriture dans les logs sont déplacées dans une nouvelle méthode `log_configuration_details()`.

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`
- `poetry run pytest --cov=sele_saisie_auto --cov-report=term-missing`
- `poetry run ruff check`
- `poetry run ruff check . --fix`
- `poetry run radon cc src/ -s`
- `poetry run radon mi src/`
- `poetry run bandit -r src/`
- `poetry run bandit -r src/ -lll -iii`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686e1aaee6d48321b5b05938a49890c8