### PR TITLE
[AutomationOrchestrator] retire choix_user

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -14,7 +14,6 @@ class PSATimeAutomation:
         self,
         log_file: str,
         app_config: AppConfig,
-        choix_user: bool = True,
         memory_config: MemoryConfig | None = None,
     ) -> None:
         """Prépare la configuration et les services nécessaires."""

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -203,11 +203,9 @@ class DateEntryPage:
         self.alert_handler.handle_date_alert(driver)
 
     @handle_selenium_errors(default_return=None)
-    def _click_action_button(self, driver: WebDriver, create_new: bool) -> None:
-        """Click the appropriate action button on the page."""
-        elem_id = (
-            Locators.OK_BUTTON.value if create_new else Locators.COPY_TIME_BUTTON.value
-        )
+    def _click_action_button(self, driver: WebDriver) -> None:
+        """Click the default action button on the page."""
+        elem_id = Locators.OK_BUTTON.value
         element_present = self.waiter.wait_for_element(
             driver,
             By.ID,

--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -70,7 +70,6 @@ def main(argv: list[str] | None = None) -> None:
             service_configurator,
             automation.context,
             cast(LoggerProtocol, automation.logger),
-            choix_user=automation.choix_user,
         )
         orchestrator.run(headless=args.headless, no_sandbox=args.no_sandbox)
 
@@ -96,7 +95,6 @@ def cli_main(
             service_configurator,
             automation.context,
             cast(LoggerProtocol, automation.logger),
-            choix_user=automation.choix_user,
         )
         orchestrator.run(headless=headless, no_sandbox=no_sandbox)
 

--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -59,7 +59,6 @@ def run_psatime(
                 service_configurator,
                 automation.context,
                 cast(LoggerProtocol, automation.logger),
-                choix_user=automation.choix_user,
             )
             orchestrator.run(headless=headless, no_sandbox=no_sandbox)
     else:
@@ -77,7 +76,6 @@ def run_psatime(
             service_configurator,
             automation.context,
             cast(LoggerProtocol, automation.logger),
-            choix_user=automation.choix_user,
         )
         orchestrator.run(headless=headless, no_sandbox=no_sandbox)
 

--- a/src/sele_saisie_auto/orchestration/automation_orchestrator.py
+++ b/src/sele_saisie_auto/orchestration/automation_orchestrator.py
@@ -56,7 +56,6 @@ class AutomationOrchestrator:
         date_entry_page: DateEntryPageProtocol,
         additional_info_page: AdditionalInfoPageProtocol,
         context: SaisieContext,
-        choix_user: bool = True,
         *,
         alert_handler: AlertHandler | None = None,
         timesheet_helper_cls: type[TimesheetHelperProtocol] = TimeSheetHelper,
@@ -72,7 +71,6 @@ class AutomationOrchestrator:
         self.date_entry_page: DateEntryPageProtocol = date_entry_page
         self.additional_info_page: AdditionalInfoPageProtocol = additional_info_page
         self.context: SaisieContext = context
-        self.choix_user: bool = choix_user
         self.timesheet_helper_cls: type[TimesheetHelperProtocol] = timesheet_helper_cls
         self._cleanup_callback: Callable[[object, object, object], None] | None = (
             cleanup_resources
@@ -108,7 +106,6 @@ class AutomationOrchestrator:
         service_configurator: ServiceConfigurator,
         context: SaisieContext,
         logger: LoggerProtocol,
-        choix_user: bool = True,
         *,
         alert_handler: AlertHandler | None = None,
         timesheet_helper_cls: type[TimesheetHelperProtocol] = TimeSheetHelper,
@@ -124,7 +121,6 @@ class AutomationOrchestrator:
             page_navigator.date_entry_page,
             page_navigator.additional_info_page,
             context,
-            choix_user,
             alert_handler=alert_handler,
             timesheet_helper_cls=timesheet_helper_cls,
             cleanup_resources=cleanup_resources,

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -121,7 +121,6 @@ class PSATimeAutomation:
         self,
         log_file: str,
         app_config: AppConfig,
-        choix_user: bool = True,
         memory_config: MemoryConfig | None = None,
         *,
         logger: Logger | None = None,
@@ -131,7 +130,6 @@ class PSATimeAutomation:
         """Initialise la configuration et les dépendances."""
 
         self.log_file: str = log_file
-        self.choix_user = choix_user
         self.memory_config = memory_config or MemoryConfig()
         LoggingConfigurator.setup(log_file, app_config.debug_mode, app_config.raw)
         self.logger = logger or get_logger(log_file)
@@ -437,7 +435,7 @@ class PSATimeAutomation:
 
     def _click_action_button(self, driver: WebDriver) -> None:
         """Clique sur le bouton d'action principal."""
-        self.date_entry_page._click_action_button(driver, self.choix_user)
+        self.date_entry_page._click_action_button(driver)
 
     def _process_date_entry(self, driver: WebDriver) -> None:
         """Renseigne la date cible dans l'interface."""
@@ -481,7 +479,6 @@ class PSATimeAutomation:
             service_configurator,
             self.context,
             cast(LoggerProtocol, self.logger),
-            choix_user=self.choix_user,
         )
         self.orchestrator.run(headless=headless, no_sandbox=no_sandbox)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ class DummyDateEntryPage:
     def process_date(self, driver, date):
         self.calls.append(("date", date))
 
