### PR TITLE
[launcher] nettoyage mémoire partagé avant démarrage

### DIFF
--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -38,6 +38,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Disable the browser sandbox",
     )
     parser.add_argument(
+        "--cleanup-mem",
+        action="store_true",
+        help="Remove leftover shared memory segments and exit",
+    )
+    parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
@@ -50,6 +55,11 @@ def main(argv: list[str] | None = None) -> None:
     """Run the automation from the command line."""
 
     args = parse_args(argv)
+    if args.cleanup_mem:
+        from sele_saisie_auto.launcher import cleanup_memory_segments
+
+        cleanup_memory_segments()
+        return
     log_file = get_log_file()
     with get_logger(log_file) as logger:
         cfg = ConfigManager(log_file=log_file).load()


### PR DESCRIPTION
## Contexte et objectif
Ajout d'une routine de nettoyage des segments de mémoire partagée définis dans `MemoryConfig`. Cette fonction est appelée automatiquement dans `launcher.main` avant la création du `EncryptionService`. Un nouveau flag `--cleanup-mem` permet d’exécuter manuellement ce nettoyage via la CLI.

## Étapes pour tester
1. `poetry install`
2. `poetry run pre-commit run --files src/sele_saisie_auto/launcher.py src/sele_saisie_auto/cli.py tests/test_launcher.py tests/test_cli.py`
3. `poetry run mypy --strict --no-incremental src/`
4. `poetry run pytest`

## Impact
Aucun impact sur les autres agents hormis l’ajout du nettoyage automatique des segments mémoire.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688d63e548988321bd81c5ba13669039