### PR TITLE
[launcher] integration architecture

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -19,7 +19,6 @@ from sele_saisie_auto.gui_builder import (
 )
 from sele_saisie_auto.logger_utils import LOG_LEVELS, initialize_logger
 from sele_saisie_auto.logging_service import Logger, get_logger
-from sele_saisie_auto.orchestration import AutomationOrchestrator
 from sele_saisie_auto.read_or_write_file_config_ini_utils import (
     read_config_ini,
     write_config_ini,
@@ -48,17 +47,7 @@ def run_psatime(
                 cfg,
                 logger=log,
             )
-            orchestrator = AutomationOrchestrator(
-                cfg,
-                log,
-                automation.browser_session,
-                automation.login_handler,
-                automation.date_entry_page,
-                automation.additional_info_page,
-                automation.context,
-                automation.choix_user,
-            )
-            orchestrator.run(headless=headless, no_sandbox=no_sandbox)
+            automation.run(headless=headless, no_sandbox=no_sandbox)
     else:
         logger.info("Launching PSA time")
         cfg = ConfigManager(log_file=log_file).load()
@@ -67,17 +56,7 @@ def run_psatime(
             cfg,
             logger=logger,
         )
-        orchestrator = AutomationOrchestrator(
-            cfg,
-            logger,
-            automation.browser_session,
-            automation.login_handler,
-            automation.date_entry_page,
-            automation.additional_info_page,
-            automation.context,
-            automation.choix_user,
-        )
-        orchestrator.run(headless=headless, no_sandbox=no_sandbox)
+        automation.run(headless=headless, no_sandbox=no_sandbox)
 
 
 def run_psatime_with_credentials(


### PR DESCRIPTION
## Contexte
Mise à jour du lanceur afin d'utiliser l'orchestrateur interne présenté dans la documentation. La logique de démarrage s'appuie désormais sur `PSATimeAutomation.run()` pour profiter de `ResourceManager` et `PageNavigator`.

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686e4a9f3bc08321b4447d9186c5ab45