### PR TITLE
[SeleniumUtils] Simplifie WaiterFactory

### DIFF
--- a/src/sele_saisie_auto/alerts/alert_handler.py
+++ b/src/sele_saisie_auto/alerts/alert_handler.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING, Any
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
-import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory  # noqa: N812
 from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 from sele_saisie_auto.exceptions import AutomationExitError
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import format_message, write_log
 from sele_saisie_auto.selenium_utils import click_element_without_wait
+from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -48,7 +48,12 @@ class AlertHandler:
                 if isinstance(cfg, ConfigParser)
                 else None
             )
-            self.waiter = WaiterFactory.get_waiter(app_cfg)
+            timeout = DEFAULT_TIMEOUT
+            if app_cfg is not None and hasattr(app_cfg, "default_timeout"):
+                timeout = app_cfg.default_timeout
+            self.waiter = create_waiter(timeout)
+            if app_cfg is not None and hasattr(app_cfg, "long_timeout"):
+                self.waiter.wrapper.long_timeout = app_cfg.long_timeout
         else:
             self.waiter = waiter
 

--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
-import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory  # noqa: N812
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.interfaces import WaiterProtocol
@@ -15,6 +14,7 @@ from sele_saisie_auto.selenium_utils import (
     ouvrir_navigateur_sur_ecran_principal,
     wait_for_dom_ready,
 )
+from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 
@@ -85,7 +85,12 @@ class BrowserSession:
         self.log_file = log_file
         self.app_config = app_config
         if waiter is None:
-            self.waiter: WaiterProtocol = WaiterFactory.get_waiter(app_config)
+            timeout = DEFAULT_TIMEOUT
+            if app_config is not None and hasattr(app_config, "default_timeout"):
+                timeout = app_config.default_timeout
+            self.waiter = create_waiter(timeout)
+            if app_config is not None and hasattr(app_config, "long_timeout"):
+                self.waiter.wrapper.long_timeout = app_config.long_timeout
         else:
             self.waiter = waiter
         if app_config is not None:

--- a/src/sele_saisie_auto/remplir_informations_supp_utils.py
+++ b/src/sele_saisie_auto/remplir_informations_supp_utils.py
@@ -2,18 +2,20 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+
 from selenium.webdriver.remote.webdriver import WebDriver
 
-import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory  # noqa: N812
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.form_processing.description_processor import process_description
 from sele_saisie_auto.logging_service import Logger
 from sele_saisie_auto.selenium_utils import Waiter
+from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.strategies import (
     ElementFillingContext,
     InputFillingStrategy,
     SelectFillingStrategy,
 )
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 
 # remplir_informations_supp_france.py
 
@@ -67,7 +69,12 @@ class ExtraInfoHelper:
     ) -> None:
         """Initialise l'assistant avec ``Logger`` et ``Waiter``."""
         if waiter is None:
-            self.waiter = WaiterFactory.get_waiter(app_config)
+            timeout = DEFAULT_TIMEOUT
+            if hasattr(app_config, "default_timeout"):
+                timeout = app_config.default_timeout
+            self.waiter = create_waiter(timeout)
+            if hasattr(app_config, "long_timeout"):
+                self.waiter.wrapper.long_timeout = app_config.long_timeout
         else:
             self.waiter = waiter
         self.page = page
@@ -91,7 +98,9 @@ class ExtraInfoHelper:
     # ------------------------------------------------------------------
     # Delegation to :class:`AdditionalInfoPage`
     # ------------------------------------------------------------------
