### PR TITLE
[SeleniumFiller] clean up navigation helper

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -745,15 +745,6 @@ def switch_to_iframe_main_target_win0(driver):
     return _ORCHESTRATOR.switch_to_iframe_main_target_win0(driver)
 
 
-def navigate_from_work_schedule_to_additional_information_page(driver):
-    """Ouvre la fenêtre d'informations supplémentaires."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return _ORCHESTRATOR.navigate_from_work_schedule_to_additional_information_page(
-        driver
-    )
-
-
 def submit_and_validate_additional_information(driver):
     """Soumet les informations complémentaires."""
     if not _ORCHESTRATOR:

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -64,7 +64,7 @@ def test_navigate_from_work_schedule_positive(monkeypatch):
         "sele_saisie_auto.automation.browser_session.BrowserSession.go_to_default_content",
         lambda *a, **k: actions.append("switch"),
     )
-    sap.navigate_from_work_schedule_to_additional_information_page("drv")
+    sap._ORCHESTRATOR.navigate_from_work_schedule_to_additional_information_page("drv")
     assert actions.count("click") == 1
     assert "switch" in actions
 

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -132,11 +132,13 @@ def test_navigate_from_work_schedule_without_element(monkeypatch, sample_config)
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    sap.navigate_from_work_schedule_to_additional_information_page("drv")
+    sap._ORCHESTRATOR.navigate_from_work_schedule_to_additional_information_page("drv")
     assert called["nav"] is True
 
 
-def test_submit_and_validate_additional_information_no_iframe(monkeypatch, sample_config):
+def test_submit_and_validate_additional_information_no_iframe(
+    monkeypatch, sample_config
+):
     setup_init(monkeypatch, sample_config)
     monkeypatch.setattr(
         sap._AUTOMATION.additional_info_page,
@@ -170,7 +172,9 @@ def test_cleanup_resources_calls(monkeypatch, sample_config):
     shm_service = DummySHMService()
     sap.context.shared_memory_service = shm_service
     sap._ORCHESTRATOR.context.shared_memory_service = shm_service
-    sap._ORCHESTRATOR.resource_manager._encryption_service.shared_memory_service = shm_service
+    sap._ORCHESTRATOR.resource_manager._encryption_service.shared_memory_service = (
+        shm_service
+    )
     sap._ORCHESTRATOR.resource_manager._credentials = sap.Credentials(
         b"k",
         "c",


### PR DESCRIPTION
## Summary
- remove the redundant `navigate_from_work_schedule_to_additional_information_page` wrapper
- update tests to use `_ORCHESTRATOR` directly

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest` *(fails: NoSuchElementException due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_68703acf9174832196ba357ff09ad3b8