### PR TITLE
[Logger] Harmonisation du format de log

### DIFF
--- a/docs/guides/logging-and-errors.md
+++ b/docs/guides/logging-and-errors.md
@@ -70,6 +70,13 @@ def cliquer_bouton(driver):
 ## Fichier de log
 Les messages sont enregistres dans le dossier `logs/` sous forme de fichier HTML. Chaque execution ajoute de nouvelles entrees au meme fichier afin de conserver l'historique complet.
 
+Le texte de chaque ligne suit le modèle défini par `LOG_ENTRY_FORMAT` dans
+`logger_utils.py` :
+
+```
+{timestamp} [{level}] {message}
+```
+
 ### Personnaliser l'apparence
 Ajoutez la section `[log_style]` dans `config.ini` :
 

--- a/src/sele_saisie_auto/logging_service.py
+++ b/src/sele_saisie_auto/logging_service.py
@@ -137,4 +137,8 @@ class LoggingConfigurator:
         set_log_file_selenium(log_file)
 
         if isinstance(config, ConfigParser):
-            initialize_logger(config, log_level_override=debug_mode)
+            initialize_logger(
+                config,
+                log_level_override=debug_mode,
+                log_file=log_file,
+            )


### PR DESCRIPTION
## Contexte et objectif
Un format unique est maintenant appliqué à toutes les lignes du journal. `LOG_ENTRY_FORMAT` définit ce modèle et `initialize_logger` écrit un message de démarrage.

## Étapes pour tester
1. `poetry run pre-commit run --files docs/guides/logging-and-errors.md src/sele_saisie_auto/logger_utils.py src/sele_saisie_auto/logging_service.py`
2. `poetry run mypy --strict --no-incremental src/`
3. `poetry run pytest -q`

## Impact éventuel sur les autres agents
Aucun impact fonctionnel attendu, seulement l’affichage des messages de log est harmonisé.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688cce79f39c8321b71e8a6013d08764