### PR TITLE
[TimeSheetHelper] retour anticipé lorsque feuille complétée

### DIFF
--- a/src/sele_saisie_auto/messages.py
+++ b/src/sele_saisie_auto/messages.py
@@ -49,4 +49,5 @@ LOCATOR_VALUE_REQUIRED = (
     "Erreur : Le paramètre 'locator_value' doit être spécifié pour localiser l'élément."
 )
 WAIT_STABILISATION = "Veuillez patienter. Court délai pour stabilisation du DOM"
+TIMESHEET_ALREADY_COMPLETE = "✅ Feuille déjà complétée, aucun traitement nécessaire."
 NO_DATE_CHANGE = "Aucune modification de la date nécessaire."

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -494,6 +494,10 @@ class TimeSheetHelper:
             filled_days = self.fill_standard_days(driver, filled_days)
             self.logger.debug(f"Jours déjà remplis : {filled_days}")
 
+            if len(set(filled_days)) == len(JOURS_SEMAINE):
+                self.logger.info(messages.TIMESHEET_ALREADY_COMPLETE)
+                return
+
             filled_days = self.fill_work_missions(driver, filled_days)
             self.logger.debug(f"Finalisation des jours remplis : {filled_days}")
 

--- a/tests/test_timesheet_helper.py
+++ b/tests/test_timesheet_helper.py
@@ -93,6 +93,30 @@ def test_timesheethelper_run_sequence(monkeypatch):
     assert seq == ["std", "work", "extra"]
 
 
+def test_timesheethelper_run_early_exit(monkeypatch):
+    helper = TimeSheetHelper(TimeSheetContext("log", [], {}, {}), Logger("log"))
+    seq = []
+    from sele_saisie_auto.constants import JOURS_SEMAINE
+
+    all_days = list(JOURS_SEMAINE.values())
+
+    monkeypatch.setattr(helper, "fill_standard_days", lambda d, j: all_days)
+    monkeypatch.setattr(
+        helper, "fill_work_missions", lambda d, j: seq.append("work") or j
+    )
+    monkeypatch.setattr(
+        helper, "handle_additional_fields", lambda d: seq.append("extra")
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.remplir_jours_feuille_de_temps.write_log",
+        lambda *a, **k: None,
+    )
+
+    helper.run(None)
+
+    assert seq == []
+
+
 def test_fill_standard_days_delegates(monkeypatch):
     ctx = TimeSheetContext("log", ["desc"], {}, {})
     logger = Logger("log", writer=lambda *a, **k: None)


### PR DESCRIPTION
## Contexte
Ajout d'un contrôle dans `TimeSheetHelper.run` pour arrêter le traitement si tous les jours sont déjà renseignés. Un nouveau message de log `TIMESHEET_ALREADY_COMPLETE` est introduit.

## Étapes de test
- `poetry run pre-commit run --files src/sele_saisie_auto/remplir_jours_feuille_de_temps.py src/sele_saisie_auto/messages.py tests/test_timesheet_helper.py`
- `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686e2d6d0edc8321b46c917a35490fb0