### PR TITLE
[logger] ajout séparateur réutilisable

### DIFF
--- a/src/sele_saisie_auto/console_ui.py
+++ b/src/sele_saisie_auto/console_ui.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sele_saisie_auto import shared_utils
-from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logger_utils import show_log_separator
 
 
 def ask_continue(prompt: str) -> None:
@@ -13,8 +13,4 @@ def ask_continue(prompt: str) -> None:
 
 def show_separator() -> None:
     """Log a separator line."""
-    write_log(
-        "*************************************************************",
-        shared_utils.get_log_file(),
-        "DEBUG",
-    )
+    show_log_separator(shared_utils.get_log_file(), "DEBUG")

--- a/src/sele_saisie_auto/logger_utils.py
+++ b/src/sele_saisie_auto/logger_utils.py
@@ -290,3 +290,13 @@ def close_logs(
         raise RuntimeError(
             f"Erreur inattendue lors de la fermeture des logs : {e}"
         ) from e
+
+
+def show_log_separator(log_file: str, level: str = "INFO") -> None:
+    """Write a visual separator to ``log_file``."""
+
+    write_log(
+        "*************************************************************",
+        log_file,
+        level,
+    )

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -19,6 +19,7 @@ from sele_saisie_auto import (
     messages,
     plugins,
     remplir_jours_feuille_de_temps,
+    shared_utils,
 )
 from sele_saisie_auto.additional_info_locators import AdditionalInfoLocators
 from sele_saisie_auto.app_config import AppConfig
@@ -45,7 +46,7 @@ from sele_saisie_auto.interfaces.protocols import (
     WaiterProtocol,
 )
 from sele_saisie_auto.locators import Locators
-from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.logger_utils import show_log_separator, write_log
 from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
 from sele_saisie_auto.navigation import PageNavigator
 from sele_saisie_auto.orchestration import AutomationOrchestrator
@@ -600,16 +601,12 @@ class PSATimeAutomation:
 
 def seprateur_menu_affichage_log(log_file: str) -> None:
     """Affiche un séparateur dans le fichier de log."""
-    write_log(
-        "*************************************************************",
-        log_file,
-        "INFO",
-    )
+    show_log_separator(log_file)
 
 
 def seprateur_menu_affichage_console() -> None:
     """Affiche un séparateur dans la console."""
-    console_ui.show_separator()
+    show_log_separator(shared_utils.get_log_file(), "DEBUG")
 
 
 # ------------------------------------------------------------------------------------------------- #

--- a/tests/test_console_ui.py
+++ b/tests/test_console_ui.py
@@ -1,5 +1,6 @@
 import builtins
 
+import sele_saisie_auto.logger_utils as logger_utils
 from sele_saisie_auto.console_ui import ask_continue, show_separator
 
 
@@ -8,7 +9,7 @@ def test_console_utils(monkeypatch):
     monkeypatch.setattr(builtins, "input", lambda p: prompts.append(p) or "ok")
     logged: list[str] = []
     monkeypatch.setattr(
-        "sele_saisie_auto.console_ui.write_log",
+        "sele_saisie_auto.logger_utils.write_log",
         lambda msg, log_file, level="INFO", log_format="html", auto_close=False: logged.append(
             msg
         ),

--- a/tests/test_console_ui_basic.py
+++ b/tests/test_console_ui_basic.py
@@ -1,5 +1,6 @@
 import builtins
 
+import sele_saisie_auto.logger_utils as logger_utils
 from sele_saisie_auto import console_ui
 from sele_saisie_auto.console_ui import ask_continue, show_separator
 
@@ -14,7 +15,9 @@ def test_console_ui_basic(monkeypatch):
         printed.append(" ".join(str(a) for a in args))
 
     monkeypatch.setattr(builtins, "print", fake_print)
-    monkeypatch.setattr(console_ui, "write_log", lambda msg, *a, **k: fake_print(msg))
+    monkeypatch.setattr(
+        "sele_saisie_auto.logger_utils.write_log", lambda msg, *a, **k: fake_print(msg)
+    )
 
     ask_continue("continue?")
     assert prompts == ["continue?"]

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -12,6 +12,7 @@ from sele_saisie_auto.utils import misc as utils_misc
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+import sele_saisie_auto.logger_utils as logger_utils  # noqa: E402
 from sele_saisie_auto import messages  # noqa: E402
 from sele_saisie_auto import saisie_automatiser_psatime as sap  # noqa: E402
 from sele_saisie_auto.logger_utils import afficher_message_insertion  # noqa: E402
@@ -255,7 +256,9 @@ def test_helpers(monkeypatch, sample_config):
     sap.seprateur_menu_affichage_log("log.html")
     with monkeypatch.context() as m:
         called = []
-        m.setattr(console_ui, "show_separator", lambda: called.append(True))
+        m.setattr(
+            logger_utils, "show_log_separator", lambda *a, **k: called.append(True)
+        )
         sap.seprateur_menu_affichage_console()
     sap.log_initialisation()
     assert messages


### PR DESCRIPTION
## Contexte
- uniformiser l'affichage d'un séparateur dans les logs et la console
- éviter la duplication de code

## Changements
- ajout de `show_log_separator` dans `logger_utils`
- utilisation de cette fonction par `console_ui` et par `saisie_automatiser_psatime`
- adaptation des tests unitaires

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6887a69b2138832197b4ada3454a9d5c