### PR TITLE
[logger] log level choices constant

### DIFF
--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -9,7 +9,7 @@ from sele_saisie_auto import __version__
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import service_configurator_factory
 from sele_saisie_auto.interfaces import LoggerProtocol
-from sele_saisie_auto.logger_utils import LOG_LEVELS
+from sele_saisie_auto.logger_utils import LOG_LEVEL_CHOICES
 from sele_saisie_auto.logging_service import LoggingConfigurator, get_logger
 from sele_saisie_auto.orchestration import AutomationOrchestrator
 from sele_saisie_auto.saisie_automatiser_psatime import PSATimeAutomation
@@ -24,7 +24,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "-l",
         "--log-level",
-        choices=list(LOG_LEVELS.keys()),
+        choices=LOG_LEVEL_CHOICES,
         help="Override log level",
     )
     parser.add_argument(

--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -21,7 +21,7 @@ from sele_saisie_auto.gui_builder import (
     create_tab,
 )
 from sele_saisie_auto.interfaces import LoggerProtocol
-from sele_saisie_auto.logger_utils import LOG_LEVELS
+from sele_saisie_auto.logger_utils import LOG_LEVEL_CHOICES
 from sele_saisie_auto.logging_service import Logger, LoggingConfigurator, get_logger
 from sele_saisie_auto.orchestration import AutomationOrchestrator
 from sele_saisie_auto.read_or_write_file_config_ini_utils import (
@@ -160,7 +160,7 @@ def start_configuration(
 
     debug_row = create_a_frame(frame, padding=(10, 10, 10, 10))
     create_modern_label_with_pack(debug_row, "Log Level:", side="left")
-    create_combobox_with_pack(debug_row, debug_var, values=list(LOG_LEVELS.keys()))
+    create_combobox_with_pack(debug_row, debug_var, values=LOG_LEVEL_CHOICES)
 
     def save() -> None:
         """Enregistre la configuration saisie."""

--- a/src/sele_saisie_auto/logger_utils.py
+++ b/src/sele_saisie_auto/logger_utils.py
@@ -29,6 +29,7 @@ LOG_LEVELS: dict[LogLevel, int] = {
     LogLevel.CRITICAL: 50,
     LogLevel.OFF: 0,
 }
+LOG_LEVEL_CHOICES: list[str] = [lvl.value for lvl in LogLevel]
 
 # Par défaut, on commence avec un niveau de log minimal (par ex., "INFO")
 DEFAULT_LOG_LEVEL: LogLevel = LogLevel.INFO


### PR DESCRIPTION
## Summary
- expose `LOG_LEVEL_CHOICES` in `logger_utils`
- use the constant in CLI and launcher
- run pre-commit and mypy

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/logger_utils.py src/sele_saisie_auto/cli.py src/sele_saisie_auto/launcher.py`
- `poetry run mypy --strict --no-incremental src`

------
https://chatgpt.com/codex/tasks/task_e_688cf91b6e0883218ee15521297e7ab8