### PR TITLE
[ConfigManager] création automatique d’une config par défaut

### DIFF
--- a/src/sele_saisie_auto/config_manager.py
+++ b/src/sele_saisie_auto/config_manager.py
@@ -1,15 +1,18 @@
 # config_manager.py
 """Gestion centralisée du fichier ``config.ini``."""
 
+import shutil
 from configparser import ConfigParser
 from pathlib import Path
 
 from sele_saisie_auto import messages
 from sele_saisie_auto.app_config import AppConfig, load_config
+from sele_saisie_auto.logger_utils import DEFAULT_LOG_LEVEL, write_log
 from sele_saisie_auto.read_or_write_file_config_ini_utils import (
     get_runtime_config_path,
     write_config_ini,
 )
+from sele_saisie_auto.shared_utils import get_log_file
 
 
 class ConfigManager:
@@ -36,8 +39,18 @@ class ConfigManager:
         """Lit ``config.ini`` et retourne un ``AppConfig``."""
         cfg_path = Path(get_runtime_config_path(log_file=self.log_file))
         if not cfg_path.exists():
-            raise FileNotFoundError(
-                f"Le fichier de configuration '{cfg_path}' est {messages.INTROUVABLE}."
+            default_cfg = Path(__file__).resolve().parents[2] / "config.ini"
+            if default_cfg.exists():
+                shutil.copy(default_cfg, cfg_path)
+            else:
+                cp = ConfigParser()
+                cp["settings"] = {"url": "http://localhost"}
+                with open(cfg_path, "w", encoding="utf-8") as f:
+                    cp.write(f)
+            write_log(
+                f"Le fichier de configuration '{cfg_path}' est {messages.INTROUVABLE}. Un fichier par défaut a été créé.",
+                self.log_file or get_log_file(),
+                DEFAULT_LOG_LEVEL,
             )
         app_cfg = load_config(log_file=self.log_file)
         self._config = app_cfg.raw


### PR DESCRIPTION
## Contexte
- jusqu’ici `ConfigManager.load` levait une erreur si `config.ini` était absent
- on souhaite créer automatiquement une configuration minimale et l’indiquer dans les logs

## Changements
- copie du `config.ini` embarqué ou génération d’un fichier basique
- journalisation de la création du fichier
- ajustement du test `test_load_missing_config`

## Test
- `poetry run pre-commit run --files src/sele_saisie_auto/config_manager.py tests/test_config_manager.py`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68887e933f848321ac3c9c0a93bf5a9d