-    def navigate_from_work_schedule_to_additional_information_page(self, driver: WebDriver) -> Any:
+    def navigate_from_work_schedule_to_additional_information_page(
+        self, driver: WebDriver
+    ) -> Any:
         """Ouvre la fenêtre des informations supplémentaires."""
         if not self.page:
             raise RuntimeError("AdditionalInfoPage not configured")

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -17,7 +17,6 @@ from selenium.common.exceptions import (
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
-import sele_saisie_auto.selenium_utils.waiter_factory as WaiterFactory  # noqa: N812
 from sele_saisie_auto import messages
 from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 from sele_saisie_auto.constants import (
@@ -46,6 +45,7 @@ from sele_saisie_auto.selenium_utils import (
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 
@@ -450,9 +450,13 @@ class TimeSheetHelper:
         if waiter is None:
             cfg = context.config
             app_cfg = None
+            timeout = DEFAULT_TIMEOUT
             if isinstance(cfg, ConfigParser):
                 app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
-            self.waiter = WaiterFactory.get_waiter(app_cfg)
+                timeout = app_cfg.default_timeout
+            self.waiter = create_waiter(timeout)
+            if app_cfg is not None:
+                self.waiter.wrapper.long_timeout = app_cfg.long_timeout
         else:
             self.waiter = waiter
         global LOG_FILE

--- a/src/sele_saisie_auto/selenium_utils/__init__.py
+++ b/src/sele_saisie_auto/selenium_utils/__init__.py
@@ -68,7 +68,7 @@ from .wait_helpers import (
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from .waiter_factory import get_waiter
+from .waiter_factory import create_waiter
 from .wrapper import Wrapper, is_document_complete
 
 __all__ = [
@@ -87,7 +87,7 @@ __all__ = [
     "find_present",
     "Wrapper",
     "Waiter",
-    "get_waiter",
+    "create_waiter",
     "modifier_date_input",
     "switch_to_frame_by_id",
     "switch_to_iframe_by_id_or_name",

--- a/src/sele_saisie_auto/selenium_utils/waiter_factory.py
+++ b/src/sele_saisie_auto/selenium_utils/waiter_factory.py
@@ -1,16 +1,25 @@
-"""Factory to create configured :class:`Waiter` instances."""
+"""Utility to create configured :class:`Waiter` objects."""
 
 from __future__ import annotations
 
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
+
+
+def create_waiter(timeout: int) -> Waiter:
+    """Return a :class:`Waiter` using ``timeout`` for its delays."""
+    return Waiter(default_timeout=timeout, long_timeout=timeout * 2)
 
 
 def get_waiter(app_config: AppConfig | None) -> Waiter:
-    """Return a :class:`Waiter` configured with ``app_config`` timeouts."""
-    if app_config is None:
-        return Waiter()
-    from sele_saisie_auto.configuration import ServiceConfigurator
+    """Return a :class:`Waiter` configured from ``app_config``."""
+    timeout = DEFAULT_TIMEOUT
+    long_timeout = DEFAULT_TIMEOUT * 2
+    if app_config is not None:
+        timeout = getattr(app_config, "default_timeout", DEFAULT_TIMEOUT)
+        long_timeout = getattr(app_config, "long_timeout", timeout * 2)
+    return Waiter(default_timeout=timeout, long_timeout=long_timeout)
 
-    configurator = ServiceConfigurator.from_config(app_config)
-    return configurator.create_waiter()
+
+__all__ = ["create_waiter", "get_waiter"]

--- a/tests/test_extra_info_helper.py
+++ b/tests/test_extra_info_helper.py
@@ -4,6 +4,8 @@ from pathlib import Path  # noqa: E402
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+import types  # noqa: E402
+
 import pytest  # noqa: E402
 
 import sele_saisie_auto.remplir_informations_supp_utils as risu  # noqa: E402
@@ -132,11 +134,14 @@ def test_submit_without_page(monkeypatch):
 def test_waiter_created_with_factory(monkeypatch):
     captured = {}
 
-    def fake_get_waiter(cfg):
-        captured["cfg"] = cfg
+    def fake_create_waiter(timeout):
+        captured["timeout"] = timeout
         return "w"
 
-    monkeypatch.setattr(risu.WaiterFactory, "get_waiter", fake_get_waiter)
-    helper = ExtraInfoHelper(Logger("log"), app_config="cfg")
+    monkeypatch.setattr(risu, "create_waiter", fake_create_waiter)
+    helper = ExtraInfoHelper(
+        Logger("log"),
+        app_config=types.SimpleNamespace(default_timeout=3, long_timeout=6),
+    )
     assert helper.waiter == "w"
-    assert captured["cfg"] == "cfg"
+    assert captured["timeout"] == 3

--- a/tests/test_full_automation.py
+++ b/tests/test_full_automation.py
@@ -113,8 +113,8 @@ def test_full_automation(monkeypatch, sample_config):
         DummyManager,
     )
     monkeypatch.setattr(
-        "sele_saisie_auto.selenium_utils.waiter_factory.get_waiter",
-        lambda cfg: dummy_waiter,
+        "sele_saisie_auto.selenium_utils.waiter_factory.create_waiter",
+        lambda timeout: dummy_waiter,
     )
     monkeypatch.setattr(
         "sele_saisie_auto.automation.additional_info_page.ExtraInfoHelper",

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -164,14 +164,15 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
 
     if patch_services:
         from sele_saisie_auto.configuration import Services
-        from sele_saisie_auto.selenium_utils.waiter_factory import get_waiter
+        from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 
         class DummyConfigurator:
             def __init__(self, cfg_b):
                 self.cfg = cfg_b
+                self.app_config = cfg_b
 
             def build_services(self, lf_b):
-                waiter = get_waiter(self.cfg)
+                waiter = create_waiter(self.cfg.default_timeout)
                 session = sap.BrowserSession(lf_b, self.cfg, waiter=waiter)
                 enc = FakeEncryptionService()
                 login = sap.LoginHandler(lf_b, enc, session)
@@ -180,7 +181,7 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
         monkeypatch.setattr(
             sap, "service_configurator_factory", lambda cfg_b: DummyConfigurator(cfg_b)
         )
-        waiter = get_waiter(app_cfg)
+        waiter = create_waiter(app_cfg.default_timeout)
         monkeypatch.setattr(
             rm,
             "ConfigManager",

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -89,14 +89,15 @@ def setup_init(monkeypatch, cfg):
     monkeypatch.setattr(sap, "SharedMemoryService", lambda logger: DummySHMService())
     from sele_saisie_auto.configuration import Services
     from sele_saisie_auto.resources import resource_manager as rm
-    from sele_saisie_auto.selenium_utils.waiter_factory import get_waiter
+    from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 
     class DummyConfigurator:
         def __init__(self, cfg_b):
             self.cfg = cfg_b
+            self.app_config = cfg_b
 
         def build_services(self, lf_b):
-            waiter = get_waiter(self.cfg)
+            waiter = create_waiter(self.cfg.default_timeout)
             session = sap.BrowserSession(lf_b, self.cfg, waiter=waiter)
             enc = DummyEnc()
             login = sap.LoginHandler(lf_b, enc, session)
@@ -105,7 +106,7 @@ def setup_init(monkeypatch, cfg):
     monkeypatch.setattr(
         sap, "service_configurator_factory", lambda cfg_b: DummyConfigurator(cfg_b)
     )
-    waiter = get_waiter(app_cfg)
+    waiter = create_waiter(app_cfg.default_timeout)
     monkeypatch.setattr(
         rm,
         "ConfigManager",

--- a/tests/test_waiter_factory.py
+++ b/tests/test_waiter_factory.py
@@ -1,30 +1,10 @@
-from configparser import ConfigParser
-
-from sele_saisie_auto.app_config import AppConfig, AppConfigRaw
 from sele_saisie_auto.selenium_utils import Waiter
-from sele_saisie_auto.selenium_utils.waiter_factory import get_waiter
+from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 
 
-def test_get_waiter_returns_configured_waiter(sample_config):
-    cfg = AppConfig.from_raw(AppConfigRaw(sample_config))
-    waiter = get_waiter(cfg)
+def test_create_waiter_returns_configured_waiter():
+    waiter = create_waiter(5)
 
     assert isinstance(waiter, Waiter)
-    assert waiter.wrapper.default_timeout == cfg.default_timeout
-    assert waiter.wrapper.long_timeout == cfg.long_timeout
-
-
-def test_get_waiter_custom_timeouts():
-    parser = ConfigParser()
-    parser["settings"] = {
-        "url": "http://x",
-        "default_timeout": "5",
-        "long_timeout": "15",
-    }
-    parser["cgi_options_billing_action"] = {"Facturable": "B"}
-
-    cfg = AppConfig.from_raw(AppConfigRaw(parser))
-    waiter = get_waiter(cfg)
-
     assert waiter.wrapper.default_timeout == 5
-    assert waiter.wrapper.long_timeout == 15
+    assert waiter.wrapper.long_timeout == 10


### PR DESCRIPTION
## Contexte
- `waiter_factory.py` ne faisait que retourner un `Waiter` via un configurateur
- simplification demandée pour exposer une fonction unique `create_waiter`

## Changements
- ajout de `create_waiter(timeout)` et maintien d`get_waiter` (compatibilité)
- adaptation des modules utilisant l’ancienne usine
- mise à jour des tests

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6887510c14708321ac668234dbead057