### PR TITLE
[SeleniumFiller] expose cli entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ strict = true
 
 [tool.poetry.scripts]
 psatime-launcher = "sele_saisie_auto.launcher:main"
-psatime-auto = "sele_saisie_auto.saisie_automatiser_psatime:main"
+psatime-auto = "sele_saisie_auto.cli:cli_main"
 
 [tool.ruff]
 line-length = 88

--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -73,4 +73,24 @@ def main(argv: list[str] | None = None) -> None:
         orchestrator.run(headless=args.headless, no_sandbox=args.no_sandbox)
 
 
-__all__ = ["parse_args", "main"]
+def cli_main(
+    log_file: str | None = None,
+    *,
+    headless: bool = False,
+    no_sandbox: bool = False,
+) -> None:
+    """Entry point used by the ``psatime-auto`` console script."""
+
+    if log_file is None:
+        log_file = get_log_file()
+
+    with get_logger(log_file):
+        cfg = ConfigManager(log_file=log_file).load()
+        automation = PSATimeAutomation(log_file, cfg)
+        try:
+            automation.run(headless=headless, no_sandbox=no_sandbox)
+        finally:
+            automation.resource_manager.close()
+
+
+__all__ = ["parse_args", "main", "cli_main"]

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -679,29 +679,15 @@ def main(
     headless: bool = False,
     no_sandbox: bool = False,
 ) -> None:  # pragma: no cover
-    """Point d'entrée principal du script.
+    """Point d'entrée principal du script."""
 
-    Parameters
-    ----------
-    log_file : str | None, optional
-        Chemin du fichier log. S'il vaut ``None``, il sera déterminé via
-        :func:`get_log_file`.
-    """
-    if log_file is None:
-        from sele_saisie_auto.shared_utils import get_log_file
+    from sele_saisie_auto.cli import cli_main
 
-        log_file = get_log_file()
-
-    with get_logger(log_file):
-        cfg = ConfigManager(log_file=log_file).load()
-        automation = PSATimeAutomation(log_file, cfg)
-        try:
-            automation.run(
-                headless=headless,
-                no_sandbox=no_sandbox,
-            )
-        finally:
-            automation.resource_manager.close()
+    cli_main(
+        log_file,
+        headless=headless,
+        no_sandbox=no_sandbox,
+    )
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Contexte et objectif
- exposer la commande `psatime-auto` via `cli.cli_main`
- déplacer l'ancien `main()` de `saisie_automatiser_psatime.py` dans `cli.py`

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/cli.py src/sele_saisie_auto/saisie_automatiser_psatime.py pyproject.toml`
- `poetry run pytest`

## Impact
- modification du point d’entrée CLI

------
https://chatgpt.com/codex/tasks/task_e_68876c25efe48321a980c9803d4ce96e