### PR TITLE
[SeleniumFiller] retire submit_date_cible wrapper

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -745,13 +745,6 @@ def switch_to_iframe_main_target_win0(driver):
     return _ORCHESTRATOR.switch_to_iframe_main_target_win0(driver)
 
 
-def submit_date_cible(driver):
-    """Valide la date cible sélectionnée."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return _ORCHESTRATOR.submit_date_cible(driver)
-
-
 def navigate_from_work_schedule_to_additional_information_page(driver):
     """Ouvre la fenêtre d'informations supplémentaires."""
     if not _ORCHESTRATOR:

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -151,7 +151,8 @@ def test_connect_to_psatime(monkeypatch, sample_config):
     assert "dom" in actions
 
 
-def test_switch_to_iframe(monkeypatch):
+def test_switch_to_iframe(monkeypatch, sample_config):
+    setup_init(monkeypatch, sample_config)
     calls = []
     monkeypatch.setattr(
         sap._AUTOMATION.waiter, "wait_for_element", lambda *a, **k: True
@@ -171,14 +172,15 @@ def test_switch_to_iframe(monkeypatch):
     assert "dom" in calls
 
 
-def test_submit_date_cible(monkeypatch):
+def test_submit_date_cible(monkeypatch, sample_config):
+    setup_init(monkeypatch, sample_config)
     called = {}
     monkeypatch.setattr(
-        sap._AUTOMATION.date_entry_page,
+        sap._ORCHESTRATOR.date_entry_page,
         "submit_date_cible",
         lambda driver: called.setdefault("done", True) or True,
     )
-    assert sap.submit_date_cible("drv") is True
+    assert sap._ORCHESTRATOR.submit_date_cible("drv") is True
     assert called["done"] is True
 
 
@@ -194,7 +196,8 @@ def test_navigation_pages(monkeypatch, sample_config):
     assert called["nav"] is True
 
 
-def test_additional_information(monkeypatch):
+def test_additional_information(monkeypatch, sample_config):
+    setup_init(monkeypatch, sample_config)
     called = {}
     monkeypatch.setattr(
         sap._AUTOMATION.additional_info_page,
@@ -223,7 +226,8 @@ def test_save_draft_and_validate(monkeypatch, sample_config):
     assert called["done"] is True
 
 
-def test_cleanup_resources(monkeypatch):
+def test_cleanup_resources(monkeypatch, sample_config):
+    setup_init(monkeypatch, sample_config)
     called = []
     manager = types.SimpleNamespace(close=lambda: called.append("close"))
     enc = DummyEnc()

--- a/tests/test_wait_for_dom_after.py
+++ b/tests/test_wait_for_dom_after.py
@@ -12,5 +12,5 @@ def test_wait_for_dom_after_decorator(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: calls.append("dom")
     )
-    sap.submit_date_cible(driver="drv")
+    sap._ORCHESTRATOR.submit_date_cible(driver="drv")
     assert calls.count("dom") == 2


### PR DESCRIPTION
## Contexte
Le module `saisie_automatiser_psatime.py` exposait encore la fonction
`submit_date_cible(driver)` utilisée comme simple relais vers
`AutomationOrchestrator`. Cette redondance a été retirée.

Les tests qui appelaient directement cette fonction ont été mis à jour pour
utiliser l’orchestrateur ou pour patcher ce dernier lorsque nécessaire.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
Suppression d’une fonction obsolète et adaptation de plusieurs tests.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_687033e105008321bb3201724b9523f4