### PR TITLE
[EncryptionService] Gestion des identifiants absents

### DIFF
--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -4,6 +4,7 @@
 # ---------------- Import des bibliothèques nécessaires ----------------------- #
 # ----------------------------------------------------------------------------- #
 
+import sys
 from dataclasses import dataclass
 from multiprocessing import shared_memory
 from types import TracebackType
@@ -21,12 +22,12 @@ from sele_saisie_auto.automation.additional_info_page import (
 from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.automation.date_entry_page import DateEntryPage
 from sele_saisie_auto.automation.login_handler import LoginHandler
+from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import Services, service_configurator_factory
 from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.encryption_utils import Credentials as EncryptionCredentials
-from sele_saisie_auto.exceptions import (
-    AutomationExitError,
-)
+from sele_saisie_auto.encryption_utils import EncryptionService
+from sele_saisie_auto.exceptions import AutomationExitError
 from sele_saisie_auto.interfaces.protocols import LoggerProtocol
 from sele_saisie_auto.locators import Locators
 from sele_saisie_auto.logger_utils import show_log_separator, write_log
@@ -47,9 +48,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.date_utils import get_next_saturday_if_not_saturday


### PR DESCRIPTION
## Contexte et objectif
- sécuriser la récupération des identifiants lorsque les segments de mémoire partagée n'existent pas
- exposer les dépendances nécessaires dans `saisie_automatiser_psatime` pour les tests

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run mypy --strict --no-incremental src/`
3. `poetry run pytest`

## Impact éventuel
- permet un arrêt contrôlé via `AutomationExitError` si les identifiants ne sont pas présents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688e480913088321a3d4c211714950ef