### PR TITLE
docs: update navigation diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Lors du démarrage, une clé AES temporaire est générée pour chiffrer ces inf
 > initialiser ``EncryptionService`` et ``BrowserSession``.
 > Les pages emploient ``AlertHandler`` pour gérer les pop-ups et ``DescriptionProcessor``
 > s'occupe du remplissage détaillé des lignes.
+> Toute la navigation se fait via la méthode ``PageNavigator.run``.
   ```
 
 ## 🔌 Injection de dépendances
@@ -130,7 +131,7 @@ graph TD
     A[Utilisateur] --> AO(AutomationOrchestrator)
   end
   AO --> RM(ResourceManager)
-  AO --> PN(PageNavigator)
+  AO -- run() --> PN(PageNavigator)
   AO --> SC(ServiceConfigurator)
   PN --> DE(DateEntryPage)
   PN --> AI(AdditionalInfoPage)
@@ -144,7 +145,7 @@ Cette séparation facilite les tests et l'évolution du code.
 - **AutomationOrchestrator** : supervise l'ensemble du processus.
 - **ResourceManager** : centralise configuration, identifiants et session Selenium.
 - **ServiceConfigurator** : prépare chiffrement et navigateur.
-- **PageNavigator** : enchaîne connexion et navigation.
+- **PageNavigator** : enchaîne connexion et navigation via la méthode unique `run()`.
 - **DateEntryPage** : sélection de la période à remplir.
 - **AdditionalInfoPage** : saisie des informations complémentaires.
 - **AlertHandler** : ferme les éventuelles pop‑ups.

--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -7,6 +7,7 @@ Afin de clarifier la logique de l'automatisation, la classe `PSATimeAutomation` 
 - **ServiceConfigurator** – instancie le navigateur, le chiffrement et le `Waiter`.
 - **ResourceManager** – gère la configuration, la session Selenium et la récupération des identifiants.
 - **PageNavigator** – orchestre la connexion et la navigation dans PSA Time.
+- Toute la navigation se déclenche via son unique méthode `run()`.
 - **AutomationOrchestrator** – coordonne l'ensemble du processus en s'appuyant sur les trois précédents.
 
 ## Diagramme d'interaction
@@ -16,5 +17,5 @@ flowchart TD
     ServiceConfigurator --> ResourceManager
     ServiceConfigurator --> PageNavigator
     ResourceManager --> AutomationOrchestrator
-    PageNavigator --> AutomationOrchestrator
+    AutomationOrchestrator -- run() --> PageNavigator
 ```


### PR DESCRIPTION
## Contexte
Le diagramme d'architecture ne montrait pas clairement l'appel à `PageNavigator.run`. Les textes étaient ambigus sur le point d'entrée de la navigation.

## Changements
- ajout d'une flèche `AutomationOrchestrator -- run() --> PageNavigator` dans les diagrammes Mermaid
- précision que toute la navigation passe par la méthode `run()` dans la documentation

## Impact
Documentation uniquement, aucune incidence sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6871065606488321b52656f05aeb5aa3