### PR TITLE
[PSATimeAutomation] Assurer cleanup via try-finally

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -644,10 +644,14 @@ def main(
 
     with get_logger(log_file):
         cfg = ConfigManager(log_file=log_file).load()
-        PSATimeAutomation(log_file, cfg).run(
-            headless=headless,
-            no_sandbox=no_sandbox,
-        )
+        automation = PSATimeAutomation(log_file, cfg)
+        try:
+            automation.run(
+                headless=headless,
+                no_sandbox=no_sandbox,
+            )
+        finally:
+            automation.resource_manager.close()
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Contexte
Ajout d'un bloc `try/finally` dans `main()` afin de garantir la fermeture du navigateur et de la mémoire partagée, même si `run()` échoue.

## Étapes pour tester
1. `poetry run pre-commit run --files src/sele_saisie_auto/saisie_automatiser_psatime.py`
2. `poetry run pytest -q`

## Impact
Aucun impact fonctionnel attendu, uniquement une meilleure gestion des ressources.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6883cb77101483219f6222e5e782b71e