### PR TITLE
[PageNavigator] utilise run dans les tests

### DIFF
--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -143,6 +143,9 @@ class DummyDateEntryPage:
     def handle_date_input(self, driver, date):
         self.calls.append(("handle", date))
 
+    def process_date(self, driver, date):
+        self.calls.append(("process", date))
+
     def submit_date_cible(self, driver):
         self.calls.append("submit")
         return True


### PR DESCRIPTION
## Contexte et objectif
Mise à jour des tests unitaires autour de `PageNavigator` pour utiliser la
méthode `run` après préparation des identifiants. Ajout de la méthode
`process_date` dans le double `DummyDateEntryPage`.

## Étapes pour tester
1. `poetry run pre-commit run --files tests/test_page_navigator_stubs.py tests/test_saisie_automatiser_psatime.py`
2. `poetry run pytest`

## Impact
Aucun impact sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_686fffec0cd88321a4a318d1474de138