### PR TITLE
[ResourceManager] introduce ResourceContext

### DIFF
--- a/src/sele_saisie_auto/resources/resource_context.py
+++ b/src/sele_saisie_auto/resources/resource_context.py
@@ -1,0 +1,46 @@
+"""Context managing encryption and shared memory lifecycle."""
+
+from __future__ import annotations
+
+from sele_saisie_auto.encryption_utils import Credentials, EncryptionService
+
+__all__ = ["ResourceContext"]
+
+
+class ResourceContext:
+    """Manage encrypted credentials and memory cleanup."""
+
+    def __init__(
+        self, log_file: str, encryption_service: EncryptionService | None = None
+    ) -> None:
+        self.log_file = log_file
+        self.encryption_service = encryption_service or EncryptionService(log_file)
+        self._credentials: Credentials | None = None
+
+    def __enter__(self) -> "ResourceContext":
+        if hasattr(self.encryption_service, "__enter__"):
+            self.encryption_service.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if hasattr(self.encryption_service, "__exit__"):
+            self.encryption_service.__exit__(exc_type, exc, tb)
+        if self._credentials is not None:
+            for mem in (
+                self._credentials.mem_key,
+                self._credentials.mem_login,
+                self._credentials.mem_password,
+            ):
+                if mem is not None:
+                    try:
+                        self.encryption_service.shared_memory_service.supprimer_memoire_partagee_securisee(
+                            mem
+                        )
+                    except Exception:  # nosec B110 - cleanup best effort
+                        pass
+        self._credentials = None
+
+    def get_credentials(self) -> Credentials:
+        if self._credentials is None:
+            self._credentials = self.encryption_service.retrieve_credentials()
+        return self._credentials


### PR DESCRIPTION
## Summary
- create `ResourceContext` to handle AES and shared memory
- refactor `ResourceManager` to rely on `ResourceContext`
- update resource manager tests

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/resources/resource_manager.py src/sele_saisie_auto/resources/resource_context.py tests/test_resource_manager.py`
- `poetry run pytest tests/test_resource_manager.py::test_resource_manager_basic -q`
- `poetry run pytest tests/test_automation_orchestrator.py::test_run_calls_services -q`
- `poetry run pytest tests/test_saisie_automatiser_psatime_extra.py::test_initialize_shared_memory_error -q` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6883af1fb2a88321ac23753cf71b06b2