### PR TITLE
[ConfigManager] Amélioration des erreurs de lecture config

### DIFF
--- a/src/sele_saisie_auto/read_or_write_file_config_ini_utils.py
+++ b/src/sele_saisie_auto/read_or_write_file_config_ini_utils.py
@@ -148,6 +148,13 @@ def read_config_ini(log_file: str | None = None) -> configparser.ConfigParser:
             lf,
         )
         raise TypeError(str(e)) from e
+    except configparser.Error as e:  # noqa: BLE001
+        section = getattr(e, "section", "inconnue")
+        log_info(
+            f"🔹 Erreur de configuration dans la section '{section}' du fichier '{config_file_ini}': {e}",
+            lf,
+        )
+        raise
     except Exception as e:
         log_info(
             f"🔹 {messages.ERREUR_INATTENDUE} lors de la lecture du fichier '{config_file_ini}': {e}",

--- a/tests/test_read_or_write_file_config_ini_utils.py
+++ b/tests/test_read_or_write_file_config_ini_utils.py
@@ -254,6 +254,29 @@ def test_read_config_ini_generic_error(tmp_path, monkeypatch):
         read_config_ini()
 
 
+def test_read_config_ini_config_error(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.ini"
+    cfg.write_text("[s]\na=b\n[s]\nc=d\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "sele_saisie_auto.read_or_write_file_config_ini_utils.write_log",
+        noop,
+    )
+    messages: list[str] = []
+
+    def capture(msg: str, lf: str | None = None) -> None:
+        messages.append(msg)
+
+    monkeypatch.setattr(
+        "sele_saisie_auto.read_or_write_file_config_ini_utils.log_info",
+        capture,
+    )
+
+    with pytest.raises(configparser.Error):
+        read_config_ini()
+    assert any("s" in m for m in messages)
+
+
 def test_write_config_ini_success(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.ini"
     cfg_path.write_text("[s]\na=b\n", encoding="utf-8")


### PR DESCRIPTION
## Contexte et objectif
Améliore la fonction `read_config_ini()` pour faciliter le diagnostic lorsque `config.ini` est invalide. Une erreur de configuration est maintenant journalisée avec la section incriminée avant d'être relancée. Un test couvre ce nouveau comportement.

## Étapes pour tester
1. Lancer `poetry run pre-commit run --files src/sele_saisie_auto/read_or_write_file_config_ini_utils.py tests/test_read_or_write_file_config_ini_utils.py`.
2. Exécuter `poetry run mypy --strict --no-incremental src`.
3. Exécuter `poetry run pytest`.

## Impact éventuel sur les autres agents
Aucun impact fonctionnel attendu ; seuls les messages d'erreur lors du chargement de la configuration sont enrichis.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688cec7a27608321a79f45aede346390