### PR TITLE
[AutomationOrchestrator] Gestion des erreurs inattendues

### DIFF
--- a/src/sele_saisie_auto/decorators/__init__.py
+++ b/src/sele_saisie_auto/decorators/__init__.py
@@ -1,5 +1,6 @@
 """Decorators utilities for error handling, etc."""
 
+from .error_handler import handle_errors
 from .error_handling import handle_selenium_errors
 
-__all__ = ["handle_selenium_errors"]
+__all__ = ["handle_selenium_errors", "handle_errors"]

--- a/src/sele_saisie_auto/decorators/error_handler.py
+++ b/src/sele_saisie_auto/decorators/error_handler.py
@@ -1,0 +1,43 @@
+"""Generic error handling decorator."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from sele_saisie_auto.error_handler import log_error
+from sele_saisie_auto.shared_utils import get_log_file
+
+
+def handle_errors(
+    log_file_attr: str = "log_file",
+    default_return: Any | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Return a decorator that logs unexpected exceptions and returns ``default_return``."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            log_file = kwargs.get("log_file")
+            if log_file is None and args:
+                inst = args[0]
+                # Try attribute on instance directly
+                if hasattr(inst, log_file_attr):
+                    log_file = getattr(inst, log_file_attr)
+                # Fallback to instance.logger.log_file
+                elif hasattr(inst, "logger") and hasattr(inst.logger, "log_file"):
+                    log_file = getattr(inst.logger, "log_file")
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                lf = log_file or get_log_file()
+                log_error(str(exc), lf)
+                return default_return
+
+        return wrapper
+
+    return decorator
+
+
+__all__ = ["handle_errors"]

--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -11,6 +11,7 @@ from sele_saisie_auto.alerts import AlertHandler
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import ServiceConfigurator
+from sele_saisie_auto.decorators import handle_errors
 from sele_saisie_auto.interfaces import (
     AdditionalInfoPageProtocol,
     BrowserSessionProtocol,
@@ -156,7 +157,10 @@ class AutomationOrchestrator:
     ) -> None:  # pragma: no cover
         """Delegate DOM wait to :class:`BrowserSession`."""
 
-        self.browser_session.wait_for_dom(driver, max_attempts=max_attempts)
+        if max_attempts is None:
+            self.browser_session.wait_for_dom(driver)
+        else:
+            self.browser_session.wait_for_dom(driver, max_attempts=max_attempts)
 
     @wait_for_dom_after  # type: ignore[misc]
     def switch_to_iframe_main_target_win0(self, driver: Any) -> bool:
@@ -218,6 +222,7 @@ class AutomationOrchestrator:
 
         self.additional_info_page.save_draft_and_validate(driver)
 
+    @handle_errors()
     def _fill_and_save_timesheet(self, driver: Any) -> None:
         """Delegate the complete timesheet workflow to :class:`PageNavigator`."""
         assert self.page_navigator is not None  # nosec B101
@@ -244,6 +249,7 @@ class AutomationOrchestrator:
         self.page_navigator.fill_timesheet(driver)
         self.page_navigator.finalize_timesheet(driver)
 
+    @handle_errors()
     def run(  # pragma: no cover - integration tested via main automation
         self,
         *,


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un décorateur `handle_errors` permettant de journaliser toute exception imprévue puis de renvoyer une valeur neutre. Ce décorateur est désormais appliqué aux fonctions critiques d'`AutomationOrchestrator`.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest tests/test_error_handler.py tests/test_automation_orchestrator.py::test_wrappers -q`

## Impact
Meilleure robustesse de l'orchestrateur grâce à une journalisation systématique des erreurs.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688892c577c083218c68d9eba494d0ca