### PR TITLE
[AutomationOrchestrator] expose orchestrator variable

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -696,6 +696,7 @@ def main(
 
 _AUTOMATION: PSATimeAutomation | None = None
 _ORCHESTRATOR: AutomationOrchestrator | None = None
+orchestrator: AutomationOrchestrator | None = None
 context: SaisieContext | None = None
 LOG_FILE: str | None = None
 
@@ -707,7 +708,7 @@ def initialize(
     memory_config: MemoryConfig | None = None,
 ) -> None:
     """Instancie l'automatisation."""
-    global _AUTOMATION, _ORCHESTRATOR, context, LOG_FILE
+    global _AUTOMATION, _ORCHESTRATOR, orchestrator, context, LOG_FILE
     _AUTOMATION = PSATimeAutomation(
         log_file,
         app_config,
@@ -726,13 +727,25 @@ def initialize(
         choix_user=_AUTOMATION.choix_user,
     )
     _AUTOMATION.orchestrator = _ORCHESTRATOR
+    orchestrator = _ORCHESTRATOR
 
 
 def log_initialisation() -> None:
     """Enregistre les informations initiales dans les logs."""
-    if not _AUTOMATION:
+    if not orchestrator:
         raise AutomationNotInitializedError("Automation non initialisée")
-    _AUTOMATION.log_initialisation()
+    if not orchestrator.log_file:
+        raise RuntimeError(f"Fichier de log {messages.INTROUVABLE}.")
+    write_log(
+        "\ud83d\udccc D\u00e9marrage de la fonction 'saisie_automatiser_psatime.run()'",
+        orchestrator.log_file,
+        "INFO",
+    )
+    write_log(
+        f"\ud83d\udd0d Chemin du fichier log : {orchestrator.log_file}",
+        orchestrator.log_file,
+        "DEBUG",
+    )
 
 
 def initialize_shared_memory() -> EncryptionCredentials:

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -218,6 +218,7 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
     auto.orchestrator = orch
     monkeypatch.setattr(sap, "_AUTOMATION", auto, raising=False)
     monkeypatch.setattr(sap, "_ORCHESTRATOR", orch, raising=False)
+    monkeypatch.setattr(sap, "orchestrator", orch, raising=False)
     monkeypatch.setattr(sap, "context", auto.context, raising=False)
     monkeypatch.setattr(sap, "LOG_FILE", "log.html", raising=False)
     monkeypatch.setattr(
@@ -259,7 +260,7 @@ def test_initialize_sets_globals(monkeypatch, sample_config):
     assert sap.context.config.url == "http://test"
     assert sap.context.config.work_schedule["lundi"] == ("En mission", "8")
     assert sap.context.project_mission_info["billing_action"] == "B"
-    assert sap._AUTOMATION.choix_user is True
+    assert sap.orchestrator.choix_user is True
     assert isinstance(sap._AUTOMATION.memory_config, sap.MemoryConfig)
 
 
@@ -304,7 +305,7 @@ def test_main_flow(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
     sap.context.config.url = "http://test"
     sap.context.config.date_cible = "06/07/2024"
-    sap._AUTOMATION.choix_user = True
+    sap.orchestrator.choix_user = True
 
     monkeypatch.setattr(sap, "log_initialisation", lambda: None)
     monkeypatch.setattr(


### PR DESCRIPTION
## Contexte et objectif
- ajout d'une variable globale `orchestrator` dans `saisie_automatiser_psatime.py`
- initialisation de cette variable dans `initialize`
- `log_initialisation` se base désormais sur cette variable
- mise à jour du test `test_saisie_automatiser_psatime.py`

## Étapes pour tester
1. `poetry run pre-commit run --files src/sele_saisie_auto/saisie_automatiser_psatime.py tests/test_saisie_automatiser_psatime.py`
2. `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688779992ee483219d493bd2c67939ae