### PR TITLE
[MemoryConfig] noms dynamiques pour la mémoire partagée

### DIFF
--- a/src/sele_saisie_auto/configuration/__init__.py
+++ b/src/sele_saisie_auto/configuration/__init__.py
@@ -1,12 +1,15 @@
 from sele_saisie_auto.app_config import AppConfig
+from sele_saisie_auto.memory_config import MemoryConfig
 
 from .service_configurator import ServiceConfigurator, Services, build_services
 
 
-def service_configurator_factory(app_config: AppConfig) -> ServiceConfigurator:
+def service_configurator_factory(
+    app_config: AppConfig, *, memory_config: MemoryConfig | None = None
+) -> ServiceConfigurator:
     """Return a :class:`ServiceConfigurator` for ``app_config``."""
 
-    return ServiceConfigurator.from_config(app_config)
+    return ServiceConfigurator.from_config(app_config, memory_config=memory_config)
 
 
 __all__ = [

--- a/src/sele_saisie_auto/encryption.py
+++ b/src/sele_saisie_auto/encryption.py
@@ -6,6 +6,7 @@ from types import TracebackType
 
 from .encryption_utils import Credentials, EncryptionBackend
 from .encryption_utils import EncryptionService as _EncryptionService
+from .memory_config import MemoryConfig
 from .shared_memory_service import SharedMemoryService
 
 
@@ -17,12 +18,14 @@ class DefaultEncryptionService:
         log_file: str | None = None,
         shared_memory_service: SharedMemoryService | None = None,
         backend: EncryptionBackend | None = None,
+        memory_config: MemoryConfig | None = None,
     ) -> None:
         """Instantiate the underlying :class:`EncryptionService`."""
         self._service = _EncryptionService(
             log_file,
             shared_memory_service=shared_memory_service,
             backend=backend,
+            memory_config=memory_config,
         )
 
     # ------------------------------------------------------------------

--- a/src/sele_saisie_auto/memory_config.py
+++ b/src/sele_saisie_auto/memory_config.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
+import os
 from dataclasses import dataclass
+from uuid import uuid4
 
 
 @dataclass
@@ -7,5 +11,26 @@ class MemoryConfig:
 
     cle_name: str = "memoire_partagee_cle"
     data_name: str = "memoire_partagee_donnees"
+    login_name: str = "memoire_nom"
+    password_name: str = "memoire_mdp"
     key_size: int = 32  # AES-256
     block_size: int = 128  # padding block
+    suffix: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.suffix:
+            for field in ("cle_name", "data_name", "login_name", "password_name"):
+                value = getattr(self, field)
+                setattr(self, field, f"{value}_{self.suffix}")
+
+    @classmethod
+    def with_pid(cls, pid: int | None = None) -> "MemoryConfig":
+        """Return a config using the given process id as suffix."""
+
+        return cls(suffix=str(pid or os.getpid()))
+
+    @classmethod
+    def with_uuid(cls) -> "MemoryConfig":
+        """Return a config using a random UUID as suffix."""
+
+        return cls(suffix=uuid4().hex)

--- a/src/sele_saisie_auto/resources/resource_context.py
+++ b/src/sele_saisie_auto/resources/resource_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from sele_saisie_auto.encryption_utils import Credentials, EncryptionService
+from sele_saisie_auto.memory_config import MemoryConfig
 
 __all__ = ["ResourceContext"]
 
@@ -13,10 +14,17 @@ class ResourceContext:
     """Manage encrypted credentials and memory cleanup."""
 
     def __init__(
-        self, log_file: str, encryption_service: EncryptionService | None = None
+        self,
+        log_file: str,
+        encryption_service: EncryptionService | None = None,
+        *,
+        memory_config: MemoryConfig | None = None,
     ) -> None:
         self.log_file = log_file
-        self.encryption_service = encryption_service or EncryptionService(log_file)
+        self.encryption_service = encryption_service or EncryptionService(
+            log_file,
+            memory_config=memory_config,
+        )
         self._credentials: Credentials | None = None
 
     def __enter__(self) -> ResourceContext:

