### PR TITLE
[PSATimeAutomation] Simplify additional info locators

### DIFF
--- a/src/sele_saisie_auto/additional_info_locators.py
+++ b/src/sele_saisie_auto/additional_info_locators.py
@@ -1,10 +1,11 @@
-from enum import Enum, auto
-from typing import Any, Dict, List
+"""Definitions of HTML id prefixes used for the additional info modal."""
+
+from typing import Dict
 
 # --------------------------------------------------------------------------- #
 # Mapping brut id_logique ➜ id_HTML
 # --------------------------------------------------------------------------- #
-LOCATOR_MAP: Dict[str, str] = {
+ADDITIONAL_INFO_LOCATORS: Dict[str, str] = {
     "ROW_DESCR100": "DESCR100$",
     "DAY_UC_DAILYREST": "UC_DAILYREST",
     "ROW_DESCR200": "UC_TIME_LIN_WRK_DESCR200$",
@@ -14,21 +15,5 @@ LOCATOR_MAP: Dict[str, str] = {
 }
 
 
-class AdditionalInfoLocators(str, Enum):
-    """Locator prefixes for additional information lines and fields."""
-
-    @staticmethod
-    def _generate_next_value_(
-        name: str,
-        start: int,
-        count: int,
-        last_values: List[Any],
-    ) -> str:
-        return LOCATOR_MAP[name]
-
-    ROW_DESCR100 = auto()
-    DAY_UC_DAILYREST = auto()
-    ROW_DESCR200 = auto()
-    DAY_UC_DAILYREST_SPECIAL = auto()
-    ROW_DESCR = auto()
-    DAY_UC_LOCATION_A = auto()
+# For backward compatibility ------------------------------------------------- #
+LOCATOR_MAP = ADDITIONAL_INFO_LOCATORS

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -21,7 +21,7 @@ from sele_saisie_auto import (
     remplir_jours_feuille_de_temps,
     shared_utils,
 )
-from sele_saisie_auto.additional_info_locators import AdditionalInfoLocators
+from sele_saisie_auto.additional_info_locators import ADDITIONAL_INFO_LOCATORS
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.automation.additional_info_page import AdditionalInfoPage
 from sele_saisie_auto.automation.browser_session import BrowserSession
@@ -168,8 +168,8 @@ class PSATimeAutomation:
             descriptions=[
                 {
                     "description_cible": "Temps de repos de 11h entre 2 jours travaillés respecté",
-                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
-                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
+                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.additional_information[
                         "periode_repos_respectee"
@@ -179,8 +179,8 @@ class PSATimeAutomation:
                     "description_cible": (
                         "Mon temps de travail effectif a débuté entre 8h00 et 10h00 et Mon temps de travail effectif a pris fin entre 16h30 et 19h00"
                     ),
-                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
-                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
+                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.additional_information[
                         "horaire_travail_effectif"
@@ -188,8 +188,8 @@ class PSATimeAutomation:
                 },
                 {
                     "description_cible": "J’ai travaillé plus d’une demi-journée",
-                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR100.value,
-                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST.value,
+                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.additional_information[
                         "plus_demi_journee_travaillee"
@@ -197,8 +197,10 @@ class PSATimeAutomation:
                 },
                 {
                     "description_cible": "Durée de la pause déjeuner",
-                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR200.value,
-                    "id_value_jours": AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value,
+                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR200"],
+                    "id_value_jours": ADDITIONAL_INFO_LOCATORS[
+                        "DAY_UC_DAILYREST_SPECIAL"
+                    ],
                     "type_element": "input",
                     "valeurs_a_remplir": app_config.additional_information[
                         "duree_pause_dejeuner"
@@ -206,15 +208,15 @@ class PSATimeAutomation:
                 },
                 {
                     "description_cible": "Matin",
-                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR.value,
-                    "id_value_jours": AdditionalInfoLocators.DAY_UC_LOCATION_A.value,
+                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
+                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.work_location_am,
                 },
                 {
                     "description_cible": "Après-midi",
-                    "id_value_ligne": AdditionalInfoLocators.ROW_DESCR.value,
-                    "id_value_jours": AdditionalInfoLocators.DAY_UC_LOCATION_A.value,
+                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
+                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
                     "type_element": "select",
                     "valeurs_a_remplir": app_config.work_location_pm,
                 },

--- a/tests/test_element_id_builder.py
+++ b/tests/test_element_id_builder.py
@@ -4,7 +4,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 from sele_saisie_auto.additional_info_locators import (  # noqa: E402
-    AdditionalInfoLocators,
+    ADDITIONAL_INFO_LOCATORS,
 )
 from sele_saisie_auto.elements.element_id_builder import ElementIdBuilder  # noqa: E402
 
@@ -14,15 +14,15 @@ def test_default_pattern():
 
 
 def test_uc_dailyrest_pattern():
-    base = AdditionalInfoLocators.DAY_UC_DAILYREST.value
+    base = ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"]
     assert ElementIdBuilder.build_day_input_id(base, 4, 2) == f"{base}4$2"
 
 
 def test_special_dailyrest_pattern():
-    base = AdditionalInfoLocators.DAY_UC_DAILYREST_SPECIAL.value
+    base = ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST_SPECIAL"]
     assert ElementIdBuilder.build_day_input_id(base, 1, 3) == f"{base}11$0"
 
 
 def test_uc_location_a_pattern():
-    base = AdditionalInfoLocators.DAY_UC_LOCATION_A.value
+    base = ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"]
     assert ElementIdBuilder.build_day_input_id(base, 7, 1) == f"{base}7$1"


### PR DESCRIPTION
## Contexte et objectif
- évaluer l'usage de l'`Enum` `AdditionalInfoLocators`
- remplacement de cet `Enum` par un simple dictionnaire pour alléger le code
- mise à jour des imports et des tests associés

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact
- aucun impact attendu sur les autres agents, l'alias `LOCATOR_MAP` reste disponible

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6888a31f903c8321b14b079385805b8a