### PR TITLE
[ServiceConfigurator] unifier la création via factory

### DIFF
--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -6,7 +6,7 @@ import argparse
 
 from sele_saisie_auto import __version__
 from sele_saisie_auto.config_manager import ConfigManager
-from sele_saisie_auto.configuration import ServiceConfigurator
+from sele_saisie_auto.configuration import service_configurator_factory
 from sele_saisie_auto.logger_utils import LOG_LEVELS
 from sele_saisie_auto.logging_service import LoggingConfigurator, get_logger
 from sele_saisie_auto.orchestration import AutomationOrchestrator
@@ -53,7 +53,7 @@ def main(argv: list[str] | None = None) -> None:
         cfg = ConfigManager(log_file=log_file).load()
         LoggingConfigurator.setup(log_file, args.log_level, cfg.raw)
 
-        service_configurator = ServiceConfigurator(cfg)
+        service_configurator = service_configurator_factory(cfg)
         services = service_configurator.build_services(log_file)
 
         automation = PSATimeAutomation(

--- a/src/sele_saisie_auto/configuration/__init__.py
+++ b/src/sele_saisie_auto/configuration/__init__.py
@@ -1,3 +1,17 @@
+from sele_saisie_auto.app_config import AppConfig
+
 from .service_configurator import ServiceConfigurator, Services, build_services
 
-__all__ = ["Services", "build_services", "ServiceConfigurator"]
+
+def service_configurator_factory(app_config: AppConfig) -> ServiceConfigurator:
+    """Return a :class:`ServiceConfigurator` for ``app_config``."""
+
+    return ServiceConfigurator.from_config(app_config)
+
+
+__all__ = [
+    "Services",
+    "build_services",
+    "ServiceConfigurator",
+    "service_configurator_factory",
+]

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -27,7 +27,7 @@ from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.automation.date_entry_page import DateEntryPage
 from sele_saisie_auto.automation.login_handler import LoginHandler
 from sele_saisie_auto.config_manager import ConfigManager
-from sele_saisie_auto.configuration import ServiceConfigurator, Services, build_services
+from sele_saisie_auto.configuration import Services, service_configurator_factory
 from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.encryption_utils import Credentials as EncryptionCredentials
 from sele_saisie_auto.encryption_utils import EncryptionService
@@ -357,7 +357,7 @@ class PSATimeAutomation:
     def _init_services(self, app_config: AppConfig) -> Services:
         """Initialise les services principaux via :class:`ServiceConfigurator`."""
 
-        configurator = ServiceConfigurator.from_config(app_config)
+        configurator = service_configurator_factory(app_config)
         self.services = configurator.build_services(self.log_file)
         return self.services
 
@@ -591,7 +591,7 @@ class PSATimeAutomation:
     ) -> None:  # pragma: no cover
         """Point d'entrée principal de l'automatisation."""
 
-        service_configurator = ServiceConfigurator(self.context.config)
+        service_configurator = service_configurator_factory(self.context.config)
         self.orchestrator = AutomationOrchestrator.from_components(
             self.resource_manager,
             self.page_navigator,
@@ -730,7 +730,7 @@ def initialize(
     )
     context = _AUTOMATION.context
     LOG_FILE = log_file
-    service_configurator = ServiceConfigurator(_AUTOMATION.context.config)
+    service_configurator = service_configurator_factory(_AUTOMATION.context.config)
     _ORCHESTRATOR = AutomationOrchestrator.from_components(
         _AUTOMATION.resource_manager,
         _AUTOMATION.page_navigator,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,9 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
             service_calls["log_file"] = log_file
             return "services"
 
-    monkeypatch.setattr(cli, "ServiceConfigurator", DummyConfigurator)
+    monkeypatch.setattr(
+        cli, "service_configurator_factory", lambda cfg: DummyConfigurator(cfg)
+    )
 
     auto_data = {}
 

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -178,9 +178,7 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
                 return Services(enc, session, waiter, login)
 
         monkeypatch.setattr(
-            ServiceConfigurator,
-            "from_config",
-            staticmethod(lambda cfg_b: DummyConfigurator(cfg_b)),
+            sap, "service_configurator_factory", lambda cfg_b: DummyConfigurator(cfg_b)
         )
         waiter = get_waiter(app_cfg)
         monkeypatch.setattr(
@@ -279,9 +277,7 @@ def test_init_services(monkeypatch, sample_config):
             return dummy
 
     monkeypatch.setattr(
-        ServiceConfigurator,
-        "from_config",
-        staticmethod(lambda cfg: DummyConfigurator(cfg)),
+        sap, "service_configurator_factory", lambda cfg: DummyConfigurator(cfg)
     )
 
     setup_init(monkeypatch, sample_config, patch_services=False)

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -103,9 +103,7 @@ def setup_init(monkeypatch, cfg):
             return Services(enc, session, waiter, login)
 
     monkeypatch.setattr(
-        ServiceConfigurator,
-        "from_config",
-        staticmethod(lambda cfg_b: DummyConfigurator(cfg_b)),
+        sap, "service_configurator_factory", lambda cfg_b: DummyConfigurator(cfg_b)
     )
     waiter = get_waiter(app_cfg)
     monkeypatch.setattr(


### PR DESCRIPTION
## Contexte
Ajout d'une factory dédiée dans `configuration/__init__.py` pour créer un
`ServiceConfigurator`. Cette fonction est maintenant utilisée par les modules
principaux (CLI et automatisation) afin d'éviter la duplication de code.
Les tests concernés ont été adaptés pour patcher cette factory.

## Impact
- nouvelle fonction `service_configurator_factory`
- appel de cette factory dans la CLI et l'automatisation
- mise à jour des tests utilisant un configurateur

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6887428e1cac8321a2104d2ac3c9fa70