### PR TITLE
[AdditionalInfoPage] initialise descriptions depuis la config

### DIFF
--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as ec
 
+from sele_saisie_auto.additional_info_locators import ADDITIONAL_INFO_LOCATORS
 from sele_saisie_auto.alerts import AlertHandler
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.decorators import handle_selenium_errors
@@ -65,6 +66,7 @@ class AdditionalInfoPage:
         from sele_saisie_auto import saisie_automatiser_psatime as sap
 
         sap.traiter_description = self.helper.traiter_description
+        self._ensure_descriptions()
 
     @property
     def log_file(self) -> str:
@@ -85,6 +87,71 @@ class AdditionalInfoPage:
     # ------------------------------------------------------------------
     def wait_for_dom(self, driver, max_attempts: int | None = None) -> None:
         self._automation.wait_for_dom(driver, max_attempts=max_attempts)
+
+    def _ensure_descriptions(self) -> None:
+        """Populate ``context.descriptions`` if empty."""
+        if getattr(self.context, "descriptions", None):
+            return
+
+        cfg = self.context.config
+        self.context.descriptions = [
+            {
+                "description_cible": "Temps de repos de 11h entre 2 jours travaillés respecté",
+                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
+                "type_element": "select",
+                "valeurs_a_remplir": cfg.additional_information.get(
+                    "periode_repos_respectee",
+                    {},
+                ),
+            },
+            {
+                "description_cible": (
+                    "Mon temps de travail effectif a débuté entre 8h00 et 10h00 et Mon temps de travail effectif a pris fin entre 16h30 et 19h00"
+                ),
+                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
+                "type_element": "select",
+                "valeurs_a_remplir": cfg.additional_information.get(
+                    "horaire_travail_effectif",
+                    {},
+                ),
+            },
+            {
+                "description_cible": "J\u2019ai travaillé plus d\u2019une demi-journée",
+                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
+                "type_element": "select",
+                "valeurs_a_remplir": cfg.additional_information.get(
+                    "plus_demi_journee_travaillee",
+                    {},
+                ),
+            },
+            {
+                "description_cible": "Durée de la pause déjeuner",
+                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR200"],
+                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST_SPECIAL"],
+                "type_element": "input",
+                "valeurs_a_remplir": cfg.additional_information.get(
+                    "duree_pause_dejeuner",
+                    {},
+                ),
+            },
+            {
+                "description_cible": "Matin",
+                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
+                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
+                "type_element": "select",
+                "valeurs_a_remplir": cfg.work_location_am,
+            },
+            {
+                "description_cible": "Après-midi",
+                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
+                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
+                "type_element": "select",
+                "valeurs_a_remplir": cfg.work_location_pm,
+            },
+        ]
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -14,12 +14,80 @@ from sele_saisie_auto.interfaces import WaiterProtocol
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import format_message, write_log
 from sele_saisie_auto.remplir_informations_supp_utils import ExtraInfoHelper
+from sele_saisie_auto.saisie_context import SaisieContext
 from sele_saisie_auto.selenium_utils import Waiter, wait_for_dom_after
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 
 if TYPE_CHECKING:
     from sele_saisie_auto.saisie_automatiser_psatime import PSATimeAutomation
