### PR TITLE
[AutomationOrchestrator] add helpers to simplify memory cleanup

### DIFF
--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -126,6 +126,11 @@ class EncryptionService:
         self.cle_aes: bytes | None = None
         self._memoires: list[shared_memory.SharedMemory] = []
 
+    def remove_shared_memory(self, memoire: shared_memory.SharedMemory) -> None:
+        """Delegate secure removal of ``memoire`` to the underlying service."""
+
+        self.shared_memory_service.supprimer_memoire_partagee_securisee(memoire)
+
     def generer_cle_aes(self, taille_cle: int = 32) -> bytes:
         """Génère aléatoirement une clé AES."""
 
@@ -162,7 +167,7 @@ class EncryptionService:
         except Exception as exc:  # pragma: no cover - cleanup best effort
             if mem is not None:
                 try:
-                    self.shared_memory_service.supprimer_memoire_partagee_securisee(mem)
+                    self.remove_shared_memory(mem)
                 except Exception:  # nosec B110
                     pass
             self.cle_aes = None
@@ -196,7 +201,7 @@ class EncryptionService:
         """Securely remove all allocated shared memories."""
         for mem in self._memoires:
             try:
-                self.shared_memory_service.supprimer_memoire_partagee_securisee(mem)
+                self.remove_shared_memory(mem)
             except Exception:  # nosec B110
                 pass
         self._memoires.clear()

--- a/src/sele_saisie_auto/resources/resource_context.py
+++ b/src/sele_saisie_auto/resources/resource_context.py
@@ -37,9 +37,7 @@ class ResourceContext:
             ):
                 if mem is not None:
                     try:
