### PR TITLE
[Logger] handle invalid log level

### DIFF
--- a/src/sele_saisie_auto/logger_utils.py
+++ b/src/sele_saisie_auto/logger_utils.py
@@ -72,15 +72,36 @@ def initialize_logger(
 
     global LOG_LEVEL_FILTER
     if log_level_override:
-        LOG_LEVEL_FILTER = (
-            log_level_override
-            if isinstance(log_level_override, LogLevel)
-            else LogLevel(log_level_override)
-        )
+        try:
+            LOG_LEVEL_FILTER = (
+                log_level_override
+                if isinstance(log_level_override, LogLevel)
+                else LogLevel(log_level_override)
+            )
+        except ValueError:  # noqa: BLE001
+            LOG_LEVEL_FILTER = LogLevel.INFO
+            if log_file is not None:
+                write_log(
+                    f"Invalid log level '{log_level_override}', fallback to INFO",
+                    log_file,
+                    LogLevel.WARNING,
+                )
     else:
-        LOG_LEVEL_FILTER = LogLevel(
-            config.get("settings", "debug_mode", fallback=LogLevel.INFO.value)
+        raw_level = config.get(
+            "settings",
+            "debug_mode",
+            fallback=LogLevel.INFO.value,
         )
+        try:
+            LOG_LEVEL_FILTER = LogLevel(raw_level)
+        except ValueError:  # noqa: BLE001
+            LOG_LEVEL_FILTER = LogLevel.INFO
+            if log_file is not None:
+                write_log(
+                    f"Invalid log level '{raw_level}' in config, fallback to INFO",
+                    log_file,
+                    LogLevel.WARNING,
+                )
 
     if log_file is not None:
         write_log(

--- a/tests/test_logger_utils.py
+++ b/tests/test_logger_utils.py
@@ -58,6 +58,22 @@ def test_initialize_logger_config_value(tmp_path):
     assert mod.LOG_LEVEL_FILTER == LogLevel.WARNING
 
 
+def test_initialize_logger_invalid_string(tmp_path):
+    mod = importlib.reload(logger_utils)
+    cfg = configparser.ConfigParser()
+    cfg["settings"] = {"debug_mode": "INFO"}
+    mod.initialize_logger(cfg, log_level_override="BOGUS")
+    assert mod.LOG_LEVEL_FILTER == LogLevel.INFO
+
+
+def test_initialize_logger_invalid_config(tmp_path):
+    mod = importlib.reload(logger_utils)
+    cfg = configparser.ConfigParser()
+    cfg["settings"] = {"debug_mode": "BAD"}
+    mod.initialize_logger(cfg, log_file=str(tmp_path / "log.html"))
+    assert mod.LOG_LEVEL_FILTER == LogLevel.INFO
+
+
 def test_initialize_html_log_file_cleanup(tmp_path):
     log_file = tmp_path / "log.html"
     log_file.write_text("</table></body></html>", encoding="utf-8")


### PR DESCRIPTION
## Contexte
- meilleure robustesse de `initialize_logger`
- ajout de tests unitaires

## Impact
- `logger_utils.initialize_logger` signale les niveaux invalides et revient au niveau INFO

## Test
- `pre-commit` sur les fichiers modifiés
- `pytest`
- `poetry run mypy --strict --no-incremental src`

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688d282e86948321a2ff14a57f775c2b