### PR TITLE
[plugins] Réintégration du système de hooks

### DIFF
--- a/docs/guides/advanced-usage-example.md
+++ b/docs/guides/advanced-usage-example.md
@@ -78,6 +78,8 @@ chaque plugin.
 ## Extensions via hooks
 
 Le projet fournit un petit système de hooks pour étendre l'automatisation.
+Le module `plugins` expose les fonctions `register`, `unregister`, `hook` et
+`call`.
 Créez simplement un fichier Python contenant des fonctions décorées avec
 `@hook` :
 

--- a/examples/example_plugin.py
+++ b/examples/example_plugin.py
@@ -1,0 +1,15 @@
+"""Exemple simple de plugin enregistrant un hook."""
+
+from sele_saisie_auto import shared_utils
+from sele_saisie_auto.logger_utils import write_log
+from sele_saisie_auto.plugins import hook
+
+
+@hook("before_submit")
+def notify_before_submit(driver) -> None:
+    """Affiche un message dans le journal avant la soumission."""
+    write_log(
+        "Plugin before_submit called",
+        shared_utils.get_log_file(),
+        "DEBUG",
+    )

--- a/src/sele_saisie_auto/__init__.py
+++ b/src/sele_saisie_auto/__init__.py
@@ -1,6 +1,8 @@
 """Package metadata."""
 
-__all__ = ["__version__"]
+from . import plugins
+
+__all__ = ["__version__", "plugins"]
 
 # Version du paquet
 __version__ = "0.1.0"

--- a/src/sele_saisie_auto/plugins.py
+++ b/src/sele_saisie_auto/plugins.py
@@ -1,0 +1,53 @@
+"""Petit système de hooks pour l'automatisation PSA Time."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+
+_HOOKS: dict[str, list[Callable[..., Any]]] = defaultdict(list)
+
+
+def register(name: str, func: Callable[..., Any]) -> None:
+    """Enregistre ``func`` pour le hook ``name``."""
+    _HOOKS[name].append(func)
+
+
+def unregister(name: str, func: Callable[..., Any]) -> None:
+    """Supprime ``func`` du hook ``name`` s'il est présent."""
+    callbacks = _HOOKS.get(name)
+    if not callbacks:
+        return
+    try:
+        callbacks.remove(func)
+        if not callbacks:
+            _HOOKS.pop(name, None)
+    except ValueError:
+        pass
+
+
+def hook(name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Décorateur pour enregistrer une fonction sur un hook."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        register(name, func)
+        return func
+
+    return decorator
+
+
+def call(name: str, *args: Any, **kwargs: Any) -> list[Any]:
+    """Appelle toutes les fonctions enregistrées et renvoie leurs résultats."""
+    results: list[Any] = []
+    for func in list(_HOOKS.get(name, [])):
+        results.append(func(*args, **kwargs))
+    return results
+
+
+def clear() -> None:
+    """Vide l'ensemble du registre (utile pour les tests)."""
+    _HOOKS.clear()
+
+
+__all__ = ["register", "unregister", "hook", "call", "clear"]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,49 @@
+from sele_saisie_auto import plugins
+
+
+def test_register_and_call():
+    plugins.clear()
+    calls = []
+    plugins.register("before_submit", lambda d: calls.append(d))
+    plugins.call("before_submit", "drv")
+    assert calls == ["drv"]
+
+
+def test_hook_decorator_registers():
+    plugins.clear()
+    called: list[int] = []
+
+    @plugins.hook("after_run")
+    def cb(data: int) -> None:
+        called.append(data)
+
+    plugins.call("after_run", 123)
+    assert called == [123]
+
+
+def test_call_returns_list_of_results():
+    plugins.clear()
+
+    @plugins.hook("after_run")
+    def plus_one(x: int) -> int:
+        return x + 1
+
+    @plugins.hook("after_run")
+    def times_two(x: int) -> int:
+        return x * 2
+
+    results = plugins.call("after_run", 3)
+    assert results == [4, 6]
+
+
+def test_unregister_removes_hook():
+    plugins.clear()
+    called: list[str] = []
+
+    def cb() -> None:
+        called.append("cb")
+
+    plugins.register("after_run", cb)
+    plugins.unregister("after_run", cb)
+    plugins.call("after_run")
+    assert called == []


### PR DESCRIPTION
## Contexte
La documentation évoquait encore un système de plugins alors que le module `plugins.py` avait été supprimé. Cette PR réintroduit une implémentation simple ainsi qu'un exemple et des tests associés.

## Modifications
- ajout d'un module `plugins.py` gérant l'enregistrement et l'appel de hooks
- export du module via `__init__`
- exemple `examples/example_plugin.py`
- documentation enrichie sur l'usage des hooks
- nouveaux tests unitaires `test_plugins.py`

## Test
- `pre-commit` exécuté sur les fichiers modifiés
- `pytest` : l'ensemble de la suite passe
- `mypy --strict --no-incremental src/` : aucun problème détecté

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688cc7d5bbfc832198ff13ce1406d6ee