-                        self.encryption_service.shared_memory_service.supprimer_memoire_partagee_securisee(
-                            mem
-                        )
+                        self.encryption_service.remove_shared_memory(mem)
                     except Exception:  # nosec B110 - cleanup best effort
                         pass
         self._credentials = None

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -12,11 +12,7 @@ from typing import Any, cast
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from sele_saisie_auto import (
-    messages,
-    remplir_jours_feuille_de_temps,
-    shared_utils,
-)
+from sele_saisie_auto import messages, remplir_jours_feuille_de_temps, shared_utils
 from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.automation.additional_info_page import (
     AdditionalInfoPage,
@@ -25,6 +21,7 @@ from sele_saisie_auto.automation.additional_info_page import (
 from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.automation.date_entry_page import DateEntryPage
 from sele_saisie_auto.automation.login_handler import LoginHandler
+from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import Services, service_configurator_factory
 from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.encryption_utils import Credentials as EncryptionCredentials
@@ -32,26 +29,28 @@ from sele_saisie_auto.exceptions import (
     AutomationExitError,
     AutomationNotInitializedError,
 )
-from sele_saisie_auto.interfaces.protocols import (
-    LoggerProtocol,
-)
+from sele_saisie_auto.interfaces.protocols import LoggerProtocol
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import show_log_separator, write_log
 from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
 from sele_saisie_auto.navigation import PageNavigator
 from sele_saisie_auto.orchestration import AutomationOrchestrator
+from sele_saisie_auto.remplir_jours_feuille_de_temps import ajouter_jour_a_jours_remplis
 from sele_saisie_auto.resources.resource_manager import ResourceManager
 from sele_saisie_auto.saisie_context import SaisieContext
 from sele_saisie_auto.selenium_utils import (
     click_element_without_wait,
+    detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.date_utils import get_next_saturday_if_not_saturday
 from sele_saisie_auto.utils.misc import program_break_time
+from sele_saisie_auto.utils.mission import est_en_mission
 
 # ----------------------------------------------------------------------------- #
 # ------------------------------- CONSTANTE ----------------------------------- #
@@ -87,8 +86,12 @@ __all__ = [
     "modifier_date_input",
     "send_keys_to_element",
     "click_element_without_wait",
+    "set_log_file_selenium",
+    "detecter_doublons_jours",
     "AutomationExitError",
     "get_next_saturday_if_not_saturday",
+    "est_en_mission",
+    "ajouter_jour_a_jours_remplis",
 ]
 
 

--- a/src/sele_saisie_auto/saisie_context.py
+++ b/src/sele_saisie_auto/saisie_context.py
@@ -17,5 +17,10 @@ class SaisieContext:
     project_mission_info: dict[str, str]
     descriptions: list[dict[str, object]]
 
+    def remove_shared_memory(self, mem) -> None:
+        """Delegate cleanup to ``SharedMemoryService``."""
+
+        self.shared_memory_service.supprimer_memoire_partagee_securisee(mem)
+
 
 __all__ = ["SaisieContext"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,10 @@ class FakeEncryptionService:
     def supprimer_memoire_partagee_securisee(self, mem):
         self.removed.append(mem)
 
+    # New helper mirroring production API
+    def remove_shared_memory(self, mem):
+        self.supprimer_memoire_partagee_securisee(mem)
+
 
 # ----------------------------
 # Common test stubs

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -299,6 +299,9 @@ def test_exit_uses_shared_memory_service(monkeypatch):
         def supprimer_memoire_partagee_securisee(self, mem):
             self.removed.append(mem)
 
+        def remove_shared_memory(self, mem):
+            self.supprimer_memoire_partagee_securisee(mem)
+
     class SpyCtx(DummyResourceContext):
         def __init__(self, log_file, encryption_service=None):
             super().__init__(log_file, encryption_service)
@@ -308,15 +311,9 @@ def test_exit_uses_shared_memory_service(monkeypatch):
             self.mem_password = object()
 
         def __exit__(self, exc_type, exc, tb):
-            self.shared_memory_service.supprimer_memoire_partagee_securisee(
-                self.mem_key
-            )
-            self.shared_memory_service.supprimer_memoire_partagee_securisee(
-                self.mem_login
-            )
-            self.shared_memory_service.supprimer_memoire_partagee_securisee(
-                self.mem_password
-            )
+            self.shared_memory_service.remove_shared_memory(self.mem_key)
+            self.shared_memory_service.remove_shared_memory(self.mem_login)
+            self.shared_memory_service.remove_shared_memory(self.mem_password)
 
         def get_credentials(self):
             return Credentials(
@@ -377,15 +374,9 @@ def test_close_removes_shared_memory_segments(monkeypatch):
             )
 
         def __exit__(self, exc_type, exc, tb):
-            self.shared_memory_service.supprimer_memoire_partagee_securisee(
-                self.mem_key
-            )
-            self.shared_memory_service.supprimer_memoire_partagee_securisee(
-                self.mem_login
-            )
-            self.shared_memory_service.supprimer_memoire_partagee_securisee(
-                self.mem_password
-            )
+            self.shared_memory_service.remove_shared_memory(self.mem_key)
+            self.shared_memory_service.remove_shared_memory(self.mem_login)
+            self.shared_memory_service.remove_shared_memory(self.mem_password)
 
     monkeypatch.setattr(resource_manager, "ConfigManager", DummyConfigManager)
     monkeypatch.setattr(

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -35,6 +35,9 @@ class DummySHMService:
     def supprimer_memoire_partagee_securisee(self, mem):
         self.removed.append(mem)
 
+    def remove_shared_memory(self, mem):
+        self.supprimer_memoire_partagee_securisee(mem)
+
 
 class DummySHM:
     def __init__(self, name):

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -51,6 +51,9 @@ class DummyEnc:
     def supprimer_memoire_partagee_securisee(self, mem):
         self.removed.append(mem)
 
+    def remove_shared_memory(self, mem):
+        self.supprimer_memoire_partagee_securisee(mem)
+
 
 class DummySHMService:
     def __init__(self):
@@ -61,6 +64,9 @@ class DummySHMService:
 
     def supprimer_memoire_partagee_securisee(self, mem):
         self.removed.append(mem)
+
+    def remove_shared_memory(self, mem):
+        self.supprimer_memoire_partagee_securisee(mem)
 
 
 class DummyManager:


### PR DESCRIPTION
## Contexte
- simplification de la libération des segments mémoire
- mise en place d'une méthode utilitaire `remove_shared_memory`
- adaptation des tests utilisant la chaîne `obj.a.b.c()`

## Impact
- légère refactorisation de `EncryptionService`, `ResourceContext` et `PSATimeAutomation`
- mise à jour de plusieurs stubs de tests

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688b3785f8e0832181791cae5b28cb67