### PR TITLE
[ResourceManager] Document options CLI

### DIFF
--- a/docs/guides/advanced-usage-example.md
+++ b/docs/guides/advanced-usage-example.md
@@ -122,5 +122,5 @@ with automation.resource_manager as manager:
         automation.context,
         automation.logger,
     )
-    orchestrator.run(headless=True)
+    orchestrator.run(headless=True, no_sandbox=True)
 ```

--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -18,6 +18,7 @@ poetry run psatime-auto
 ```
 
 Cette commande lit `config.ini` dans le répertoire courant et lance directement l'automatisation. Un fichier de log est créé automatiquement sous `logs/` si aucun chemin n'est spécifié.
+Vous pouvez également utiliser les options `--headless` et `--no-sandbox` pour contrôler la façon dont le navigateur est lancé.
 
 ### Exemple de configuration minimale
 


### PR DESCRIPTION
## Contexte et objectif
- vérification de l'usage du paramètre `no_sandbox`
- documentation des options CLI pour le navigateur

## Étapes pour tester
- `poetry run pre-commit run --files docs/guides/usage-example.md docs/guides/advanced-usage-example.md`
- `poetry run mypy --strict --no-incremental src/`

## Impact éventuel
- aucun impact sur les autres agents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688c92f31f588321b4e0cc15f19c3e18