### PR TITLE
[SeleniumFiller] déplace la gestion de samedi

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -62,7 +62,10 @@ from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
-from sele_saisie_auto.utils.mission import est_en_mission
+from sele_saisie_auto.utils.mission import (
+    est_en_mission,
+    get_next_saturday_if_not_saturday,
+)
 
 # ----------------------------------------------------------------------------- #
 # ------------------------------- CONSTANTE ----------------------------------- #
@@ -111,6 +114,7 @@ __all__ = [
     "send_keys_to_element",
     "click_element_without_wait",
     "AutomationExitError",
+    "get_next_saturday_if_not_saturday",
 ]
 
 
@@ -608,17 +612,6 @@ def seprateur_menu_affichage_log(log_file: str) -> None:
 def seprateur_menu_affichage_console() -> None:
     """Affiche un séparateur dans la console."""
     console_ui.show_separator()
-
-
-def get_next_saturday_if_not_saturday(date_str: str) -> str:
-    """Retourne le prochain samedi si la date donnée n'est pas déjà un samedi."""
-    initial_date = datetime.strptime(date_str, "%d/%m/%Y")
-    initial_weekday = initial_date.weekday()
-    if initial_weekday != 5:
-        days_to_next_saturday = (5 - initial_weekday) % 7
-        next_saturday_date = initial_date + timedelta(days=days_to_next_saturday)
-        return next_saturday_date.strftime("%d/%m/%Y")
-    return date_str
 
 
 def afficher_message_insertion(

--- a/src/sele_saisie_auto/utils/mission.py
+++ b/src/sele_saisie_auto/utils/mission.py
@@ -2,7 +2,23 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
 
 def est_en_mission(description: str) -> bool:
     """Return True if the description indicates a mission day."""
     return description == "En mission"
+
+
+def get_next_saturday_if_not_saturday(date_str: str) -> str:
+    """Return the next Saturday if the provided date is not already a Saturday."""
+    initial_date = datetime.strptime(date_str, "%d/%m/%Y")
+    initial_weekday = initial_date.weekday()
+    if initial_weekday != 5:
+        days_to_next_saturday = (5 - initial_weekday) % 7
+        next_saturday_date = initial_date + timedelta(days=days_to_next_saturday)
+        return next_saturday_date.strftime("%d/%m/%Y")
+    return date_str
+
+
+__all__ = ["est_en_mission", "get_next_saturday_if_not_saturday"]


### PR DESCRIPTION
## Contexte et objectif
- centralisation des utilitaires liés aux missions
- déplacement de la fonction `get_next_saturday_if_not_saturday` vers `utils/mission`
- mise à jour de l'import dans `saisie_automatiser_psatime`

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/saisie_automatiser_psatime.py src/sele_saisie_auto/utils/mission.py`
- `poetry run pytest tests/test_remplir_jours_utils.py`

## Impact
- `SeleniumFiller` expose toujours la fonction mais via `utils.mission`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68878d1fd9848321bc83a903f9103aa6