### PR TITLE
[tests] validate cli and launcher flags

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -29,3 +30,59 @@ def test_parse_flags():
     args = cli.parse_args(["--headless", "--no-sandbox"])
     assert args.headless is True
     assert args.no_sandbox is True
+
+
+def test_main_creates_services_and_passes_flags(monkeypatch):
+    dummy_args = types.SimpleNamespace(log_level=None, headless=True, no_sandbox=True)
+    monkeypatch.setattr(cli, "parse_args", lambda argv: dummy_args)
+    monkeypatch.setattr(cli, "get_log_file", lambda: "log.html")
+
+    cfg = types.SimpleNamespace(raw={})
+    monkeypatch.setattr(
+        cli,
+        "ConfigManager",
+        lambda log_file=None: types.SimpleNamespace(load=lambda: cfg),
+    )
+
+    service_calls = {}
+
+    class DummyConfigurator:
+        def __init__(self, conf):
+            service_calls["cfg"] = conf
+
+        def build_services(self, log_file):
+            service_calls["log_file"] = log_file
+            return "services"
+
+    monkeypatch.setattr(cli, "ServiceConfigurator", DummyConfigurator)
+
+    auto_data = {}
+
+    class DummyAutomation:
+        def __init__(self, lf, conf, logger=None, services=None):
+            auto_data["init"] = (lf, conf, logger, services)
+
+        def run(self, headless=False, no_sandbox=False):
+            auto_data["run"] = (headless, no_sandbox)
+
+    monkeypatch.setattr(cli, "PSATimeAutomation", DummyAutomation)
+
+    class DummyLogger:
+        def __enter__(self):
+            auto_data["enter"] = True
+            return "logger"
+
+        def __exit__(self, exc_type, exc, tb):
+            auto_data["exit"] = True
+
+    monkeypatch.setattr(cli, "get_logger", lambda lf: DummyLogger())
+    monkeypatch.setattr(
+        cli, "initialize_logger", lambda cfg_raw, log_level_override=None: None
+    )
+
+    cli.main([])
+
+    assert service_calls == {"cfg": cfg, "log_file": "log.html"}
+    assert auto_data["init"] == ("log.html", cfg, "logger", "services")
+    assert auto_data["run"] == (True, True)
+    assert auto_data["enter"] and auto_data["exit"]


### PR DESCRIPTION
## Contexte
Ajout de tests pour vérifier l'utilisation de `ServiceConfigurator` dans le CLI et la transmission correcte des options `headless` et `no_sandbox` dans le launcher.

## Instructions de test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686e503e01188321bb0f82e23ae4ec59