### PR TITLE
[AutomationOrchestrator] enforce BrowserSession instance

### DIFF
--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -9,6 +9,7 @@ from selenium.webdriver.common.by import By
 
 from sele_saisie_auto.alerts import AlertHandler
 from sele_saisie_auto.app_config import AppConfig
+from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import ServiceConfigurator
 from sele_saisie_auto.decorators import handle_errors
@@ -64,6 +65,8 @@ class AutomationOrchestrator:
         cleanup_resources: Callable[[object, object, object], None] | None = None,
         resource_manager: ResourceManager | None = None,
     ) -> None:
+        if not isinstance(browser_session, BrowserSession):
+            raise TypeError("browser_session must be an instance of BrowserSession")
         self.config = config
         self.logger = logger
         self.browser_session = browser_session

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from sele_saisie_auto.automation.browser_session import BrowserSession
+
 
 class DummyLogger:
     """Simple logger collecting messages."""
@@ -78,10 +80,13 @@ class FakeEncryptionService:
 # ----------------------------
 
 
-class DummyBrowserSession:
+class DummyBrowserSession(BrowserSession):
     """Lightweight browser session stub."""
 
     def __init__(self):
+        # Intentionally bypass BrowserSession.__init__ to avoid side effects
+        self.log_file = "log.html"
+        self.app_config = None
         self.open_calls = []
         self.driver = "drv"
         self.waiter = types.SimpleNamespace(wait_for_element=lambda *a, **k: True)

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -331,7 +331,7 @@ def test_run_sequence_with_mocks(sample_config):
     rm.get_driver.side_effect = lambda *a, **k: (order.append("driver"), "drv")[1]
 
     pn = MagicMock()
-    pn.browser_session = Mock(waiter=None)
+    pn.browser_session = DummyBrowserSession()
     pn.prepare.side_effect = lambda *a, **k: order.append("prepare")
     pn.run.side_effect = lambda *a, **k: order.append("run")
 

--- a/tests/test_remplir_jours_feuille_de_temps_additional.py
+++ b/tests/test_remplir_jours_feuille_de_temps_additional.py
@@ -391,7 +391,7 @@ def test_main_handles_other_exceptions(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.log_error",
         lambda msg, *_: logs.append(msg),
     )
-    main(None, "log")
+    main(object(), "log")
     assert any(messages.INTROUVABLE in m for m in logs)
 
 
@@ -410,7 +410,7 @@ def test_main_webdriver_exception(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.log_error",
         lambda msg, *_: logs.append(msg),
     )
-    main(None, "log")
+    main(object(), "log")
     assert any(messages.WEBDRIVER in m for m in logs)
 
 
@@ -429,7 +429,7 @@ def test_main_stale_exception(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.log_error",
         lambda msg, *_: logs.append(msg),
     )
-    main(None, "log")
+    main(object(), "log")
     assert any(messages.REFERENCE_OBSOLETE in m for m in logs)
 
 
@@ -446,5 +446,5 @@ def test_main_generic_exception(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.log_error",
         lambda msg, *_: logs.append(msg),
     )
-    main(None, "log")
+    main(object(), "log")
     assert any(messages.ERREUR_INATTENDUE in m for m in logs)

--- a/tests/test_remplir_jours_main_flow.py
+++ b/tests/test_remplir_jours_main_flow.py
@@ -168,7 +168,7 @@ def test_main_invokes_helper(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.TimeSheetHelper", DummyHelper
     )
 
-    main(None, "file")
+    main(object(), "file")
     assert called == {"init": "file", "run": True}
 
 
@@ -247,7 +247,7 @@ def test_main_with_mission(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.TimeSheetHelper", DummyHelper
     )
 
-    main(None, "file")
+    main(object(), "file")
     assert seq == ["init", "run"]
 
 
@@ -298,5 +298,5 @@ def test_main_handles_exception(monkeypatch):
         lambda msg, *_: logs.append(msg),
     )
 
-    main(None, "file")
+    main(object(), "file")
     assert any("Temps d'attente" in m for m in logs)

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from sele_saisie_auto import console_ui
+from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.configuration import ServiceConfigurator
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.orchestration import AutomationOrchestrator
@@ -68,9 +69,11 @@ class DummyManager:
         self.close()
 
 
-class DummyBrowserSession:
+class DummyBrowserSession(BrowserSession):
     def __init__(self, log_file, app_config=None, waiter=None):
+        # Do not call super().__init__ to avoid heavy setup
         self.log_file = log_file
+        self.app_config = app_config
         self.open_calls = []
         self.driver = types.SimpleNamespace(page_source="")
         self.waiter = waiter
@@ -279,7 +282,7 @@ def test_initialize_sets_globals(monkeypatch, sample_config):
 def test_init_services(monkeypatch, sample_config):
     from sele_saisie_auto.configuration import Services
 
-    dummy = Services(None, None, None, None)
+    dummy = Services(None, DummyBrowserSession("log.html"), None, None)
     called = {}
 
     class DummyConfigurator:

--- a/tests/test_timesheet_helper.py
+++ b/tests/test_timesheet_helper.py
@@ -90,7 +90,7 @@ def test_timesheethelper_run_sequence(monkeypatch):
         "sele_saisie_auto.remplir_jours_feuille_de_temps.write_log",
         lambda *a, **k: None,
     )
-    helper.run(None)
+    helper.run(object())
     assert seq == ["std", "work", "extra"]
 
 
@@ -113,7 +113,7 @@ def test_timesheethelper_run_early_exit(monkeypatch):
         lambda *a, **k: None,
     )
 
-    helper.run(None)
+    helper.run(object())
 
     assert seq == []
 
@@ -252,7 +252,7 @@ def test_run_logs_early_return(monkeypatch):
         lambda *_a, **_k: extra_called.__setitem__("called", True),
     )
 
-    helper.run(None)
+    helper.run(object())
 
     assert ("INFO", messages.TIMESHEET_ALREADY_COMPLETE) in logs
     assert not work_called["called"]


### PR DESCRIPTION
## Contexte et objectif
- Validation du type de `browser_session` lors de l'initialisation de `AutomationOrchestrator`.
- Mise à jour des stubs de tests pour hériter de `BrowserSession` et adaptation des appels aux fonctions de remplissage.

## Étapes pour tester
- `poetry install --no-root`
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6888aea41348832186e7402a1cb12fc7