### PR TITLE
Inject AlertHandler in AutomationOrchestrator

### DIFF
--- a/src/sele_saisie_auto/alerts/alert_handler.py
+++ b/src/sele_saisie_auto/alerts/alert_handler.py
@@ -9,7 +9,7 @@ from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.exceptions import AutomationExitError
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import format_message, write_log
-from sele_saisie_auto.selenium_utils import Waiter
+from sele_saisie_auto.selenium_utils import Waiter, click_element_without_wait
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -66,15 +66,13 @@ class AlertHandler:
         AutomationExitError
             If a conflicting date alert was found and closed.
         """
-        from sele_saisie_auto import saisie_automatiser_psatime as sap
-
         if self.browser_session is not None:
             self.browser_session.go_to_default_content()
         for alerte in self.alert_configs.get("date_alerts", []):
             if self.waiter.wait_for_element(
                 driver, By.ID, alerte, timeout=self.config.default_timeout
             ):
-                sap.click_element_without_wait(driver, By.ID, Locators.CONFIRM_OK.value)
+                click_element_without_wait(driver, By.ID, Locators.CONFIRM_OK.value)
                 write_log(
                     format_message("TIME_SHEET_EXISTS_ERROR", {}),
                     self.log_file,
@@ -91,8 +89,6 @@ class AlertHandler:
 
     def handle_save_alerts(self, driver) -> None:
         """Dismiss any alert shown after saving."""
-        from sele_saisie_auto import saisie_automatiser_psatime as sap
-
         alerts = self.alert_configs.get("save_alerts", [])
         if self.browser_session is not None:
             self.browser_session.go_to_default_content()
@@ -100,7 +96,7 @@ class AlertHandler:
             if self.waiter.wait_for_element(
                 driver, By.ID, alerte, timeout=self.config.default_timeout
             ):
-                sap.click_element_without_wait(driver, By.ID, Locators.CONFIRM_OK.value)
+                click_element_without_wait(driver, By.ID, Locators.CONFIRM_OK.value)
                 write_log(
                     format_message("SAVE_ALERT_WARNING", {}),
                     self.log_file,

--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Callable
 
 from selenium.webdriver.common.by import By
 
+from sele_saisie_auto.alerts import AlertHandler
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import ServiceConfigurator
@@ -56,6 +57,7 @@ class AutomationOrchestrator:
         context: SaisieContext,
         choix_user: bool = True,
         *,
+        alert_handler: AlertHandler | None = None,
         timesheet_helper_cls: type[TimeSheetHelperProtocol] = TimeSheetHelper,
         cleanup_resources: Callable[[object, object, object], None] | None = None,
         resource_manager: ResourceManager | None = None,
@@ -72,6 +74,9 @@ class AutomationOrchestrator:
         self._cleanup_callback = cleanup_resources
         self.resource_manager = resource_manager or ResourceManager(logger.log_file)
         self.page_navigator: PageNavigator | None = None
+        self.log_file = logger.log_file
+        self.waiter = getattr(browser_session, "waiter", None)
+        self.alert_handler = alert_handler or AlertHandler(self, waiter=self.waiter)
         try:
             self.resource_manager._encryption_service = context.encryption_service
             self.resource_manager._config_manager = types.SimpleNamespace(
@@ -95,6 +100,7 @@ class AutomationOrchestrator:
         logger: LoggerProtocol,
         choix_user: bool = True,
         *,
+        alert_handler: AlertHandler | None = None,
         timesheet_helper_cls: type[TimeSheetHelperProtocol] = TimeSheetHelper,
         cleanup_resources: Callable[[object, object, object], None] | None = None,
     ) -> AutomationOrchestrator:
@@ -109,6 +115,7 @@ class AutomationOrchestrator:
             page_navigator.additional_info_page,
             context,
             choix_user,
+            alert_handler=alert_handler,
             timesheet_helper_cls=timesheet_helper_cls,
             cleanup_resources=cleanup_resources,
             resource_manager=resource_manager,

--- a/tests/test_alert_handler.py
+++ b/tests/test_alert_handler.py
@@ -34,7 +34,7 @@ def test_handle_alerts_clicks_confirm_ok_and_logs(monkeypatch):
         clicks.append((by, locator))
 
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.click_element_without_wait",
+        "sele_saisie_auto.alerts.alert_handler.click_element_without_wait",
         fake_click,
     )
 
@@ -55,11 +55,11 @@ def test_handle_alerts_date(monkeypatch):
     handler = AlertHandler(dummy)
     monkeypatch.setattr(handler.waiter, "wait_for_element", lambda *a, **k: True)
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.click_element_without_wait",
+        "sele_saisie_auto.alerts.alert_handler.click_element_without_wait",
         lambda *a, **k: None,
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.saisie_automatiser_psatime.write_log",
+        "sele_saisie_auto.alerts.alert_handler.write_log",
         lambda *a, **k: None,
     )
     with pytest.raises(AutomationExitError):


### PR DESCRIPTION
## Summary
- allow AutomationOrchestrator to receive an AlertHandler dependency
- drop direct import of `saisie_automatiser_psatime` in AlertHandler
- update AlertHandler tests for the new import path

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/alerts/alert_handler.py tests/test_alert_handler.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fe87140483218f5ddab14f89d9fd