### PR TITLE
[utils] centralise est_en_mission

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -48,6 +48,7 @@ from sele_saisie_auto.selenium_utils import (
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
+from sele_saisie_auto.utils.mission import est_en_mission
 
 
 @dataclass
@@ -141,11 +142,6 @@ def wait_for_dom(driver: WebDriver, waiter: WaiterProtocol | None = None) -> Non
     else:
         waiter.wait_until_dom_is_stable(driver, timeout=DEFAULT_TIMEOUT)
         waiter.wait_for_dom_ready(driver, LONG_TIMEOUT)
-
-
-def est_en_mission(description: str) -> bool:
-    """Renvoie True si la description indique un jour 'En mission'."""
-    return description == "En mission"
 
 
 def est_en_mission_presente(work_days: dict[str, tuple[str, str]]) -> bool:
@@ -496,11 +492,11 @@ class TimeSheetHelper:
                 "Jour 'En mission' détecté. Traitement des champs associés..."
             )
             traiter_champs_mission(
-                driver=driver,
-                listes_id_informations_mission=LISTES_ID_INFORMATIONS_MISSION,
-                id_to_key_mapping=ID_TO_KEY_MAPPING,
-                project_mission_info=self.context.project_mission_info,
-                context=self.context,
+                driver,
+                LISTES_ID_INFORMATIONS_MISSION,
+                ID_TO_KEY_MAPPING,
+                self.context.project_mission_info,
+                self.context,
                 waiter=self.waiter,
             )
         else:

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -49,6 +49,7 @@ from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
 from sele_saisie_auto.navigation import PageNavigator
 from sele_saisie_auto.orchestration import AutomationOrchestrator
+from sele_saisie_auto.remplir_jours_feuille_de_temps import ajouter_jour_a_jours_remplis
 from sele_saisie_auto.resources.resource_manager import ResourceManager
 from sele_saisie_auto.selenium_utils import (
     click_element_without_wait,
@@ -61,6 +62,7 @@ from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
+from sele_saisie_auto.utils.mission import est_en_mission
 
 # ----------------------------------------------------------------------------- #
 # ------------------------------- CONSTANTE ----------------------------------- #
@@ -617,18 +619,6 @@ def get_next_saturday_if_not_saturday(date_str: str) -> str:
         next_saturday_date = initial_date + timedelta(days=days_to_next_saturday)
         return next_saturday_date.strftime("%d/%m/%Y")
     return date_str
-
-
-def est_en_mission(description: str) -> bool:
-    """Renvoie True si la description indique un jour 'En mission'."""
-    return description == "En mission"
-
-
-def ajouter_jour_a_jours_remplis(jour: str, filled_days: list[str]) -> list[str]:
-    """Ajoute un jour à la liste jours_remplis si ce n'est pas déjà fait."""
-    if jour not in filled_days:
-        filled_days.append(jour)
-    return filled_days
 
 
 def afficher_message_insertion(

--- a/src/sele_saisie_auto/utils/__init__.py
+++ b/src/sele_saisie_auto/utils/__init__.py
@@ -1,3 +1,3 @@
 """Utility subpackages."""
 
-__all__ = ["misc"]
+__all__ = ["misc", "mission"]

--- a/src/sele_saisie_auto/utils/mission.py
+++ b/src/sele_saisie_auto/utils/mission.py
@@ -1,0 +1,8 @@
+"""Mission related helper functions."""
+
+from __future__ import annotations
+
+
+def est_en_mission(description: str) -> bool:
+    """Return True if the description indicates a mission day."""
+    return description == "En mission"

--- a/tests/test_remplir_jours_utils.py
+++ b/tests/test_remplir_jours_utils.py
@@ -7,11 +7,11 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 from sele_saisie_auto.remplir_jours_feuille_de_temps import (  # noqa: E402
     afficher_message_insertion,
     ajouter_jour_a_jours_remplis,
-    est_en_mission,
     est_en_mission_presente,
     insert_with_retries,
 )
 from sele_saisie_auto.utils.misc import clear_screen  # noqa: E402
+from sele_saisie_auto.utils.mission import est_en_mission  # noqa: E402
 
 
 def test_utilities(monkeypatch):


### PR DESCRIPTION
## Contexte
- la fonction `est_en_mission` était dupliquée
- nettoyage de `saisie_automatiser_psatime` et `remplir_jours_feuille_de_temps`

## Changements
- ajout d'un module `utils.mission`
- import de `est_en_mission` depuis les modules concernés
- ajustement des imports dans les tests

## Impacts
- les tests continuent de s'exécuter mais plusieurs échecs restent

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688787d8d9e8832186a0e5243301748f