### PR TITLE
[additional_info] centralise logging

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -176,3 +176,30 @@ class AdditionalInfoPage:
         """Dismiss any alert shown after saving."""
 
         self.alert_handler.handle_alerts(driver, "save_alerts")
+
+    def log_information_details(self) -> None:
+        """Log the extra information configuration details."""
+
+        cfg = self.context.config
+
+        write_log("👉 Infos_supp_cgi_periode_repos_respectee:", self.log_file, "DEBUG")
+        for day, status in cfg.additional_information[
+            "periode_repos_respectee"
+        ].items():
+            write_log(f"🔹 '{day}': '{status}'", self.log_file, "DEBUG")
+
+        write_log("👉 Infos_supp_cgi_horaire_travail_effectif:", self.log_file, "DEBUG")
+        for day, status in cfg.additional_information[
+            "horaire_travail_effectif"
+        ].items():
+            write_log(f"🔹 '{day}': '{status}'", self.log_file, "DEBUG")
+
+        write_log("👉 Planning de travail de la semaine:", self.log_file, "DEBUG")
+        for day, status in cfg.additional_information[
+            "plus_demi_journee_travaillee"
+        ].items():
+            write_log(f"🔹 '{day}': '{status}'", self.log_file, "DEBUG")
+
+        write_log("👉 Infos_supp_cgi_duree_pause_dejeuner:", self.log_file, "DEBUG")
+        for day, status in cfg.additional_information["duree_pause_dejeuner"].items():
+            write_log(f"🔹 '{day}': '{status}'", self.log_file, "DEBUG")

--- a/src/sele_saisie_auto/interfaces/protocols.py
+++ b/src/sele_saisie_auto/interfaces/protocols.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-from sele_saisie_auto.app_config import AppConfig
 from selenium.webdriver.remote.webdriver import WebDriver
+
+from sele_saisie_auto.app_config import AppConfig
 
 
 @runtime_checkable
@@ -27,11 +28,20 @@ class LoggerProtocol(Protocol):
 
 @runtime_checkable
 class WaiterProtocol(Protocol):
-    def wait_for_dom_ready(self, driver: WebDriver, timeout: int | None = None) -> None: ...
-    def wait_until_dom_is_stable(self, driver: WebDriver, timeout: int | None = None) -> bool: ...
+    def wait_for_dom_ready(
+        self, driver: WebDriver, timeout: int | None = None
+    ) -> None: ...
+
+    def wait_until_dom_is_stable(
+        self, driver: WebDriver, timeout: int | None = None
+    ) -> bool: ...
+
     def wait_for_element(self, driver: WebDriver, *args: Any, **kwargs: Any) -> Any: ...
+
     def find_clickable(self, driver: WebDriver, *args: Any, **kwargs: Any) -> Any: ...
+
     def find_visible(self, driver: WebDriver, *args: Any, **kwargs: Any) -> Any: ...
+
     def find_present(self, driver: WebDriver, *args: Any, **kwargs: Any) -> Any: ...
 
 
@@ -65,7 +75,6 @@ class LoginHandlerProtocol(Protocol):
     ) -> None: ...
 
 
-
 @runtime_checkable
 class DateEntryPageProtocol(Protocol):
     def navigate_from_home_to_date_entry_page(self, driver: WebDriver) -> bool: ...
@@ -75,9 +84,12 @@ class DateEntryPageProtocol(Protocol):
 
 @runtime_checkable
 class AdditionalInfoPageProtocol(Protocol):
-    def navigate_from_work_schedule_to_additional_information_page(self, driver: WebDriver) -> bool: ...
+    def navigate_from_work_schedule_to_additional_information_page(
+        self, driver: WebDriver
+    ) -> bool: ...
     def submit_and_validate_additional_information(self, driver: WebDriver) -> None: ...
     def save_draft_and_validate(self, driver: WebDriver) -> None: ...
+    def log_information_details(self) -> None: ...
 
 
 @runtime_checkable

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -289,45 +289,8 @@ class PSATimeAutomation:
                 "DEBUG",
             )  # pragma: no cover
 
-        write_log(
-            "👉 Infos_supp_cgi_periode_repos_respectee:", self.log_file, "DEBUG"
-        )  # pragma: no cover
-        for day, status in self.context.config.additional_information[
-            "periode_repos_respectee"
-        ].items():
-            write_log(
-                f"🔹 '{day}': '{status}'", self.log_file, "DEBUG"
-            )  # pragma: no cover
-
-        write_log(
-            "👉 Infos_supp_cgi_horaire_travail_effectif:", self.log_file, "DEBUG"
-        )  # pragma: no cover
-        for day, status in self.context.config.additional_information[
-            "horaire_travail_effectif"
-        ].items():
-            write_log(
-                f"🔹 '{day}': '{status}'", self.log_file, "DEBUG"
-            )  # pragma: no cover
-
-        write_log(
-            "👉 Planning de travail de la semaine:", self.log_file, "DEBUG"
-        )  # pragma: no cover
-        for day, status in self.context.config.additional_information[
-            "plus_demi_journee_travaillee"
-        ].items():
-            write_log(
-                f"🔹 '{day}': '{status}'", self.log_file, "DEBUG"
-            )  # pragma: no cover
-
-        write_log(
-            "👉 Infos_supp_cgi_duree_pause_dejeuner:", self.log_file, "DEBUG"
-        )  # pragma: no cover
-        for day, status in self.context.config.additional_information[
-            "duree_pause_dejeuner"
-        ].items():
-            write_log(
-                f"🔹 '{day}': '{status}'", self.log_file, "DEBUG"
-            )  # pragma: no cover
+        # Delegate detailed additional information logs to the page helper
+        self.additional_info_page.log_information_details()
 
         write_log(
             "👉 Lieu de travail Matin:", self.log_file, "DEBUG"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,6 +159,9 @@ class DummyAdditionalInfoPage:
     def save_draft_and_validate(self, driver):
         self.calls.append("save")
 
+    def log_information_details(self):
+        self.calls.append("log_info")
+
 
 class DummyTimeSheetHelper:
     ran = None
@@ -212,6 +215,10 @@ class LoggedDummyAdditionalInfoPage(DummyAdditionalInfoPage):
     def save_draft_and_validate(self, driver):
         super().save_draft_and_validate(driver)
         self.log.append("save")
+
+    def log_information_details(self):
+        super().log_information_details()
+        self.log.append("log_info")
 
 
 class LoggedDummyTimeSheetHelper(DummyTimeSheetHelper):

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -152,6 +152,9 @@ class DummyAdditionalInfoPage:
     def _handle_save_alerts(self, driver):
         self.alert_handler.handle_alerts(driver, "save_alerts")
 
+    def log_information_details(self):
+        self.calls.append("log_info")
+
 
 def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
     from sele_saisie_auto.app_config import AppConfig, AppConfigRaw


### PR DESCRIPTION
## Summary
- move logging of additional information to `AdditionalInfoPage.log_information_details`
- delegate from `PSATimeAutomation.log_configuration_details`
- update protocols and tests

## Testing
- `pre-commit run --files src/sele_saisie_auto/automation/additional_info_page.py src/sele_saisie_auto/interfaces/protocols.py src/sele_saisie_auto/saisie_automatiser_psatime.py tests/conftest.py tests/test_saisie_automatiser_psatime.py`
- `pytest -q` *(fails: 24 failed, 297 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6887aaa051848321b5c72c59879bf9df