### PR TITLE
[DefaultEncryptionService] simplifie la gestion du chiffrement

### DIFF
--- a/src/sele_saisie_auto/encryption.py
+++ b/src/sele_saisie_auto/encryption.py
@@ -2,13 +2,48 @@
 
 from __future__ import annotations
 
+from .encryption_utils import Credentials
 from .encryption_utils import EncryptionService as _EncryptionService
 
 
-class DefaultEncryptionService(_EncryptionService):
+class DefaultEncryptionService:
     """Default implementation relying on :class:`EncryptionService`."""
 
-    pass
+    def __init__(self, *args, **kwargs) -> None:
+        self._service = _EncryptionService(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Expose EncryptionService API through delegation
+    # ------------------------------------------------------------------
+    @property
+    def shared_memory_service(self):  # pragma: no cover - simple proxy
+        return self._service.shared_memory_service
+
+    def generer_cle_aes(self, taille_cle: int = 32) -> bytes:
+        return self._service.generer_cle_aes(taille_cle)
+
+    def chiffrer_donnees(
+        self, donnees: str, cle: bytes, taille_bloc: int = 128
+    ) -> bytes:
+        return self._service.chiffrer_donnees(donnees, cle, taille_bloc)
+
+    def dechiffrer_donnees(
+        self, donnees_chiffrees: bytes, cle: bytes, taille_bloc: int = 128
+    ) -> str:
+        return self._service.dechiffrer_donnees(donnees_chiffrees, cle, taille_bloc)
+
+    def store_credentials(self, login_data: bytes, password_data: bytes) -> None:
+        self._service.store_credentials(login_data, password_data)
+
+    def retrieve_credentials(self) -> Credentials:
+        return self._service.retrieve_credentials()
+
+    def __enter__(self) -> "DefaultEncryptionService":
+        self._service.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._service.__exit__(exc_type, exc, tb)
 
 
 __all__ = ["DefaultEncryptionService"]


### PR DESCRIPTION
## Contexte et objectif
- la classe `DefaultEncryptionService` héritait directement de `EncryptionService` sans apport
- refactor pour encapsuler une instance interne et déléguer les appels

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption.py`
- `poetry run pytest`

## Impact éventuel
- aucun impact fonctionnel attendu, la classe conserve la même interface

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6888978014088321bfc7878755c41acf