### PR TITLE
[ResourceManager] expose decrypted credential helper

### DIFF
--- a/src/sele_saisie_auto/resources/resource_manager.py
+++ b/src/sele_saisie_auto/resources/resource_manager.py
@@ -102,6 +102,18 @@ class ResourceManager:
             self._credentials = self._resource_context.get_credentials()
         return self._credentials
 
+    def read_credentials(self) -> tuple[str, str]:
+        """Return decrypted credentials using the encryption service."""
+
+        creds = self.get_credentials()
+        login = self._encryption_service.dechiffrer_donnees(
+            creds.login, creds.aes_key
+        )
+        password = self._encryption_service.dechiffrer_donnees(
+            creds.password, creds.aes_key
+        )
+        return login, password
+
     def initialize_shared_memory(self, logger: Logger | None = None) -> Credentials:
         """Retrieve credentials and ensure shared memory is initialized."""
 


### PR DESCRIPTION
## Contexte
- le `ResourceManager` ne proposait pas d'API simple pour obtenir les identifiants
  déchiffrés.

## Changements
- ajout de `read_credentials()` dans `ResourceManager`

## Tests
- `poetry run pytest -q tests/test_shared_utils.py`
- `poetry run pytest -q` *(échecs attendus sur la suite complète)*

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6883b470da0c8321b00b136ded18ec1b