### PR TITLE
[ResourceManager] injection d'encryption service

### DIFF
--- a/src/sele_saisie_auto/interfaces/__init__.py
+++ b/src/sele_saisie_auto/interfaces/__init__.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 from .protocols import (
-    LoggerProtocol,
-    WaiterProtocol,
-    BrowserSessionProtocol,
-    LoginHandlerProtocol,
-    DateEntryPageProtocol,
     AdditionalInfoPageProtocol,
+    BrowserSessionProtocol,
+    DateEntryPageProtocol,
+    LoggerProtocol,
+    LoginHandlerProtocol,
     TimeSheetHelperProtocol,
+    WaiterProtocol,
 )
 
 __all__ = [

--- a/src/sele_saisie_auto/interfaces/protocols.py
+++ b/src/sele_saisie_auto/interfaces/protocols.py
@@ -17,7 +17,10 @@ class LoggerProtocol(Protocol):
     def critical(self, message: str) -> None: ...
 
     def __enter__(self) -> "LoggerProtocol": ...
-    def __exit__(self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any) -> None: ...
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc: BaseException | None, tb: Any
+    ) -> None: ...
 
 
 @runtime_checkable
@@ -35,7 +38,14 @@ class BrowserSessionProtocol(Protocol):
     waiter: WaiterProtocol
     app_config: AppConfig | None
 
-    def open(self, url: str, *, fullscreen: bool = False, headless: bool = False, no_sandbox: bool = False): ...
+    def open(
+        self,
+        url: str,
+        *,
+        fullscreen: bool = False,
+        headless: bool = False,
+        no_sandbox: bool = False,
+    ): ...
     def close(self) -> None: ...
     def wait_for_dom(self, driver) -> None: ...
     def go_to_iframe(self, id_or_name: str) -> bool: ...
@@ -44,7 +54,9 @@ class BrowserSessionProtocol(Protocol):
 
 @runtime_checkable
 class LoginHandlerProtocol(Protocol):
-    def connect_to_psatime(self, driver, aes_key: bytes, encrypted_login: bytes, encrypted_password: bytes) -> None: ...
+    def connect_to_psatime(
+        self, driver, aes_key: bytes, encrypted_login: bytes, encrypted_password: bytes
+    ) -> None: ...
 
 
 @runtime_checkable

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -49,6 +49,14 @@ def test_run_calls_services(monkeypatch, sample_config):
     shm_service = DummySHMService()
 
     ctx = SaisieContext(app_cfg, enc_service, shm_service, {}, [])
