### PR TITLE
[BrowserSession] typage waiter

### DIFF
--- a/src/sele_saisie_auto/automation/browser_session.py
+++ b/src/sele_saisie_auto/automation/browser_session.py
@@ -87,13 +87,15 @@ class BrowserSession:
     ) -> None:  # pragma: no cover - simple wiring
         self.log_file = log_file
         self.app_config = app_config
+        self.waiter: WaiterProtocol
         if waiter is None:
             timeout = DEFAULT_TIMEOUT
             if app_config is not None and hasattr(app_config, "default_timeout"):
                 timeout = app_config.default_timeout
-            self.waiter = create_waiter(timeout)
+            internal_waiter: Waiter = create_waiter(timeout)
             if app_config is not None and hasattr(app_config, "long_timeout"):
-                self.waiter.wrapper.long_timeout = app_config.long_timeout
+                internal_waiter.wrapper.long_timeout = app_config.long_timeout
+            self.waiter = internal_waiter
         else:
             self.waiter = waiter
         if app_config is not None:


### PR DESCRIPTION
## Contexte
- typage manquant pour l'attribut `waiter`

## Changements
- déclarer `self.waiter` avec le protocole `WaiterProtocol`
- s'assurer que `create_waiter` renvoie un objet compatible

## Impact
- aucune régression fonctionnelle attendue

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6889262b618083218a28a13666ffcb24