### PR TITLE
Refactor logging initialization via LoggingConfigurator

### DIFF
--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -7,8 +7,8 @@ import argparse
 from sele_saisie_auto import __version__
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import ServiceConfigurator
-from sele_saisie_auto.logger_utils import LOG_LEVELS, initialize_logger
-from sele_saisie_auto.logging_service import get_logger
+from sele_saisie_auto.logger_utils import LOG_LEVELS
+from sele_saisie_auto.logging_service import LoggingConfigurator, get_logger
 from sele_saisie_auto.orchestration import AutomationOrchestrator
 from sele_saisie_auto.saisie_automatiser_psatime import PSATimeAutomation
 from sele_saisie_auto.shared_utils import get_log_file
@@ -51,7 +51,7 @@ def main(argv: list[str] | None = None) -> None:
     log_file = get_log_file()
     with get_logger(log_file) as logger:
         cfg = ConfigManager(log_file=log_file).load()
-        initialize_logger(cfg.raw, log_level_override=args.log_level)
+        LoggingConfigurator.setup(log_file, args.log_level, cfg.raw)
 
         service_configurator = ServiceConfigurator(cfg)
         services = service_configurator.build_services(log_file)

--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -17,8 +17,8 @@ from sele_saisie_auto.gui_builder import (
     create_modern_label_with_pack,
     create_tab,
 )
-from sele_saisie_auto.logger_utils import LOG_LEVELS, initialize_logger
-from sele_saisie_auto.logging_service import Logger, get_logger
+from sele_saisie_auto.logger_utils import LOG_LEVELS
+from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
 from sele_saisie_auto.read_or_write_file_config_ini_utils import (
     read_config_ini,
     write_config_ini,
@@ -165,7 +165,7 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("Initialisation")
 
         config = read_config_ini(log_file)
-        initialize_logger(config, log_level_override=args.log_level)
+        LoggingConfigurator.setup(log_file, args.log_level, config)
 
         multiprocessing.freeze_support()
         with EncryptionService(log_file) as encryption_service:

--- a/src/sele_saisie_auto/logging_service.py
+++ b/src/sele_saisie_auto/logging_service.py
@@ -83,3 +83,23 @@ def get_logger(log_file: str | None) -> Logger:
     if log_file not in _LOGGERS:
         _LOGGERS[log_file] = Logger(log_file)
     return _LOGGERS[log_file]
+
+
+class LoggingConfigurator:
+    """Utility to configure global logging for the application."""
+
+    @staticmethod
+    def setup(log_file: str, debug_mode: str | None, config) -> None:
+        """Configure logging for Selenium helpers and the logger utils."""
+
+        from configparser import ConfigParser
+
+        from sele_saisie_auto.logger_utils import initialize_logger
+        from sele_saisie_auto.selenium_utils import (
+            set_log_file as set_log_file_selenium,
+        )
+
+        set_log_file_selenium(log_file)
+
+        if isinstance(config, ConfigParser):
+            initialize_logger(config, log_level_override=debug_mode)

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -29,8 +29,8 @@ from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.exceptions import AutomationNotInitializedError
 from sele_saisie_auto.locators import Locators
-from sele_saisie_auto.logger_utils import initialize_logger, write_log
-from sele_saisie_auto.logging_service import Logger, get_logger
+from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
 from sele_saisie_auto.navigation import PageNavigator
 from sele_saisie_auto.orchestration import AutomationOrchestrator
 from sele_saisie_auto.resources.resource_manager import ResourceManager
@@ -127,8 +127,7 @@ class PSATimeAutomation:
         self.log_file = log_file
         self.choix_user = choix_user
         self.memory_config = memory_config or MemoryConfig()
-        set_log_file_selenium(log_file)
-        initialize_logger(app_config.raw, log_level_override=app_config.debug_mode)
+        LoggingConfigurator.setup(log_file, app_config.debug_mode, app_config.raw)
         self.logger = logger or get_logger(log_file)
         self.shared_memory_service = shared_memory_service or SharedMemoryService(
             self.logger

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,7 +92,9 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
 
     monkeypatch.setattr(cli, "get_logger", lambda lf: DummyLogger())
     monkeypatch.setattr(
-        cli, "initialize_logger", lambda cfg_raw, log_level_override=None: None
+        cli.LoggingConfigurator,
+        "setup",
+        lambda log_file, debug_mode, config=None: None,
     )
 
     cli.main([])

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -339,9 +339,9 @@ def test_main(monkeypatch):
     monkeypatch.setattr(launcher, "read_config_ini", lambda lf: cfg)
     init = {}
     monkeypatch.setattr(
-        launcher,
-        "initialize_logger",
-        lambda c, log_level_override=None: init.setdefault("lvl", log_level_override),
+        launcher.LoggingConfigurator,
+        "setup",
+        lambda log_file, debug_mode, config=None: init.setdefault("lvl", debug_mode),
     )
     monkeypatch.setattr(
         launcher.multiprocessing,


### PR DESCRIPTION
## Summary
- centralize log setup in new `LoggingConfigurator`
- use `LoggingConfigurator.setup` in CLI, launcher and `PSATimeAutomation`
- adapt tests to patch the new configurator

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6883a34bcaac83218da6cc07a26ef5c9