+    from sele_saisie_auto.orchestration import automation_orchestrator as orch_mod
+    from sele_saisie_auto.resources import resource_manager as rm
+
+    monkeypatch.setattr(
+        orch_mod,
+        "ResourceManager",
+        lambda log_file: rm.ResourceManager(log_file, enc_service),
+    )
 
     orch = AutomationOrchestrator(
         app_cfg,
@@ -172,6 +180,14 @@ def test_run_order(monkeypatch, sample_config):
             pass
 
     ctx = SaisieContext(app_cfg, DummyEncService(), DummySHMService(), {}, [])
+    from sele_saisie_auto.orchestration import automation_orchestrator as orch_mod
+    from sele_saisie_auto.resources import resource_manager as rm
+
+    monkeypatch.setattr(
+        orch_mod,
+        "ResourceManager",
+        lambda log_file: rm.ResourceManager(log_file, DummyEncService()),
+    )
     orch = AutomationOrchestrator(
         app_cfg,
         logger,
@@ -237,6 +253,14 @@ def test_run_uses_passed_cleanup_function(monkeypatch, sample_config):
     shm_service = DummySHMService()
 
     ctx = SaisieContext(app_cfg, enc_service, shm_service, {}, [])
+    from sele_saisie_auto.orchestration import automation_orchestrator as orch_mod
+    from sele_saisie_auto.resources import resource_manager as rm
+
+    monkeypatch.setattr(
+        orch_mod,
+        "ResourceManager",
+        lambda log_file: rm.ResourceManager(log_file, enc_service),
+    )
 
     cleanup_args = {}
 

--- a/tests/test_full_automation.py
+++ b/tests/test_full_automation.py
@@ -124,7 +124,6 @@ def test_full_automation(monkeypatch, sample_config):
     logger = Logger(log_file)
 
     monkeypatch.setattr(resource_manager, "ConfigManager", DummyConfigManager)
-    monkeypatch.setattr(resource_manager, "EncryptionService", DummyEncryption)
     monkeypatch.setattr(
         "sele_saisie_auto.automation.browser_session.SeleniumDriverManager",
         DummyManager,
@@ -138,7 +137,7 @@ def test_full_automation(monkeypatch, sample_config):
         lambda *a, **k: types.SimpleNamespace(traiter_description=lambda *a, **k: None),
     )
 
-    with resource_manager.ResourceManager(log_file) as rm:
+    with resource_manager.ResourceManager(log_file, DummyEncryption(log_file)) as rm:
         ctx = SaisieContext(APP_CFG, rm._encryption_service, DummySHMService(), {}, [])
         automation = DummyAutomation(log_file, ctx, rm._session, logger)
         login = LoginHandler(log_file, rm._encryption_service, rm._session)

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -187,9 +187,10 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
     monkeypatch.setattr(sap, "LoginHandler", DummyLoginHandler)
     monkeypatch.setattr(sap, "DateEntryPage", DummyDateEntryPage)
     monkeypatch.setattr(sap, "AdditionalInfoPage", DummyAdditionalInfoPage)
+    from sele_saisie_auto.resources import resource_manager as rm
+
     if patch_services:
         from sele_saisie_auto.configuration import Services
-        from sele_saisie_auto.resources import resource_manager as rm
         from sele_saisie_auto.selenium_utils.waiter_factory import get_waiter
 
         def fake_build(cfg_b, lf_b):
@@ -214,7 +215,17 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
                 log_file, cfg, waiter=waiter
             ),
         )
-        monkeypatch.setattr(rm, "EncryptionService", lambda log_file: DummyEnc())
+        monkeypatch.setattr(
+            sap,
+            "ResourceManager",
+            lambda log_file: rm.ResourceManager(log_file, DummyEnc()),
+        )
+    else:
+        monkeypatch.setattr(
+            sap,
+            "ResourceManager",
+            lambda log_file: rm.ResourceManager(log_file, DummyEnc()),
+        )
     auto = sap.PSATimeAutomation("log.html", app_cfg)
     service_configurator = ServiceConfigurator(app_cfg)
     orch = AutomationOrchestrator.from_components(

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -109,7 +109,11 @@ def setup_init(monkeypatch, cfg):
         "BrowserSession",
         lambda log_file, cfg=app_cfg: DummyBrowserSession(log_file, cfg, waiter=waiter),
     )
-    monkeypatch.setattr(rm, "EncryptionService", lambda log_file: DummyEnc())
+    monkeypatch.setattr(
+        sap,
+        "ResourceManager",
+        lambda log_file: rm.ResourceManager(log_file, DummyEnc()),
+    )
     auto = sap.PSATimeAutomation("log.html", app_cfg)
     service_configurator = ServiceConfigurator(app_cfg)
     orch = AutomationOrchestrator.from_components(

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -79,6 +79,9 @@ def test_initialize_shared_memory_error(monkeypatch, sample_config):
     )
     sap.context.encryption_service = DummyEnc()
     sap.context.shared_memory_service = DummySHMService()
+    sap._ORCHESTRATOR.resource_manager._resource_context.encryption_service = (
+        sap._ORCHESTRATOR.resource_manager._encryption_service
+    )
     monkeypatch.setattr(
         sap._ORCHESTRATOR.resource_manager._encryption_service,
         "retrieve_credentials",


### PR DESCRIPTION
## Contexte
- `ResourceManager` devait accepter un `EncryptionService` injectable
- les tests utilisaient l'ancien alias `EncryptionService = ResourceContext`

## Changements
- ajout d'un paramètre `encryption_service` dans `ResourceManager`
- suppression de l'alias d'héritage
- adaptation des contextes de tests et des ressources
- mise à jour des tests pour utiliser l'injection

## Impact
- `ResourceManager` peut recevoir n'importe quel service de chiffrement
- ajustement des tests pour refléter ce nouveau fonctionnement

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6883f5d169488321a56d440b4623de22