### PR TITLE
[ResourceManager] expose helpers

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -157,6 +157,18 @@ class ResourceManager:
         """Ouvre le navigateur si nécessaire."""
 ```
 
+## Resource access helpers
+
+Fonctions utilitaires pour récupérer les identifiants ou ouvrir le navigateur en
+s'appuyant directement sur ``EncryptionService`` et ``BrowserSession``.
+
+```python
+from sele_saisie_auto.resources.accessors import get_credentials, get_driver
+
+creds = get_credentials(encryption_service)
+driver = get_driver(browser_session, "https://example.com", headless=True)
+```
+
 ## PageNavigator
 
 Orchestre la navigation entre les différentes pages PSA Time

--- a/src/sele_saisie_auto/resources/accessors.py
+++ b/src/sele_saisie_auto/resources/accessors.py
@@ -1,0 +1,22 @@
+"""Simplified helpers to retrieve credentials and open a browser."""
+
+from sele_saisie_auto.automation.browser_session import BrowserSession
+from sele_saisie_auto.encryption_utils import Credentials, EncryptionService
+
+__all__ = ["get_credentials", "get_driver"]
+
+
+def get_credentials(encryption_service: EncryptionService) -> Credentials:
+    """Return encrypted credentials using ``encryption_service``."""
+    return encryption_service.retrieve_credentials()
+
+
+def get_driver(
+    browser_session: BrowserSession,
+    url: str,
+    *,
+    headless: bool = False,
+    no_sandbox: bool = False,
+):
+    """Open the browser through ``browser_session`` and return the driver."""
+    return browser_session.open(url, headless=headless, no_sandbox=no_sandbox)


### PR DESCRIPTION
## Contexte et objectif
- ajouter deux fonctions utilitaires permettant d'obtenir le navigateur et les identifiants
- documenter ces helpers dans la référence API

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686faa3485cc83219fbba53de626abf2