### PR TITLE
[saisie_automatiser_psatime] remove obsolete wrapper

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -43,7 +43,6 @@ class PSATimeAutomation:
 - `navigate_from_home_to_date_entry_page(driver)` – ouvre la page de saisie de date.
 - `submit_date_cible(driver)` – valide la date choisie.
 - `navigate_from_work_schedule_to_additional_information_page(driver)` – accède aux informations supplémentaires.
-- `submit_and_validate_additional_information(driver)` – remplit puis confirme les données complémentaires.
 - `save_draft_and_validate(driver)` – sauvegarde la feuille et déclenche la validation.
 - `cleanup_resources(mem_key, mem_login, mem_password)` – fonction injectable pour fermer le navigateur et libérer la mémoire.
 - *Cette propriété peut être redéfinie pour personnaliser la stratégie de nettoyage.*

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -745,13 +745,6 @@ def switch_to_iframe_main_target_win0(driver):
     return _ORCHESTRATOR.switch_to_iframe_main_target_win0(driver)
 
 
-def submit_and_validate_additional_information(driver):
-    """Soumet les informations complémentaires."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return _ORCHESTRATOR.submit_and_validate_additional_information(driver)
-
-
 def save_draft_and_validate(driver):
     """Enregistre le brouillon et valide la feuille de temps."""
     if not _ORCHESTRATOR:

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -207,7 +207,7 @@ def test_additional_information(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    sap.submit_and_validate_additional_information("drv")
+    sap._ORCHESTRATOR.submit_and_validate_additional_information("drv")
     assert called["done"] is True
 
 

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -101,7 +101,7 @@ def test_submit_and_validate_additional_information_positive(monkeypatch):
             "valeurs_a_remplir": {"lundi": "1"},
         }
     ]
-    sap.submit_and_validate_additional_information("drv")
+    sap._ORCHESTRATOR.submit_and_validate_additional_information("drv")
     assert "desc" in records
     assert "ok" in records
 
@@ -174,7 +174,7 @@ def test_submit_and_validate_additional_information_none(monkeypatch):
         lambda driver: (_ for _ in ()).throw(NameError()),
     )
     with pytest.raises(NameError):
-        sap.submit_and_validate_additional_information("drv")
+        sap._ORCHESTRATOR.submit_and_validate_additional_information("drv")
 
 
 def test_cleanup_resources_none(monkeypatch):

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -148,7 +148,7 @@ def test_submit_and_validate_additional_information_no_iframe(
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    sap.submit_and_validate_additional_information("drv")
+    sap._ORCHESTRATOR.submit_and_validate_additional_information("drv")
 
 
 def test_save_draft_and_validate_no_element(monkeypatch, sample_config):


### PR DESCRIPTION
## Contexte
- simplification de l'API `saisie_automatiser_psatime`
- mise à jour des tests pour utiliser directement l'orchestrateur

## Modifications
- suppression de la fonction `submit_and_validate_additional_information`
- appel direct à `sap._ORCHESTRATOR.submit_and_validate_additional_information` dans les tests
- documentation API ajustée

## Impact
- aucun changement fonctionnel

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6870b80f58588321b3d909fc1922d4c9