+
+
+def ensure_descriptions(context: SaisieContext) -> None:
+    """Populate ``context.descriptions`` from ``context.config`` if empty."""
+
+    if getattr(context, "descriptions", None):
+        return
+
+    cfg = context.config
+    context.descriptions = [
+        {
+            "description_cible": "Temps de repos de 11h entre 2 jours travaillés respecté",
+            "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+            "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
+            "type_element": "select",
+            "valeurs_a_remplir": cfg.additional_information.get(
+                "periode_repos_respectee",
+                {},
+            ),
+        },
+        {
+            "description_cible": (
+                "Mon temps de travail effectif a débuté entre 8h00 et 10h00 et Mon temps de travail effectif a pris fin entre 16h30 et 19h00"
+            ),
+            "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+            "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
+            "type_element": "select",
+            "valeurs_a_remplir": cfg.additional_information.get(
+                "horaire_travail_effectif",
+                {},
+            ),
+        },
+        {
+            "description_cible": "J\u2019ai travaillé plus d\u2019une demi-journée",
+            "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
+            "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
+            "type_element": "select",
+            "valeurs_a_remplir": cfg.additional_information.get(
+                "plus_demi_journee_travaillee",
+                {},
+            ),
+        },
+        {
+            "description_cible": "Durée de la pause déjeuner",
+            "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR200"],
+            "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST_SPECIAL"],
+            "type_element": "input",
+            "valeurs_a_remplir": cfg.additional_information.get(
+                "duree_pause_dejeuner",
+                {},
+            ),
+        },
+        {
+            "description_cible": "Matin",
+            "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
+            "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
+            "type_element": "select",
+            "valeurs_a_remplir": cfg.work_location_am,
+        },
+        {
+            "description_cible": "Après-midi",
+            "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
+            "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
+            "type_element": "select",
+            "valeurs_a_remplir": cfg.work_location_pm,
+        },
+    ]
 
 
 class AdditionalInfoPage:
@@ -66,7 +134,7 @@ class AdditionalInfoPage:
         from sele_saisie_auto import saisie_automatiser_psatime as sap
 
         sap.traiter_description = self.helper.traiter_description
-        self._ensure_descriptions()
+        ensure_descriptions(self.context)
 
     @property
     def log_file(self) -> str:
@@ -87,71 +155,6 @@ class AdditionalInfoPage:
     # ------------------------------------------------------------------
     def wait_for_dom(self, driver, max_attempts: int | None = None) -> None:
         self._automation.wait_for_dom(driver, max_attempts=max_attempts)
-
-    def _ensure_descriptions(self) -> None:
-        """Populate ``context.descriptions`` if empty."""
-        if getattr(self.context, "descriptions", None):
-            return
-
-        cfg = self.context.config
-        self.context.descriptions = [
-            {
-                "description_cible": "Temps de repos de 11h entre 2 jours travaillés respecté",
-                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
-                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
-                "type_element": "select",
-                "valeurs_a_remplir": cfg.additional_information.get(
-                    "periode_repos_respectee",
-                    {},
-                ),
-            },
-            {
-                "description_cible": (
-                    "Mon temps de travail effectif a débuté entre 8h00 et 10h00 et Mon temps de travail effectif a pris fin entre 16h30 et 19h00"
-                ),
-                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
-                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
-                "type_element": "select",
-                "valeurs_a_remplir": cfg.additional_information.get(
-                    "horaire_travail_effectif",
-                    {},
-                ),
-            },
-            {
-                "description_cible": "J\u2019ai travaillé plus d\u2019une demi-journée",
-                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
-                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
-                "type_element": "select",
-                "valeurs_a_remplir": cfg.additional_information.get(
-                    "plus_demi_journee_travaillee",
-                    {},
-                ),
-            },
-            {
-                "description_cible": "Durée de la pause déjeuner",
-                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR200"],
-                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST_SPECIAL"],
-                "type_element": "input",
-                "valeurs_a_remplir": cfg.additional_information.get(
-                    "duree_pause_dejeuner",
-                    {},
-                ),
-            },
-            {
-                "description_cible": "Matin",
-                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
-                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
-                "type_element": "select",
-                "valeurs_a_remplir": cfg.work_location_am,
-            },
-            {
-                "description_cible": "Après-midi",
-                "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
-                "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
-                "type_element": "select",
-                "valeurs_a_remplir": cfg.work_location_pm,
-            },
-        ]
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -21,9 +21,11 @@ from sele_saisie_auto import (
     remplir_jours_feuille_de_temps,
     shared_utils,
 )
-from sele_saisie_auto.additional_info_locators import ADDITIONAL_INFO_LOCATORS
 from sele_saisie_auto.app_config import AppConfig
-from sele_saisie_auto.automation.additional_info_page import AdditionalInfoPage
+from sele_saisie_auto.automation.additional_info_page import (
+    AdditionalInfoPage,
+    ensure_descriptions,
+)
 from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.automation.date_entry_page import DateEntryPage
 from sele_saisie_auto.automation.login_handler import LoginHandler
