### PR TITLE
[TimeSheetHelper] type self.waiter

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -50,6 +50,7 @@ from sele_saisie_auto.selenium_utils import (
     wait_for_element,
     wait_until_dom_is_stable,
 )
+from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
@@ -451,6 +452,7 @@ class TimeSheetHelper:
         self.context = context
         self.logger = logger
         self.log_file = logger.log_file
+        self.waiter: WaiterProtocol
         if waiter is None:
             cfg = context.config
             app_cfg = None
@@ -458,9 +460,10 @@ class TimeSheetHelper:
             if isinstance(cfg, ConfigParser):
                 app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
                 timeout = app_cfg.default_timeout
-            self.waiter = create_waiter(timeout)
+            w: Waiter = create_waiter(timeout)
             if app_cfg is not None:
-                self.waiter.wrapper.long_timeout = app_cfg.long_timeout
+                w.wrapper.long_timeout = app_cfg.long_timeout
+            self.waiter = w
         else:
             self.waiter = waiter
         self.additional_info_page = additional_info_page


### PR DESCRIPTION
## Contexte et objectif
- le `Waiter` de `TimeSheetHelper` n’était pas typé selon l’interface
- on ajoute l’annotation `WaiterProtocol` et on adapte l’initialisation

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/remplir_jours_feuille_de_temps.py`
- `poetry run pytest`
- `poetry run mypy src/sele_saisie_auto/remplir_jours_feuille_de_temps.py`

## Impact éventuel sur les autres agents
- aucun impact direct, mise à jour interne du typage

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68890e875dac8321a6167992e4161543