--- a/src/sele_saisie_auto/resources/resource_manager.py
+++ b/src/sele_saisie_auto/resources/resource_manager.py
@@ -15,6 +15,7 @@ from sele_saisie_auto.encryption_utils import Credentials, EncryptionService
 from sele_saisie_auto.exceptions import AutomationExitError, ResourceManagerInitError
 from sele_saisie_auto.interfaces import BrowserSessionProtocol
 from sele_saisie_auto.logging_service import Logger
+from sele_saisie_auto.memory_config import MemoryConfig
 from sele_saisie_auto.resources.resource_context import ResourceContext
 
 __all__ = ["ResourceManager"]
@@ -24,7 +25,11 @@ class ResourceManager:
     """Prépare et nettoie navigateur et mémoire pour l'automatisation."""
 
     def __init__(
-        self, log_file: str, encryption_service: EncryptionService | None = None
+        self,
+        log_file: str,
+        encryption_service: EncryptionService | None = None,
+        *,
+        memory_config: MemoryConfig | None = None,
     ) -> None:
         """Initialise le gestionnaire.
 
@@ -34,8 +39,12 @@ class ResourceManager:
 
         self.log_file = log_file
         self._config_manager = ConfigManager(log_file)
-        self._encryption_service = encryption_service or EncryptionService(log_file)
-        self._resource_context = ResourceContext(log_file, self._encryption_service)
+        self._encryption_service = encryption_service or EncryptionService(
+            log_file, memory_config=memory_config
+        )
+        self._resource_context = ResourceContext(
+            log_file, self._encryption_service, memory_config=memory_config
+        )
         self._credentials: Credentials | None = None
         self._session: BrowserSessionProtocol | None = None
         self._driver: WebDriver | None = None

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -151,7 +151,9 @@ class PSATimeAutomation:
 
         # Initialise orchestrator helpers
         self.page_navigator = self._create_page_navigator()
-        self.resource_manager = ResourceManager(log_file)
+        self.resource_manager = ResourceManager(
+            log_file, memory_config=self.memory_config
+        )
         self.orchestrator: AutomationOrchestrator | None = None
 
         self.log_configuration_details()
@@ -234,7 +236,9 @@ class PSATimeAutomation:
     def _init_services(self, app_config: AppConfig) -> Services:
         """Initialise les services principaux via :class:`ServiceConfigurator`."""
 
-        configurator = service_configurator_factory(app_config)
+        configurator = service_configurator_factory(
+            app_config, memory_config=self.memory_config
+        )
         return configurator.build_services(self.log_file)
 
     def _create_page_navigator(self) -> PageNavigator:
@@ -470,7 +474,9 @@ class PSATimeAutomation:
     ) -> None:
         """Point d'entrée principal de l'automatisation."""
 
-        service_configurator = service_configurator_factory(self.context.config)
+        service_configurator = service_configurator_factory(
+            self.context.config, memory_config=self.memory_config
+        )
         self.orchestrator = AutomationOrchestrator.from_components(
             self.resource_manager,
             self.page_navigator,

--- a/tests/test_automation_orchestrator.py
+++ b/tests/test_automation_orchestrator.py
@@ -55,7 +55,7 @@ def test_run_calls_services(monkeypatch, sample_config):
     monkeypatch.setattr(
         orch_mod,
         "ResourceManager",
-        lambda log_file: rm.ResourceManager(log_file, enc_service),
+        lambda log_file, **kw: rm.ResourceManager(log_file, enc_service),
     )
 
     orch = AutomationOrchestrator(
@@ -182,7 +182,7 @@ def test_run_order(monkeypatch, sample_config):
     monkeypatch.setattr(
         orch_mod,
         "ResourceManager",
-        lambda log_file: rm.ResourceManager(log_file, DummyEncService()),
+        lambda log_file, **kw: rm.ResourceManager(log_file, DummyEncService()),
     )
     orch = AutomationOrchestrator(
         app_cfg,
@@ -254,7 +254,7 @@ def test_run_uses_passed_cleanup_function(monkeypatch, sample_config):
     monkeypatch.setattr(
         orch_mod,
         "ResourceManager",
-        lambda log_file: rm.ResourceManager(log_file, enc_service),
+        lambda log_file, **kw: rm.ResourceManager(log_file, enc_service),
     )
 
     cleanup_args = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,7 +55,9 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
             return "services"
 
     monkeypatch.setattr(
-        cli, "service_configurator_factory", lambda cfg: DummyConfigurator(cfg)
+        cli,
+        "service_configurator_factory",
+        lambda cfg, **kw: DummyConfigurator(cfg),
     )
 
     auto_data = {}

--- a/tests/test_encryption_service.py
+++ b/tests/test_encryption_service.py
@@ -9,6 +9,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 from sele_saisie_auto.encryption_utils import EncryptionService  # noqa: E402
 from sele_saisie_auto.logging_service import Logger  # noqa: E402
+from sele_saisie_auto.memory_config import MemoryConfig  # noqa: E402
 from sele_saisie_auto.shared_memory_service import SharedMemoryService  # noqa: E402
 
 
@@ -198,6 +199,22 @@ def test_full_encryption_shared_memory_flow():
             creds.mem_password.close()
 
 
+def test_custom_memory_config_names():
+    cfg = MemoryConfig(suffix="xyz")
+    service = EncryptionService(memory_config=cfg)
+
+    with service as enc:
+        enc.store_credentials(b"user", b"pass")
+        creds = enc.retrieve_credentials()
+        try:
+            assert creds.mem_login.name == cfg.login_name
+            assert creds.mem_password.name == cfg.password_name
+        finally:
+            creds.mem_key.close()
+            creds.mem_login.close()
+            creds.mem_password.close()
+
+
 def test_retrieve_after_exit_fails():
     service = EncryptionService()
     with service as enc:
@@ -232,4 +249,4 @@ def test_enter_cleans_on_failure(monkeypatch):
         with service:
             pass
     with pytest.raises(FileNotFoundError):
-        shared_memory.SharedMemory(name="memoire_partagee_cle")
+        shared_memory.SharedMemory(name=MemoryConfig().cle_name)

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from sele_saisie_auto.memory_config import MemoryConfig
+
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
 pytestmark = pytest.mark.slow
@@ -36,9 +38,10 @@ class DummyVar:
 
 
 class DummyEncryption:
-    def __init__(self):
+    def __init__(self, memory_config=None):
         self.encrypted = []
         self.stored = []
+        self.memory_config = memory_config or MemoryConfig()
         self.shared_memory_service = types.SimpleNamespace(
             stocker_en_memoire_partagee=lambda name, data: self.stored.append(
                 (name, data)
@@ -60,8 +63,8 @@ class DummyEncryption:
         return b"k" * size
 
     def store_credentials(self, login, pwd):
-        self.stored.append(("memoire_nom", login))
-        self.stored.append(("memoire_mdp", pwd))
+        self.stored.append((self.memory_config.login_name, login))
+        self.stored.append((self.memory_config.password_name, pwd))
 
 
 class DummyRoot:
@@ -149,7 +152,7 @@ def test_run_psatime(monkeypatch, dummy_logger, sample_config):
     monkeypatch.setattr(
         launcher,
         "service_configurator_factory",
-        lambda conf: types.SimpleNamespace(build_services=lambda lf: None),
+        lambda conf, **kw: types.SimpleNamespace(build_services=lambda lf: None),
     )
     automation_instance = {}
 
@@ -215,7 +218,7 @@ def test_run_psatime_flags(monkeypatch, dummy_logger, sample_config):
     monkeypatch.setattr(
         launcher,
         "service_configurator_factory",
-        lambda conf: types.SimpleNamespace(build_services=lambda lf: None),
+        lambda conf, **kw: types.SimpleNamespace(build_services=lambda lf: None),
     )
 
     inst = DummyAutomation("file.html", app_cfg, logger=dummy_logger)

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -10,5 +10,20 @@ def test_defaults():
     cfg = MemoryConfig()
     assert cfg.cle_name == "memoire_partagee_cle"
     assert cfg.data_name == "memoire_partagee_donnees"
+    assert cfg.login_name == "memoire_nom"
+    assert cfg.password_name == "memoire_mdp"
     assert cfg.key_size == 32
     assert cfg.block_size == 128
+
+
+def test_suffix():
+    cfg = MemoryConfig(suffix="123")
+    assert cfg.cle_name.endswith("_123")
+    assert cfg.login_name.endswith("_123")
+
+
+def test_factories():
+    cfg_pid = MemoryConfig.with_pid(1)
+    assert cfg_pid.cle_name.endswith("_1")
+    cfg_uuid = MemoryConfig.with_uuid()
+    assert cfg_uuid.cle_name.startswith("memoire_partagee_cle_")

--- a/tests/test_resource_manager.py
+++ b/tests/test_resource_manager.py
@@ -44,7 +44,7 @@ class DummyBrowserSession:
 
 
 class DummyResourceContext:
-    def __init__(self, log_file, encryption_service=None):
+    def __init__(self, log_file, encryption_service=None, **kwargs):
         self.log_file = log_file
         self.encryption_service = encryption_service
         self.ctx_entered = False
@@ -337,7 +337,7 @@ def test_exit_uses_shared_memory_service(monkeypatch):
     monkeypatch.setattr(
         resource_manager,
         "ResourceContext",
-        lambda log_file, encryption_service=None: enc,
+        lambda log_file, encryption_service=None, **kw: enc,
     )
 
     with resource_manager.ResourceManager(
@@ -350,8 +350,8 @@ def test_exit_uses_shared_memory_service(monkeypatch):
 
 def test_close_removes_shared_memory_segments(monkeypatch):
     class CleanResourceContext(DummyResourceContext):
-        def __init__(self, log_file, encryption_service=None):
-            super().__init__(log_file, encryption_service)
+        def __init__(self, log_file, encryption_service=None, **kwargs):
+            super().__init__(log_file, encryption_service, **kwargs)
             self.shared_memory_service = SharedMemoryService(Logger(None))
 
         def __enter__(self):

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -110,7 +110,9 @@ def setup_init(monkeypatch, cfg):
             return Services(enc, session, waiter, login)
 
     monkeypatch.setattr(
-        sap, "service_configurator_factory", lambda cfg_b: DummyConfigurator(cfg_b)
+        sap,
+        "service_configurator_factory",
+        lambda cfg_b, **kw: DummyConfigurator(cfg_b),
     )
     waiter = create_waiter(get_default_timeout(app_cfg))
     monkeypatch.setattr(
@@ -126,7 +128,7 @@ def setup_init(monkeypatch, cfg):
     monkeypatch.setattr(
         sap,
         "ResourceManager",
-        lambda log_file: rm.ResourceManager(log_file, DummyEnc()),
+        lambda log_file, **kw: rm.ResourceManager(log_file, DummyEnc()),
     )
     auto = sap.PSATimeAutomation("log.html", app_cfg)
     service_configurator = ServiceConfigurator(app_cfg)


### PR DESCRIPTION
## Contexte et objectif
Ajout d'un suffixe optionnel pour créer des segments de mémoire uniques et prise en charge des noms pour login/mot de passe. `EncryptionService` et ses consommateurs utilisent désormais `MemoryConfig` pour toutes les clés.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run mypy --strict --no-incremental src/`
3. `poetry run pytest -q`

## Impact
Nouveaux paramètres pour la configuration mémoire et mise à jour des tests associés.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688d4b81978c8321b818de385a386054