### PR TITLE
[SeleniumFiller] retire l'appel global obsolète

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -745,13 +745,6 @@ def switch_to_iframe_main_target_win0(driver):
     return _ORCHESTRATOR.switch_to_iframe_main_target_win0(driver)
 
 
-def save_draft_and_validate(driver):
-    """Enregistre le brouillon et valide la feuille de temps."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return _ORCHESTRATOR.save_draft_and_validate(driver)
-
-
 def cleanup_resources(session, memoire_cle, memoire_nom, memoire_mdp):
     """Nettoie les ressources utilisées par l'automatisation."""
     if not _ORCHESTRATOR:

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -222,7 +222,7 @@ def test_save_draft_and_validate(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    assert sap.save_draft_and_validate("drv") is True
+    assert sap._ORCHESTRATOR.save_draft_and_validate("drv") is True
     assert called["done"] is True
 
 

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -161,7 +161,7 @@ def test_save_draft_and_validate_no_element(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    assert sap.save_draft_and_validate("drv") is False
+    assert sap._ORCHESTRATOR.save_draft_and_validate("drv") is False
 
 
 def test_cleanup_resources_calls(monkeypatch, sample_config):


### PR DESCRIPTION
## Contexte
- simplification de l'API `saisie_automatiser_psatime`
- les tests utilisaient la fonction `save_draft_and_validate` exposée au niveau du module
- cette fonction est désormais inutile : on accède directement à l'orchestrateur

## Changements
- suppression de `save_draft_and_validate(driver)` dans `saisie_automatiser_psatime.py`
- mise à jour des tests pour appeler `sap._ORCHESTRATOR.save_draft_and_validate(driver)`

## Tests
- `poetry run pre-commit run --files src/sele_saisie_auto/saisie_automatiser_psatime.py tests/test_saisie_automatiser_psatime_additional.py tests/test_saisie_automatiser_psatime_extra.py`
- `poetry run pytest -q` *(quelques tests échouent toujours)*

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6870bb2b885c8321a3ffdc6491f7753e