### PR TITLE
[utils] ajout helper date

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Cette séparation facilite les tests et l'évolution du code.
 - **AdditionalInfoPage** : saisie des informations complémentaires.
 - **AlertHandler** : ferme les éventuelles pop‑ups.
 - **DescriptionProcessor** : prépare les descriptions de lignes.
+- **date_utils.get_next_saturday_if_not_saturday** : renvoie le prochain samedi si la date fournie n'en est pas un.
 
 Consultez [AGENT.md](AGENT.md) et la
 [documentation détaillée](docs/reference/architecture.md) pour plus d'informations.
@@ -164,6 +165,7 @@ Consultez [AGENT.md](AGENT.md) et la
 ├── saisie_automatiser_psatime.py
 ├── encryption_utils.py
 ├── remplir_jours_feuille_de_temps.py
+├── utils/date_utils.py
 ├── config.ini
 ├── tests/
 └── ...

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -61,11 +61,9 @@ from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_seleniu
 from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
+from sele_saisie_auto.utils.date_utils import get_next_saturday_if_not_saturday
 from sele_saisie_auto.utils.misc import program_break_time
-from sele_saisie_auto.utils.mission import (
-    est_en_mission,
-    get_next_saturday_if_not_saturday,
-)
+from sele_saisie_auto.utils.mission import est_en_mission
 
 # ----------------------------------------------------------------------------- #
 # ------------------------------- CONSTANTE ----------------------------------- #

--- a/src/sele_saisie_auto/utils/__init__.py
+++ b/src/sele_saisie_auto/utils/__init__.py
@@ -1,3 +1,3 @@
 """Utility subpackages."""
 
-__all__ = ["misc", "mission"]
+__all__ = ["misc", "mission", "date_utils"]

--- a/src/sele_saisie_auto/utils/date_utils.py
+++ b/src/sele_saisie_auto/utils/date_utils.py
@@ -1,0 +1,19 @@
+"""Utilities for date-related calculations."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+
+def get_next_saturday_if_not_saturday(date_str: str) -> str:
+    """Return the next Saturday if the provided date is not already a Saturday."""
+    initial_date = datetime.strptime(date_str, "%d/%m/%Y")
+    initial_weekday = initial_date.weekday()
+    if initial_weekday != 5:
+        days_to_next_saturday = (5 - initial_weekday) % 7
+        next_saturday_date = initial_date + timedelta(days=days_to_next_saturday)
+        return next_saturday_date.strftime("%d/%m/%Y")
+    return date_str
+
+
+__all__ = ["get_next_saturday_if_not_saturday"]

--- a/src/sele_saisie_auto/utils/mission.py
+++ b/src/sele_saisie_auto/utils/mission.py
@@ -2,23 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from .date_utils import get_next_saturday_if_not_saturday
 
 
 def est_en_mission(description: str) -> bool:
     """Return True if the description indicates a mission day."""
     return description == "En mission"
-
-
-def get_next_saturday_if_not_saturday(date_str: str) -> str:
-    """Return the next Saturday if the provided date is not already a Saturday."""
-    initial_date = datetime.strptime(date_str, "%d/%m/%Y")
-    initial_weekday = initial_date.weekday()
-    if initial_weekday != 5:
-        days_to_next_saturday = (5 - initial_weekday) % 7
-        next_saturday_date = initial_date + timedelta(days=days_to_next_saturday)
-        return next_saturday_date.strftime("%d/%m/%Y")
-    return date_str
 
 
 __all__ = ["est_en_mission", "get_next_saturday_if_not_saturday"]


### PR DESCRIPTION
## Contexte
Ajout d'un utilitaire pour calculer le prochain samedi et utilisation dans `saisie_automatiser_psatime.py`.

## Étapes de test
1. `poetry install --no-root`
2. `poetry run pre-commit run --all-files`
3. `poetry run pytest`

Impact limité aux fonctions d'aide.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688797ead86c832195af0cc776f9d6aa