### PR TITLE
[LoginHandler] expose login handler via services

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -140,6 +140,7 @@ class PSATimeAutomation:
         self.waiter = self.services.waiter
         self.browser_session = self.services.browser_session
         self.encryption_service = self.services.encryption_service
+        self._login_handler = getattr(self.services, "login_handler", None)
         self.context = SaisieContext(
             config=app_config,
             encryption_service=self.encryption_service,
@@ -348,15 +349,19 @@ class PSATimeAutomation:
     @property
     def login_handler(self) -> LoginHandler:
         if self._login_handler is None:
-            cls = LoginHandler
-            if hasattr(cls, "from_automation"):
-                self._login_handler = cls.from_automation(self)
-            else:  # pragma: no cover - fallback for patched classes
-                self._login_handler = cls(
-                    self.log_file,
-                    self.encryption_service,
-                    self.browser_session,
-                )
+            handler = getattr(self.services, "login_handler", None)
+            if handler is not None:
+                self._login_handler = handler
+            else:
+                cls = LoginHandler
+                if hasattr(cls, "from_automation"):
+                    self._login_handler = cls.from_automation(self)
+                else:  # pragma: no cover - fallback for patched classes
+                    self._login_handler = cls(
+                        self.log_file,
+                        self.encryption_service,
+                        self.browser_session,
+                    )
         return self._login_handler
 
     @property

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -195,11 +195,10 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
 
         def fake_build(cfg_b, lf_b):
             waiter = get_waiter(cfg_b)
-            return Services(
-                DummyEnc(),
-                sap.BrowserSession(lf_b, cfg_b, waiter=waiter),
-                waiter,
-            )
+            session = sap.BrowserSession(lf_b, cfg_b, waiter=waiter)
+            enc = DummyEnc()
+            login = sap.LoginHandler(lf_b, enc, session)
+            return Services(enc, session, waiter, login)
 
         monkeypatch.setattr(sap, "build_services", fake_build)
         waiter = get_waiter(app_cfg)
@@ -287,7 +286,7 @@ def test_initialize_sets_globals(monkeypatch, sample_config):
 def test_init_services(monkeypatch, sample_config):
     from sele_saisie_auto.configuration import Services
 
-    dummy = Services(None, None, None)
+    dummy = Services(None, None, None, None)
     called = {}
 
     def fake_build(cfg, lf):

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -93,9 +93,10 @@ def setup_init(monkeypatch, cfg):
 
     def fake_build(cfg_b, lf_b):
         waiter = get_waiter(cfg_b)
-        return Services(
-            DummyEnc(), sap.BrowserSession(lf_b, cfg_b, waiter=waiter), waiter
-        )
+        session = sap.BrowserSession(lf_b, cfg_b, waiter=waiter)
+        enc = DummyEnc()
+        login = sap.LoginHandler(lf_b, enc, session)
+        return Services(enc, session, waiter, login)
 
     monkeypatch.setattr(sap, "build_services", fake_build)
     waiter = get_waiter(app_cfg)

--- a/tests/test_service_configurator.py
+++ b/tests/test_service_configurator.py
@@ -1,7 +1,7 @@
 import pytest
 
 from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
-from sele_saisie_auto.automation import BrowserSession
+from sele_saisie_auto.automation import BrowserSession, LoginHandler
 from sele_saisie_auto.configuration import ServiceConfigurator, Services, build_services
 from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.selenium_utils import Waiter
@@ -15,6 +15,7 @@ def test_build_services(sample_config):
     assert isinstance(services.encryption_service, EncryptionService)
     assert isinstance(services.browser_session, BrowserSession)
     assert isinstance(services.waiter, Waiter)
+    assert isinstance(services.login_handler, LoginHandler)
     assert services.browser_session.app_config is app_cfg
     assert services.browser_session.waiter is services.waiter
 
@@ -121,6 +122,7 @@ def test_service_configurator_build_services(sample_config):
     assert isinstance(services.encryption_service, EncryptionService)
     assert isinstance(services.browser_session, BrowserSession)
     assert isinstance(services.waiter, Waiter)
+    assert isinstance(services.login_handler, LoginHandler)
     assert services.browser_session.app_config is app_cfg
     assert services.browser_session.waiter is services.waiter
     assert services.waiter.wrapper.default_timeout == app_cfg.default_timeout


### PR DESCRIPTION
## Contexte
- le `LoginHandler` n'était pas fourni par le `ServiceConfigurator`
- certains tests simulaient la construction des services manuellement

## Changements
- création d'un `login_handler` dans `ServiceConfigurator`
- ajout de `login_handler` dans la dataclass `Services`
- injection du handler dans `PSATimeAutomation`
- mise à jour des tests pour refléter ces modifications

## Instructions de test
- `poetry run pre-commit run --files src/sele_saisie_auto/configuration/service_configurator.py src/sele_saisie_auto/saisie_automatiser_psatime.py tests/test_service_configurator.py tests/test_saisie_automatiser_psatime_additional.py tests/test_saisie_automatiser_psatime.py`
- `poetry run pytest -q`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68840717d1ac832183d2fb9ab23b9ab8