### PR TITLE
[PageNavigator] vérification du driver

### DIFF
--- a/src/sele_saisie_auto/navigation/page_navigator.py
+++ b/src/sele_saisie_auto/navigation/page_navigator.py
@@ -126,6 +126,9 @@ class PageNavigator:
     def run(self, driver: WebDriver) -> None:
         """Execute the complete navigation sequence."""
 
+        if driver is None:
+            raise RuntimeError("driver missing")
+
         if self.credentials is None or self.date_cible is None:
             raise RuntimeError("PageNavigator not prepared")
 

--- a/tests/test_page_navigator_sequence.py
+++ b/tests/test_page_navigator_sequence.py
@@ -41,6 +41,15 @@ def test_run_without_prepare_raises():
     assert not log
 
 
+def test_run_without_driver_raises():
+    log, nav = make_navigator()
+    creds = Credentials(b"k", None, b"u", None, b"p", None)
+    nav.prepare(creds, "2024")
+    with pytest.raises(RuntimeError, match="driver missing"):
+        nav.run(None)  # type: ignore[arg-type]
+    assert not log
+
+
 def test_run_calls_dependencies_in_order():
     log, nav = make_navigator()
     creds = Credentials(b"k", None, b"u", None, b"p", None)


### PR DESCRIPTION
## Contexte
Ajout d'un garde-fou dans `PageNavigator.run` pour détecter l'absence de driver et lever l'exception correspondante. Un test dédié couvre ce cas dans `test_page_navigator_sequence.py`.

## Impact
Aucun impact prévu sur les autres agents.

## Tests
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6888817f402883218110bdb8530d242c