### PR TITLE
[automation_orchestrator] retire fonctions globales

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -668,44 +668,5 @@ def initialize_shared_memory() -> EncryptionCredentials:
     )
 
 
-def setup_browser(
-    session: BrowserSession,
-    *,
-    headless: bool = False,
-    no_sandbox: bool = False,
-) -> WebDriver:
-    """Instancie le navigateur Selenium."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    _ORCHESTRATOR.browser_session = session  # type: ignore[assignment]
-    return cast(
-        WebDriver,
-        _ORCHESTRATOR.browser_session.open(
-            _ORCHESTRATOR.config.url,
-            fullscreen=False,
-            headless=headless,
-            no_sandbox=no_sandbox,
-        ),
-    )
-
-
-def connect_to_psatime(
-    driver: WebDriver, cle_aes: bytes, login_c: bytes, pwd_c: bytes
-) -> Any:
-    """Ouvre la session PSA Time avec les identifiants fournis."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return _ORCHESTRATOR.login_handler.connect_to_psatime(
-        driver, cle_aes, login_c, pwd_c
-    )
-
-
-def switch_to_iframe_main_target_win0(driver: WebDriver) -> bool:
-    """Bascule vers l'iframe principale."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return cast(bool, _ORCHESTRATOR.switch_to_iframe_main_target_win0(driver))
-
-
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -179,7 +179,7 @@ def test_switch_to_iframe(monkeypatch, sample_config):
         "wait_for_dom",
         lambda *a, **k: calls.append("dom"),
     )
-    assert sap.switch_to_iframe_main_target_win0("drv") is True
+    assert sap._ORCHESTRATOR.switch_to_iframe_main_target_win0("drv") is True
     assert "sw" in calls
     assert "dom" in calls
 

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -153,7 +153,7 @@ def test_switch_to_iframe_main_target_win0_no_element(monkeypatch):
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
     with pytest.raises(NameError):
-        sap.switch_to_iframe_main_target_win0("drv")
+        sap._ORCHESTRATOR.switch_to_iframe_main_target_win0("drv")
 
 
 def test_navigate_from_home_to_date_entry_page_no_elements(monkeypatch, sample_config):

--- a/tests/test_saisie_automatiser_psatime_extra.py
+++ b/tests/test_saisie_automatiser_psatime_extra.py
@@ -115,7 +115,7 @@ def test_switch_to_iframe_main_target_win0_false(monkeypatch, sample_config):
     monkeypatch.setattr(
         sap.PSATimeAutomation, "wait_for_dom", lambda self, *a, **k: None
     )
-    assert sap.switch_to_iframe_main_target_win0("drv") is False
+    assert sap._ORCHESTRATOR.switch_to_iframe_main_target_win0("drv") is False
 
 
 def test_submit_date_cible_no_element(monkeypatch, sample_config):


### PR DESCRIPTION
## Contexte
Les fonctions utilitaires `setup_browser`, `connect_to_psatime` et `switch_to_iframe_main_target_win0` dans `saisie_automatiser_psatime.py` faisaient doublon avec les méthodes de `AutomationOrchestrator`. Elles ont été supprimées et les tests ont été mis à jour pour appeler directement l'orchestrateur.

## Étapes pour tester
1. `poetry install`
2. `poetry run pre-commit run --all-files`
3. `poetry run pytest`

## Impact
Ces changements simplifient l'API du module et alignent les tests sur l’orchestrateur.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6887c17087ec8321971c7a002bad6a43