### PR TITLE
[AutomationOrchestrator] retire legacy wrappers

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -10,6 +10,7 @@ from typing import cast
 
 from sele_saisie_auto import cli, messages, saisie_automatiser_psatime
 from sele_saisie_auto.config_manager import ConfigManager
+from sele_saisie_auto.configuration import service_configurator_factory
 from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.gui_builder import (
     create_a_frame,
@@ -19,8 +20,10 @@ from sele_saisie_auto.gui_builder import (
     create_modern_label_with_pack,
     create_tab,
 )
+from sele_saisie_auto.interfaces import LoggerProtocol
 from sele_saisie_auto.logger_utils import LOG_LEVELS
 from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
+from sele_saisie_auto.orchestration import AutomationOrchestrator
 from sele_saisie_auto.read_or_write_file_config_ini_utils import (
     read_config_ini,
     write_config_ini,
@@ -44,21 +47,39 @@ def run_psatime(
         with get_logger(log_file) as log:
             log.info("Launching PSA time")
             cfg = ConfigManager(log_file=log_file).load()
+            service_configurator = service_configurator_factory(cfg)
             automation = saisie_automatiser_psatime.PSATimeAutomation(
                 log_file,
                 cfg,
                 logger=log,
             )
-            automation.run(headless=headless, no_sandbox=no_sandbox)
+            orchestrator = AutomationOrchestrator.from_components(
+                automation.resource_manager,
+                automation.page_navigator,
+                service_configurator,
+                automation.context,
+                cast(LoggerProtocol, automation.logger),
+                choix_user=automation.choix_user,
+            )
+            orchestrator.run(headless=headless, no_sandbox=no_sandbox)
     else:
         logger.info("Launching PSA time")
         cfg = ConfigManager(log_file=log_file).load()
+        service_configurator = service_configurator_factory(cfg)
         automation = saisie_automatiser_psatime.PSATimeAutomation(
             log_file,
             cfg,
             logger=logger,
         )
-        automation.run(headless=headless, no_sandbox=no_sandbox)
+        orchestrator = AutomationOrchestrator.from_components(
+            automation.resource_manager,
+            automation.page_navigator,
+            service_configurator,
+            automation.context,
+            cast(LoggerProtocol, automation.logger),
+            choix_user=automation.choix_user,
+        )
+        orchestrator.run(headless=headless, no_sandbox=no_sandbox)
 
 
 def run_psatime_with_credentials(

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -552,58 +552,5 @@ orchestrator: AutomationOrchestrator | None = None
 LOG_FILE: str | None = None
 
 
-def initialize(
-    log_file: str,
-    app_config: AppConfig,
-    choix_user: bool = True,
-    memory_config: MemoryConfig | None = None,
-) -> SaisieContext:
-    """Instancie l'automatisation and return the new context."""
-    global _AUTOMATION, _ORCHESTRATOR, orchestrator, LOG_FILE
-    _AUTOMATION = PSATimeAutomation(
-        log_file,
-        app_config,
-        choix_user=choix_user,
-        memory_config=memory_config,
-    )
-    LOG_FILE = log_file
-    service_configurator = service_configurator_factory(_AUTOMATION.context.config)
-    _ORCHESTRATOR = AutomationOrchestrator.from_components(
-        _AUTOMATION.resource_manager,
-        _AUTOMATION.page_navigator,
-        service_configurator,
-        _AUTOMATION.context,
-        cast(LoggerProtocol, _AUTOMATION.logger),
-        choix_user=_AUTOMATION.choix_user,
-    )
-    _AUTOMATION.orchestrator = _ORCHESTRATOR
-    orchestrator = _ORCHESTRATOR
-    return _AUTOMATION.context
-
-
-def log_initialisation() -> None:
-    """Enregistre les informations initiales dans les logs."""
-    if not orchestrator:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    if not orchestrator.log_file:
-        raise RuntimeError(f"Fichier de log {messages.INTROUVABLE}.")
-    log_info(
-        "\ud83d\udccc D\u00e9marrage de la fonction 'saisie_automatiser_psatime.run()'",
-        orchestrator.log_file,
-    )
-    write_log(
-        f"\ud83d\udd0d Chemin du fichier log : {orchestrator.log_file}",
-        orchestrator.log_file,
-        "DEBUG",
-    )
-
-
-def initialize_shared_memory() -> EncryptionCredentials:
-    """Récupère les identifiants chiffrés depuis la mémoire partagée."""
-    if not _ORCHESTRATOR:
-        raise AutomationNotInitializedError("Automation non initialisée")
-    return cast(EncryptionCredentials, _ORCHESTRATOR.initialize_shared_memory())
-
-
 if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -269,7 +269,7 @@ def test_helpers(monkeypatch, sample_config):
             logger_utils, "show_log_separator", lambda *a, **k: called.append(True)
         )
         sap.seprateur_menu_affichage_console()
-    sap.log_initialisation()
+    sap._AUTOMATION.log_initialisation()
     assert messages
 
 
@@ -314,7 +314,7 @@ def test_initialize_shared_memory(monkeypatch, sample_config):
     sap.context.encryption_service = FakeEncryptionService()
     sap.context.shared_memory_service = DummySHMService()
     monkeypatch.setattr(sap, "write_log", lambda *a, **k: None)
-    result = sap.initialize_shared_memory()
+    result = sap._ORCHESTRATOR.initialize_shared_memory()
     assert result.login == b"user"
     assert result.password == b"pass"
 
@@ -325,7 +325,7 @@ def test_main_flow(monkeypatch, sample_config):
     sap.context.config.date_cible = "06/07/2024"
     sap.orchestrator.choix_user = True
 
-    monkeypatch.setattr(sap, "log_initialisation", lambda: None)
+    monkeypatch.setattr(sap._AUTOMATION, "log_initialisation", lambda: None)
     monkeypatch.setattr(
         sap.PSATimeAutomation,
         "initialize_shared_memory",

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -272,7 +272,7 @@ EXCEPTIONS = [
 def test_main_exceptions(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
     sap._AUTOMATION.choix_user = True
-    monkeypatch.setattr(sap, "log_initialisation", lambda: None)
+    monkeypatch.setattr(sap._AUTOMATION, "log_initialisation", lambda: None)
     monkeypatch.setattr(
         sap.PSATimeAutomation,
         "initialize_shared_memory",
@@ -329,7 +329,7 @@ def test_main_exceptions(monkeypatch, sample_config):
         lambda self: cleanup.setdefault("done", True),
     )
     monkeypatch.setattr(
-        sap.PSATimeAutomation,
+        sap.AutomationOrchestrator,
         "run",
         lambda self, headless=False, no_sandbox=False: cleanup.setdefault("done", True),
     )

--- a/tests/test_saisie_automatiser_psatime_cover.py
+++ b/tests/test_saisie_automatiser_psatime_cover.py
@@ -133,12 +133,8 @@ def test_initialize_debug_mode_off(monkeypatch, sample_config, tmp_path):
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
     monkeypatch.setattr(sap, "EncryptionService", lambda lf, shm=None: DummyManager())
     app_cfg.debug_mode = "OFF"
-    sap.initialize(
-        str(log_path),
-        app_cfg,
-        choix_user=True,
-        memory_config=sap.MemoryConfig(),
-    )
+    cfg["settings"]["debug_mode"] = "OFF"
+    setup_init(monkeypatch, cfg)
     monkeypatch.setattr(
         sap,
         "ConfigManager",
@@ -148,6 +144,7 @@ def test_initialize_debug_mode_off(monkeypatch, sample_config, tmp_path):
 
 
 def test_switch_to_iframe_main_target_win0_no_element(monkeypatch):
+    setup_init(monkeypatch, configparser.ConfigParser())
     monkeypatch.setattr(
         sap._AUTOMATION.waiter, "wait_for_element", lambda *a, **k: False
     )
@@ -181,6 +178,7 @@ def test_handle_date_input_no_element(monkeypatch, sample_config):
 
 
 def test_submit_and_validate_additional_information_none(monkeypatch):
+    setup_init(monkeypatch, configparser.ConfigParser())
     monkeypatch.setattr(
         sap._AUTOMATION.additional_info_page,
         "submit_and_validate_additional_information",


### PR DESCRIPTION
## Contexte
- simplifie `saisie_automatiser_psatime` en supprimant les fonctions
  `initialize`, `log_initialisation` et `initialize_shared_memory`
- les scripts utilisent désormais directement `AutomationOrchestrator`
- mise à jour des imports et des tests

## Test
- `pre-commit` sur les fichiers modifiés
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c71498b8883218af277bac5d7a4fc