### PR TITLE
[ConfigManager] lecture sans interpolation

### DIFF
--- a/src/sele_saisie_auto/read_or_write_file_config_ini_utils.py
+++ b/src/sele_saisie_auto/read_or_write_file_config_ini_utils.py
@@ -132,7 +132,7 @@ def read_config_ini(log_file: str | None = None) -> configparser.ConfigParser:
         )
         return cached[1]
 
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
 
     try:
         # Lire le fichier avec l'encodage UTF-8

--- a/tests/test_read_or_write_file_config_ini_utils.py
+++ b/tests/test_read_or_write_file_config_ini_utils.py
@@ -182,6 +182,28 @@ def test_read_config_ini_success(tmp_path, monkeypatch):
     assert config.get("s", "a") == "b"
 
 
+def test_read_config_ini_percent_in_log_style(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text(
+        """[log_style]
+column_widths = timestamp:50%, level:25%, message:25%
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sele_saisie_auto.read_or_write_file_config_ini_utils.write_log", noop
+    )
+    monkeypatch.setattr(
+        "sele_saisie_auto.read_or_write_file_config_ini_utils.log_info", noop
+    )
+    config = read_config_ini()
+    assert (
+        config.get("log_style", "column_widths")
+        == "timestamp:50%, level:25%, message:25%"
+    )
+
+
 def test_read_config_ini_not_found(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(


### PR DESCRIPTION
## Contexte
La lecture de `config.ini` échouait lorsque la section `[log_style]` contenait des pourcentages (`%`) à cause de l'interpolation automatique de `ConfigParser`.

## Changements
- `read_config_ini` utilise désormais `ConfigParser(interpolation=None)` pour désactiver l'interpolation.
- Ajout d'un test validant la lecture d'une section `[log_style]` avec des `%`.

## Test
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688cd9749b548321aefbb8b9a3f7d20e