@@ -154,63 +156,9 @@ class PSATimeAutomation:
                 }.get(str(value).lower(), str(value))
                 for item_projet, value in app_config.project_information.items()
             },
-            descriptions=[
-                {
-                    "description_cible": "Temps de repos de 11h entre 2 jours travaillés respecté",
-                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
-                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
-                    "type_element": "select",
-                    "valeurs_a_remplir": app_config.additional_information[
-                        "periode_repos_respectee"
-                    ],
-                },
-                {
-                    "description_cible": (
-                        "Mon temps de travail effectif a débuté entre 8h00 et 10h00 et Mon temps de travail effectif a pris fin entre 16h30 et 19h00"
-                    ),
-                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
-                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
-                    "type_element": "select",
-                    "valeurs_a_remplir": app_config.additional_information[
-                        "horaire_travail_effectif"
-                    ],
-                },
-                {
-                    "description_cible": "J’ai travaillé plus d’une demi-journée",
-                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR100"],
-                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_DAILYREST"],
-                    "type_element": "select",
-                    "valeurs_a_remplir": app_config.additional_information[
-                        "plus_demi_journee_travaillee"
-                    ],
-                },
-                {
-                    "description_cible": "Durée de la pause déjeuner",
-                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR200"],
-                    "id_value_jours": ADDITIONAL_INFO_LOCATORS[
-                        "DAY_UC_DAILYREST_SPECIAL"
-                    ],
-                    "type_element": "input",
-                    "valeurs_a_remplir": app_config.additional_information[
-                        "duree_pause_dejeuner"
-                    ],
-                },
-                {
-                    "description_cible": "Matin",
-                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
-                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
-                    "type_element": "select",
-                    "valeurs_a_remplir": app_config.work_location_am,
-                },
-                {
-                    "description_cible": "Après-midi",
-                    "id_value_ligne": ADDITIONAL_INFO_LOCATORS["ROW_DESCR"],
-                    "id_value_jours": ADDITIONAL_INFO_LOCATORS["DAY_UC_LOCATION_A"],
-                    "type_element": "select",
-                    "valeurs_a_remplir": app_config.work_location_pm,
-                },
-            ],
+            descriptions=[],
         )
+        ensure_descriptions(self.context)
 
         self._date_entry_page: DateEntryPage | None = None
         self._additional_info_page: AdditionalInfoPage | None = None

--- a/tests/test_additional_info_page.py
+++ b/tests/test_additional_info_page.py
@@ -14,16 +14,21 @@ class DummyAutomation:
     def __init__(self):
         self.log_file = "log.html"
         self.logger = Logger(self.log_file)
+        cfg = types.SimpleNamespace(
+            additional_information={
+                "periode_repos_respectee": {},
+                "horaire_travail_effectif": {},
+                "plus_demi_journee_travaillee": {},
+                "duree_pause_dejeuner": {},
+            },
+            work_location_am={},
+            work_location_pm={},
+            default_timeout=1,
+            long_timeout=1,
+        )
         self.context = types.SimpleNamespace(
-            descriptions=[
-                {
-                    "description_cible": "d",
-                    "id_value_ligne": "x",
-                    "id_value_jours": "y",
-                    "type_element": "select",
-                    "valeurs_a_remplir": {"lundi": "1"},
-                }
-            ]
+            descriptions=[],
+            config=cfg,
         )
         self.browser_session = types.SimpleNamespace(
             go_to_iframe=lambda *a, **k: True,


### PR DESCRIPTION
## Contexte
- les blocs définissant les descriptions des informations supplémentaires étaient construits dans `saisie_automatiser_psatime.py`
- ces valeurs doivent être initialisées par la page `AdditionalInfoPage`

## Changements
- ajout de la méthode `_ensure_descriptions` dans `AdditionalInfoPage`
- appel de cette méthode à l'initialisation de la page

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6888dadd3b988321a8fc95ec4e6c32c2