### PR TITLE
[TimesheetHelper] Ajout du protocole d'interface

### DIFF
--- a/src/sele_saisie_auto/interfaces/protocols.py
+++ b/src/sele_saisie_auto/interfaces/protocols.py
@@ -2,11 +2,20 @@
 # pragma: no cover
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from sele_saisie_auto.app_config import AppConfig
+
+if TYPE_CHECKING:  # pragma: no cover - avoid runtime circular import
+    from sele_saisie_auto.remplir_jours_feuille_de_temps import (
+        TimesheetHelperProtocol as TimeSheetHelperProtocol,
+    )
+else:
+
+    class TimeSheetHelperProtocol(Protocol):
+        def run(self, driver: WebDriver) -> None: ...
 
 
 @runtime_checkable
@@ -92,11 +101,6 @@ class AdditionalInfoPageProtocol(Protocol):
     def submit_and_validate_additional_information(self, driver: WebDriver) -> bool: ...
     def save_draft_and_validate(self, driver: WebDriver) -> bool: ...
     def log_information_details(self) -> None: ...
-
-
-@runtime_checkable
-class TimeSheetHelperProtocol(Protocol):
-    def run(self, driver: WebDriver) -> None: ...
 
 
 __all__ = [

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from configparser import ConfigParser
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Protocol, cast, runtime_checkable
 
 from selenium.common.exceptions import (
     NoSuchElementException,
@@ -67,6 +67,13 @@ class TimeSheetContext:
     work_days: dict[str, tuple[str, str]]
     project_mission_info: dict[str, str]
     config: ConfigParser | None = None
+
+
+@runtime_checkable
+class TimesheetHelperProtocol(Protocol):
+    """Minimal interface for :class:`TimeSheetHelper`."""
+
+    def run(self, driver: WebDriver) -> None: ...
 
 
 def context_from_app_config(


### PR DESCRIPTION
## Contexte et objectif
- introduction du `TimesheetHelperProtocol` dans `remplir_jours_feuille_de_temps`
- utilisation de cette interface dans `AutomationOrchestrator`
- mise à jour des types et résolution de l'import circulaire

## Étapes pour tester
1. `poetry run pre-commit run --files src/sele_saisie_auto/remplir_jours_feuille_de_temps.py src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/interfaces/protocols.py`
2. `poetry run mypy --strict --no-incremental src`
3. `poetry run pytest -q` *(peut échouer sur la couverture)*

## Impact éventuel
- améliore l'encapsulation entre les modules

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688b7af79c1c83219232572ddc63077e