### PR TITLE
[refactor] retire from_automation helpers

### DIFF
--- a/src/sele_saisie_auto/additional_info_locators.py
+++ b/src/sele_saisie_auto/additional_info_locators.py
@@ -1,6 +1,5 @@
 """Definitions of HTML id prefixes used for the additional info modal."""
 
-
 # --------------------------------------------------------------------------- #
 # Mapping brut id_logique ➜ id_HTML
 # --------------------------------------------------------------------------- #

--- a/src/sele_saisie_auto/automation/additional_info_page.py
+++ b/src/sele_saisie_auto/automation/additional_info_page.py
@@ -95,13 +95,6 @@ def ensure_descriptions(context: SaisieContext) -> None:
 class AdditionalInfoPage:
     """Handle the additional information modal."""
 
-    @classmethod
-    def from_automation(
-        cls, automation: PSATimeAutomation, waiter: WaiterProtocol | None = None
-    ) -> AdditionalInfoPage:
-        """Create a page instance from a :class:`PSATimeAutomation`."""
-        return cls(automation, waiter=waiter)
-
     def __init__(
         self, automation: PSATimeAutomation, waiter: WaiterProtocol | None = None
     ) -> None:

--- a/src/sele_saisie_auto/automation/date_entry_page.py
+++ b/src/sele_saisie_auto/automation/date_entry_page.py
@@ -30,17 +30,6 @@ if TYPE_CHECKING:
 class DateEntryPage:
     """Handle the timesheet date selection page."""
 
-    @classmethod
-    def from_automation(
-        cls,
-        automation: PSATimeAutomation,
-        *,
-        page_navigator: PageNavigator | None = None,
-        waiter: WaiterProtocol | None = None,
-    ) -> DateEntryPage:
-        """Create a page instance from a :class:`PSATimeAutomation`."""
-        return cls(automation, page_navigator=page_navigator, waiter=waiter)
-
     def __init__(
         self,
         automation: PSATimeAutomation,

--- a/src/sele_saisie_auto/automation/login_handler.py
+++ b/src/sele_saisie_auto/automation/login_handler.py
@@ -21,15 +21,6 @@ if TYPE_CHECKING:
 class LoginHandler:
     """Handle login steps for PSA Time."""
 
-    @classmethod
-    def from_automation(cls, automation: PSATimeAutomation) -> LoginHandler:
-        """Create a new instance using an automation context."""
-        return cls(
-            automation.log_file,
-            automation.encryption_service,
-            automation.browser_session,
-        )
-
     def __init__(
         self,
         log_file: str | None,

--- a/src/sele_saisie_auto/navigation/page_navigator.py
+++ b/src/sele_saisie_auto/navigation/page_navigator.py
@@ -30,30 +30,6 @@ class PageNavigator:
     those pages.
     """
 
-    @classmethod
-    def from_automation(cls, automation: PSATimeAutomation) -> PageNavigator:
-        """Return a new :class:`PageNavigator` configured from ``automation``."""
-        from sele_saisie_auto import remplir_jours_feuille_de_temps
-
-        timesheet_ctx = remplir_jours_feuille_de_temps.context_from_app_config(
-            automation.context.config,
-            automation.log_file,
-        )
-        helper = remplir_jours_feuille_de_temps.TimeSheetHelper(
-            timesheet_ctx,
-            cast(LoggerProtocol, automation.logger),
-            waiter=automation.waiter,
-            additional_info_page=automation.additional_info_page,
-            browser_session=automation.browser_session,
-        )
-        return cls(
-            automation.browser_session,
-            automation.login_handler,
-            automation.date_entry_page,
-            automation.additional_info_page,
-            helper,
-        )
-
     def __init__(
         self,
         browser_session: BrowserSessionProtocol,

--- a/tests/test_contract_compliance.py
+++ b/tests/test_contract_compliance.py
@@ -1,4 +1,3 @@
-
 from sele_saisie_auto.contracts.encryption import EncryptionService
 from sele_saisie_auto.encryption import DefaultEncryptionService
 

--- a/tests/test_page_navigator.py
+++ b/tests/test_page_navigator.py
@@ -1,5 +1,4 @@
 import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -7,22 +6,10 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 import pytest  # noqa: E402
 
-from sele_saisie_auto.app_config import (  # noqa: E402
-    AppConfig,
-    AppConfigRaw,
-    get_default_timeout,
-)
+from sele_saisie_auto.app_config import AppConfig, AppConfigRaw  # noqa: E402
 from sele_saisie_auto.encryption_utils import Credentials  # noqa: E402
-from sele_saisie_auto.logging_service import Logger  # noqa: E402
 from sele_saisie_auto.navigation import page_navigator as pn_mod  # noqa: E402
 from sele_saisie_auto.navigation.page_navigator import PageNavigator  # noqa: E402
-from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter  # noqa: E402
-from tests.conftest import (  # noqa: E402
-    DummyAdditionalInfoPage,
-    DummyBrowserSession,
-    DummyDateEntryPage,
-    DummyLoginHandler,
-)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -138,25 +125,3 @@ def test_run_requires_prepare():
     _, _, _, _, _, nav = make_navigator()
     with pytest.raises(RuntimeError):
         nav.run("drv")
-
-
-def test_from_automation_builds_navigator(sample_config):
-    app_cfg = AppConfig.from_raw(AppConfigRaw(sample_config))
-    automation = types.SimpleNamespace(
-        log_file="log.html",
-        logger=Logger("log.html"),
-        waiter=create_waiter(get_default_timeout(app_cfg)),
-        browser_session=DummyBrowserSession(),
-        login_handler=DummyLoginHandler(),
-        date_entry_page=DummyDateEntryPage(),
-        additional_info_page=DummyAdditionalInfoPage(),
-        context=types.SimpleNamespace(config=app_cfg),
-    )
-
-    nav = PageNavigator.from_automation(automation)
-
-    assert nav.browser_session is automation.browser_session
-    assert nav.login_handler is automation.login_handler
-    assert nav.date_entry_page is automation.date_entry_page
-    assert nav.additional_info_page is automation.additional_info_page
-    assert nav.timesheet_helper is not None


### PR DESCRIPTION
## Contexte

Les méthodes `from_automation` n'étaient appelées que depuis l'automate
lui-même et un test. Aucun module externe ne les utilisait réellement.

## Changements

- suppression des méthodes `from_automation` dans les classes de navigation
  et de pages
- instanciation directe des pages dans `PSATimeAutomation`
- ajout d'une méthode privée pour construire `PageNavigator`
- mise à jour des tests en conséquence

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688cade0d3ac83219b63bd2b9903365d