### PR TITLE
[main_menu] Accepte SimpleNamespace pour root_frame

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -126,7 +126,7 @@ def start_configuration(
 
     notebook: ttk.Notebook | tk.Tk
     if hasattr(root, "tk"):
-        notebook= ttk.Notebook(root)  # pragma: no cover - UI init
+        notebook = ttk.Notebook(root)  # pragma: no cover - UI init
         notebook.pack(fill="both", expand=True)  # pragma: no cover - UI init
     else:  # fallback for DummyRoot in tests
         notebook = root

--- a/src/sele_saisie_auto/main_menu.py
+++ b/src/sele_saisie_auto/main_menu.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import tkinter as tk
 from tkinter import ttk
+from typing import Any
 
 from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.gui_builder import (
@@ -31,6 +32,7 @@ def main_menu(
     menu.geometry("400x300")
 
     # Conteneur ttk pour satisfaire les helpers typés « ttk.Widget »
+    root_frame: ttk.Frame | Any
     try:
         root_frame = ttk.Frame(menu)
         root_frame.pack(fill="both", expand=True)


### PR DESCRIPTION
## Contexte et objectif
- corrige l'erreur `mypy` lors de l'assignation de `SimpleNamespace` dans `main_menu`
- adaptation légère de `launcher` pour respecter le formatage

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
- aucun autre agent impacté

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6889cfb025ac8321887e1e33b48d8e44