### PR TITLE
[docs] ajout config minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Automatiser la saisie de la feuille de temps PSA Time via Selenium et une interf
 ## ⚡ Démarrage rapide
 ```bash
 poetry install --no-root
+cp examples/config_minimal.ini config.ini  # première utilisation
 poetry run psatime-launcher
 ```
 
@@ -191,6 +192,7 @@ l'installation des dépendances hors de l'environnement Poetry.
 
 ## 🛠️ Fichiers de configuration
 - `config.ini` : paramètres de connexion et de planning
+- `examples/config_minimal.ini` : configuration minimale à copier pour démarrer rapidement
 - `examples/config_example.ini` : modèle listant toutes les sections nécessaires
 - `examples/dropdown_defaults.json` : valeurs par défaut des menus déroulants si
   les sections correspondantes sont absentes de `config.ini`

--- a/examples/config_minimal.ini
+++ b/examples/config_minimal.ini
@@ -1,0 +1,31 @@
+[settings]
+url = http://example.com
+date_cible = 01/07/2024
+liste_items_planning = "En mission"
+
+[work_schedule]
+lundi = En mission,8
+
+[project_information]
+billing_action = Facturable
+
+[additional_information_rest_period_respected]
+lundi = Oui
+
+[additional_information_work_time_range]
+lundi = 8-16
+
+[additional_information_half_day_worked]
+lundi = Non
+
+[additional_information_lunch_break_duration]
+lundi = 1
+
+[work_location_am]
+lundi = CGI
+
+[work_location_pm]
+lundi = CGI
+
+[cgi_options_billing_action]
+Facturable = B

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import types
 from configparser import ConfigParser
+from pathlib import Path
 
 import pytest
 
@@ -31,23 +32,11 @@ def dummy_logger():
 
 @pytest.fixture
 def sample_config():
-    """Provide a sample ConfigParser similar to real config."""
+    """Load the minimal example configuration."""
     cfg = ConfigParser()
-    cfg["credentials"] = {"login": "enc_login", "mdp": "enc_pwd"}
-    cfg["settings"] = {
-        "url": "http://test",
-        "date_cible": "01/07/2024",
-        "liste_items_planning": '"desc1", "desc2"',
-    }
-    cfg["work_schedule"] = {"lundi": "En mission,8"}
-    cfg["project_information"] = {"billing_action": "Facturable"}
-    cfg["additional_information_rest_period_respected"] = {"lundi": "Oui"}
-    cfg["additional_information_work_time_range"] = {"lundi": "8-16"}
-    cfg["additional_information_half_day_worked"] = {"lundi": "Non"}
-    cfg["additional_information_lunch_break_duration"] = {"lundi": "1"}
-    cfg["work_location_am"] = {"lundi": "CGI"}
-    cfg["work_location_pm"] = {"lundi": "CGI"}
-    cfg["cgi_options_billing_action"] = {"Facturable": "B"}
+    path = Path(__file__).resolve().parents[1] / "examples" / "config_minimal.ini"
+    cfg.read(path, encoding="utf-8")
+    cfg["settings"]["url"] = "http://test"
     return cfg
 
 


### PR DESCRIPTION
## Contexte
Ajout d'un fichier `examples/config_minimal.ini` pour proposer un modèle de configuration simplifié. Le README explique désormais comment le copier pour démarrer rapidement. Les tests d'intégration utilisent ce fichier via le fixture `sample_config`.

## Étapes pour tester
1. `poetry install --no-root`
2. `poetry run pre-commit run --all-files`
3. `poetry run pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68839fdddda08321a6cd3a78e83e7959