### PR TITLE
[PageNavigator] adoption de prepare et run

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -181,14 +181,10 @@ Orchestre la navigation entre les différentes pages PSA Time
 
 ```python
 class PageNavigator:
-    def login(self, driver, aes_key: bytes, encrypted_login: bytes, encrypted_password: bytes) -> None:
-        """Connecte l'utilisateur via ``LoginHandler``."""
-    def navigate_to_date_entry(self, driver, date_cible: str | None) -> None:
-        """Atteint la page de sélection de période."""
-    def fill_timesheet(self, driver) -> None:
-        """Remplit la feuille de temps et les infos additionnelles."""
-    def submit_timesheet(self, driver) -> None:
-        """Sauvegarde puis valide la feuille de temps."""
+    def prepare(self, credentials: Credentials, date_cible: str) -> None:
+        """Stocke les informations nécessaires pour ``run()``."""
+    def run(self, driver) -> None:
+        """Enchaîne connexion, saisie et validation."""
 ```
 
 ## Logger utils
@@ -237,7 +233,7 @@ Collection de fonctions Tkinter définies dans ``gui_builder.py``.
 ```python
 from config_manager import ConfigManager
 from selenium_driver_manager import SeleniumDriverManager
-from saisie_automatiser_psatime import PSATimeAutomation, TimeSheetHelper
+from saisie_automatiser_psatime import PSATimeAutomation
 
 cfg = ConfigManager().load()
 filler = PSATimeAutomation("log.html", cfg)
@@ -245,9 +241,7 @@ filler = PSATimeAutomation("log.html", cfg)
 with SeleniumDriverManager("log.html") as dm:
     driver = filler.setup_browser(dm)
     creds = filler.initialize_shared_memory()
-    filler.login_handler.login(
-        driver, creds, filler.context.encryption_service
-    )
-    TimeSheetHelper("log.html").run(driver)
+    filler.page_navigator.prepare(creds, cfg.date_cible)
+    filler.page_navigator.run(driver)
 ```
 

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -405,8 +405,8 @@ def test_run_sequence_with_mocks(sample_config):
     assert order == [
         "enter",
         "init",
-        "prepare",
         "driver",
+        "prepare",
         "run",
         "cleanup",
         "exit",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,11 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
     class DummyAutomation:
         def __init__(self, lf, conf, logger=None, services=None):
             auto_data["init_auto"] = (lf, conf, logger, services)
+            self.resource_manager = object()
+            self.page_navigator = object()
+            self.context = types.SimpleNamespace()
+            self.logger = logger
+            self.choix_user = True
 
     class DummyOrchestrator:
         def __init__(self, *args, **kwargs):

--- a/tests/test_page_navigator.py
+++ b/tests/test_page_navigator.py
@@ -179,10 +179,9 @@ def make_logged_navigator():
 
 def test_full_sequence_order():
     log, nav = make_logged_navigator()
-    nav.login("drv", b"k", b"u", b"p")
-    nav.navigate_to_date_entry("drv", "2024")
-    nav.fill_timesheet("drv")
-    nav.submit_timesheet("drv")
+    creds = Credentials(b"k", None, b"u", None, b"p", None)
+    nav.prepare(creds, "2024")
+    nav.run("drv")
     assert log == [
         "login",
         "navigate",

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -117,6 +117,13 @@ def test_run_invokes_hook(monkeypatch, sample_config):
         "close",
         lambda self: calls.append("close"),
     )
+    from tests.test_saisie_automatiser_psatime import DummyBrowserSession
+
+    monkeypatch.setattr(
+        DummyBrowserSession,
+        "close",
+        lambda self: calls.append("close"),
+    )
 
     sap.main("log.html")
 


### PR DESCRIPTION
## Contexte
- mise en avant des nouvelles méthodes `prepare()` et `run()`
- adaptation des scénarios de test pour la séquence complète

## Impact
- `PageNavigator` utilisé via `prepare()` puis `run()`
- ajustements des tests et documentation

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68700bcad9248321aaa857376cae22ff