### PR TITLE
[SharedMemoryService] Vérification du segment

### DIFF
--- a/tests/test_encryption_service.py
+++ b/tests/test_encryption_service.py
@@ -127,6 +127,17 @@ def test_recuperer_de_memoire_partagee_error(monkeypatch):
         service.recuperer_de_memoire_partagee("name", 4)
 
 
+def test_recuperer_de_memoire_partagee_warning(monkeypatch):
+    logs = []
+    logger = Logger(None, writer=lambda *a, **k: None)
+    monkeypatch.setattr(logger, "warning", lambda msg: logs.append(msg))
+    service = SharedMemoryService(logger)
+    name = f"missing_{uuid4().hex}"
+    with pytest.raises(FileNotFoundError):
+        service.recuperer_de_memoire_partagee(name, 4)
+    assert logs and "not accessible" in logs[0]
+
+
 def test_dechiffrer_donnees_error(monkeypatch):
     service = EncryptionService()
     key = service.generer_cle_aes()


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un contrôle préalable dans `SharedMemoryService` pour vérifier l'existence d'un segment de mémoire avant ouverture. Un avertissement est désormais journalisé si la mémoire n'est pas accessible.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact sur les autres agents
Aucun impact identifié, la logique reste compatible.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6883c1264f948321bef93a64590fb8a0