-    def _click_action_button(self, driver, create_new):
+    def _click_action_button(self, driver):
         self.calls.append("click")
 
     def submit_date_cible(self, driver):

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -66,7 +66,6 @@ def test_run_calls_services(monkeypatch, sample_config):
         date_page,
         add_page,
         ctx,
-        True,
         timesheet_helper_cls=DummyHelper,
     )
     orch.page_navigator = PageNavigator(
@@ -106,7 +105,7 @@ def test_run_calls_services(monkeypatch, sample_config):
     orch.browser_session.waiter = types.SimpleNamespace(
         wait_for_element=lambda *a, **k: True
     )
-    orch.date_entry_page._click_action_button = lambda d, c: None
+    orch.date_entry_page._click_action_button = lambda d: None
     orch.additional_info_page._handle_save_alerts = lambda d: None
     from sele_saisie_auto.orchestration import automation_orchestrator as orch_mod
 
@@ -147,7 +146,6 @@ def test_wrappers(monkeypatch, sample_config):
         DummyDateEntryPage(),
         DummyAddPage(),
         SaisieContext(app_cfg, None, None, {}, []),
-        True,
         timesheet_helper_cls=DummyHelper,
     )
 
@@ -194,7 +192,6 @@ def test_run_order(monkeypatch, sample_config):
         date_page,
         add_page,
         ctx,
-        True,
         timesheet_helper_cls=DummyHelper,
     )
     orch.page_navigator = PageNavigator(
@@ -273,7 +270,6 @@ def test_run_uses_passed_cleanup_function(monkeypatch, sample_config):
         date_page,
         add_page,
         ctx,
-        True,
         timesheet_helper_cls=DummyHelper,
         cleanup_resources=cleanup_func,
     )
@@ -292,7 +288,7 @@ def test_run_uses_passed_cleanup_function(monkeypatch, sample_config):
     orch.browser_session.waiter = types.SimpleNamespace(
         wait_for_element=lambda *a, **k: True
     )
-    orch.date_entry_page._click_action_button = lambda d, c: None
+    orch.date_entry_page._click_action_button = lambda d: None
     orch.additional_info_page._handle_save_alerts = lambda d: None
     from sele_saisie_auto.orchestration import automation_orchestrator as orch_mod
 
@@ -339,7 +335,6 @@ def test_run_sequence_with_mocks(sample_config):
         svc,
         ctx,
         logger,
-        choix_user=True,
         timesheet_helper_cls=lambda *a, **k: object(),
     )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,7 +67,6 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
             self.page_navigator = object()
             self.context = types.SimpleNamespace()
             self.logger = logger
-            self.choix_user = True
 
     class DummyOrchestrator:
         def __init__(self, *args, **kwargs):

--- a/tests/test_date_entry_page.py
+++ b/tests/test_date_entry_page.py
@@ -163,7 +163,7 @@ def test_click_action_button(monkeypatch):
     monkeypatch.setattr(
         dummy.browser_session, "click", lambda *a, **k: clicks.append(True)
     )
-    page._click_action_button("drv", True)
+    page._click_action_button("drv")
     assert clicks
 
 
