### PR TITLE
[automation] retire global context

### DIFF
--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -137,7 +137,7 @@ class BrowserSession:
                 "ERROR",
             )
             raise DriverError(f"Failed to start WebDriver: {exc}") from exc
-        if self.driver is not None:  # pragma: no cover - simple branch
+        if self.driver is not None and hasattr(self.driver, "execute_script"):
             self.waiter.wait_for_dom_ready(
                 self.driver,
                 self.app_config.long_timeout if self.app_config else LONG_TIMEOUT,

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -548,7 +548,6 @@ def main(
 _AUTOMATION: PSATimeAutomation | None = None
 _ORCHESTRATOR: AutomationOrchestrator | None = None
 orchestrator: AutomationOrchestrator | None = None
-context: SaisieContext | None = None
 LOG_FILE: str | None = None
 
 
@@ -557,16 +556,15 @@ def initialize(
     app_config: AppConfig,
     choix_user: bool = True,
     memory_config: MemoryConfig | None = None,
-) -> None:
-    """Instancie l'automatisation."""
-    global _AUTOMATION, _ORCHESTRATOR, orchestrator, context, LOG_FILE
+) -> SaisieContext:
+    """Instancie l'automatisation and return the new context."""
+    global _AUTOMATION, _ORCHESTRATOR, orchestrator, LOG_FILE
     _AUTOMATION = PSATimeAutomation(
         log_file,
         app_config,
         choix_user=choix_user,
         memory_config=memory_config,
     )
-    context = _AUTOMATION.context
     LOG_FILE = log_file
     service_configurator = service_configurator_factory(_AUTOMATION.context.config)
     _ORCHESTRATOR = AutomationOrchestrator.from_components(
@@ -579,6 +577,7 @@ def initialize(
     )
     _AUTOMATION.orchestrator = _ORCHESTRATOR
     orchestrator = _ORCHESTRATOR
+    return _AUTOMATION.context
 
 
 def log_initialisation() -> None:


### PR DESCRIPTION
## Contexte et objectif
- suppression de la variable globale `context`
- passage du `SaisieContext` par retour de `initialize`
- protection de `wait_for_dom_ready` quand le faux driver ne supporte pas `execute_script`

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest --cov-fail-under=0 tests/test_full_automation.py`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6888f98efdf4832181955da8b1745196