### PR TITLE
[AlertHandler] Retour booléen et orchestration

### DIFF
--- a/src/sele_saisie_auto/alerts/alert_handler.py
+++ b/src/sele_saisie_auto/alerts/alert_handler.py
@@ -58,8 +58,15 @@ class AlertHandler:
     # ------------------------------------------------------------------
     # Alert helpers
     # ------------------------------------------------------------------
-    def handle_date_alert(self, driver) -> None:
-        """Close alert if the date already exists."""
+    def handle_date_alert(self, driver) -> bool:
+        """Close alert if the date already exists.
+
+        Returns
+        -------
+        bool
+            ``False`` if a conflicting date alert was found and closed,
+            ``True`` otherwise.
+        """
         from sele_saisie_auto import saisie_automatiser_psatime as sap
 
         if self.browser_session is not None:
@@ -79,9 +86,10 @@ class AlertHandler:
                     self.log_file,
                     "INFO",
                 )
-                sys.exit()
+                return False
 
         write_log(format_message("DATE_VALIDATED", {}), self.log_file, "DEBUG")
+        return True
 
     def handle_save_alerts(self, driver) -> None:
         """Dismiss any alert shown after saving."""
@@ -123,4 +131,4 @@ class AlertHandler:
         handler = handlers.get(alert_type)
         if handler is None:
             raise ValueError(f"Unknown alert_type: {alert_type}")
-        handler(driver)
+        return handler(driver)

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -160,8 +160,12 @@ class DateEntryPage:
         return element_present
 
     @handle_selenium_errors(default_return=None)
-    def process_date(self, driver, date_cible) -> None:
-        """Orchestrate date selection and validation."""
+    def process_date(self, driver, date_cible) -> bool | None:
+        """Orchestrate date selection and validation.
+
+        Returns ``False`` if a conflicting date alert was detected,
+        ``True`` if submission succeeded without alert, ``None`` otherwise.
+        """
 
         self.handle_date_input(driver, date_cible)
         program_break_time(
@@ -170,13 +174,14 @@ class DateEntryPage:
         )
         write_log(format_message("DOM_STABLE", {}), self.log_file, "DEBUG")
         if self.submit_date_cible(driver):
-            self._handle_date_alert(driver)
+            return self._handle_date_alert(driver)
+        return True
 
     @handle_selenium_errors(default_return=None)
-    def _handle_date_alert(self, driver) -> None:
+    def _handle_date_alert(self, driver) -> bool:
         """Delegate alert handling to :class:`AlertHandler`."""
 
-        self.alert_handler.handle_date_alert(driver)
+        return self.alert_handler.handle_date_alert(driver)
 
     @handle_selenium_errors(default_return=None)
     def _click_action_button(self, driver, create_new: bool) -> None:

--- a/src/sele_saisie_auto/navigation/page_navigator.py
+++ b/src/sele_saisie_auto/navigation/page_navigator.py
@@ -59,10 +59,11 @@ class PageNavigator:
             driver, aes_key, encrypted_login, encrypted_password
         )
 
-    def navigate_to_date_entry(self, driver, date_cible: str | None) -> None:
+    def navigate_to_date_entry(self, driver, date_cible: str | None) -> bool | None:
         """Ouvre la page de sélection de période et choisit ``date_cible``."""
         if self.date_entry_page.navigate_from_home_to_date_entry_page(driver):
-            self.date_entry_page.process_date(driver, date_cible)
+            return self.date_entry_page.process_date(driver, date_cible)
+        return None
 
     def fill_timesheet(self, driver) -> None:
         """Remplit la feuille de temps puis les informations additionnelles."""

--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -247,10 +247,11 @@ class AutomationOrchestrator:
                         creds.login,
                         creds.password,
                     )
-                    self.page_navigator.navigate_to_date_entry(
+                    result = self.page_navigator.navigate_to_date_entry(
                         driver, self.config.date_cible
                     )
-                    self._fill_and_save_timesheet(driver)
+                    if result is not False:
+                        self._fill_and_save_timesheet(driver)
             finally:
                 self.cleanup_resources(
                     creds.mem_key,

--- a/tests/test_alert_handler.py
+++ b/tests/test_alert_handler.py
@@ -61,8 +61,7 @@ def test_handle_alerts_date(monkeypatch):
         "sele_saisie_auto.saisie_automatiser_psatime.write_log",
         lambda *a, **k: None,
     )
-    with pytest.raises(SystemExit):
-        handler.handle_alerts("drv", alert_type="date_alert")
+    assert handler.handle_alerts("drv", alert_type="date_alert") is False
 
 
 def test_handle_alerts_unknown(monkeypatch):

--- a/tests/test_date_entry_page.py
+++ b/tests/test_date_entry_page.py
@@ -174,11 +174,10 @@ def test_handle_date_alert(monkeypatch):
 
     def fake_handle(driver):
         calls.append("handled")
-        raise SystemExit()
+        return False
 
     monkeypatch.setattr(page.alert_handler, "handle_date_alert", fake_handle)
-    with pytest.raises(SystemExit):
-        page._handle_date_alert("drv")
+    assert page._handle_date_alert("drv") is False
     assert "handled" in calls
 
 


### PR DESCRIPTION
## Contexte et objectif
- éviter l'appel direct à `sys.exit` lors d'une alerte de date
- permettre à l'orchestrateur de gérer l'arrêt du flux
- mettre à jour les tests unitaires concernés

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
- `AlertHandler` renvoie désormais un booléen
- l'orchestrateur stoppe le traitement si une alerte est détectée

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6883a826d0ec8321acc81a345ef32b34