@@ -175,7 +175,7 @@ def test_click_action_button_copy(monkeypatch):
     monkeypatch.setattr(
         dummy.browser_session, "click", lambda *a, **k: clicks.append(True)
     )
-    page._click_action_button("drv", False)
+    page._click_action_button("drv")
     assert clicks
 
 

--- a/tests/test_full_automation.py
+++ b/tests/test_full_automation.py
@@ -139,7 +139,6 @@ def test_full_automation(monkeypatch, sample_config):
             types.SimpleNamespace(app_config=APP_CFG),
             ctx,
             logger,
-            choix_user=True,
             timesheet_helper_cls=DummyHelper,
         )
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -126,7 +126,6 @@ def test_run_psatime(monkeypatch, dummy_logger, sample_config):
             self.page_navigator = object()
             self.context = types.SimpleNamespace()
             self.logger = logger
-            self.choix_user = True
 
     class DummyOrchestrator:
         def __init__(self, *a, **k):
@@ -196,7 +195,6 @@ def test_run_psatime_flags(monkeypatch, dummy_logger, sample_config):
             self.page_navigator = object()
             self.context = types.SimpleNamespace()
             self.logger = logger
-            self.choix_user = True
 
     class DummyOrchestrator:
         def __init__(self):

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -222,7 +222,6 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
         service_configurator,
         auto.context,
         auto.logger,
-        choix_user=True,
     )
     auto.orchestrator = orch
     monkeypatch.setattr(sap, "_AUTOMATION", auto, raising=False)
@@ -278,7 +277,6 @@ def test_initialize_sets_globals(monkeypatch, sample_config):
     assert sap.context.config.url == "http://test"
     assert sap.context.config.work_schedule["lundi"] == ("En mission", "8")
     assert sap.context.project_mission_info["billing_action"] == "B"
-    assert sap.orchestrator.choix_user is True
     assert isinstance(sap._AUTOMATION.memory_config, sap.MemoryConfig)
 
 
@@ -323,7 +321,6 @@ def test_main_flow(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
     sap.context.config.url = "http://test"
     sap.context.config.date_cible = "06/07/2024"
-    sap.orchestrator.choix_user = True
 
     monkeypatch.setattr(sap._AUTOMATION, "log_initialisation", lambda: None)
     monkeypatch.setattr(
@@ -447,5 +444,4 @@ def test_run_delegates_to_orchestrator(monkeypatch, sample_config):
     assert called["from_components"][0][2].app_config is app_cfg
     assert called["from_components"][0][3] is auto.context
     assert called["from_components"][0][4] is auto.logger
-    assert called["from_components"][1]["choix_user"] is True
     assert called["run"] == (True, True)

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -136,7 +136,6 @@ def setup_init(monkeypatch, cfg):
         service_configurator,
         auto.context,
         auto.logger,
-        choix_user=True,
     )
     auto.orchestrator = orch
     monkeypatch.setattr(sap, "_AUTOMATION", auto, raising=False)
@@ -271,7 +270,6 @@ EXCEPTIONS = [
 
 def test_main_exceptions(monkeypatch, sample_config):
     setup_init(monkeypatch, sample_config)
-    sap._AUTOMATION.choix_user = True
     monkeypatch.setattr(sap._AUTOMATION, "log_initialisation", lambda: None)
     monkeypatch.setattr(
         sap.PSATimeAutomation,


### PR DESCRIPTION
## Contexte
Suppression de la logique `choix_user` devenue inutile dans `PSATimeAutomation` et `AutomationOrchestrator`.

## Changements
- retrait du paramètre `choix_user` et simplification des appels
- adaptation des tests et de la documentation

## Tests
- `poetry run pre-commit run --files docs/reference/api-reference.md src/sele_saisie_auto/automation/date_entry_page.py src/sele_saisie_auto/cli.py src/sele_saisie_auto/launcher.py src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/saisie_automatiser_psatime.py tests/conftest.py tests/test_automation_orchestrator.py tests/test_cli.py tests/test_date_entry_page.py tests/test_full_automation.py tests/test_launcher.py tests/test_saisie_automatiser_psatime.py tests/test_saisie_automatiser_psatime_additional.py`
- `poetry run pytest -q`
- `poetry run mypy --strict --no-incremental src/`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688c9d4fbcfc8321bc2b692d97b2e25a