### PR TITLE
[ResourceContext] Réutilisation du service de chiffrement

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -146,12 +146,6 @@ def _run_psa_time(
         logger=logger,
         services=services,
     )
-    if services is not None:
-        automation.resource_manager = ResourceManager(
-            log_file,
-            services.encryption_service,
-            memory_config=services.encryption_service.memory_config,
-        )
     orchestrator = AutomationOrchestrator.from_components(
         automation.resource_manager,
         automation.page_navigator,

--- a/src/sele_saisie_auto/resources/resource_context.py
+++ b/src/sele_saisie_auto/resources/resource_context.py
@@ -28,7 +28,9 @@ class ResourceContext:
         self._credentials: Credentials | None = None
 
     def __enter__(self) -> ResourceContext:
-        if hasattr(self.encryption_service, "__enter__"):
+        if getattr(self.encryption_service, "cle_aes", None) is None and hasattr(
+            self.encryption_service, "__enter__"
+        ):
             self.encryption_service.__enter__()
         return self
 

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -117,7 +117,10 @@ class PSATimeAutomation:
         """Initialise la configuration et les dépendances."""
 
         self.log_file: str = log_file
-        self.memory_config = memory_config or MemoryConfig()
+        mem_cfg = memory_config
+        if mem_cfg is None and services is not None:
+            mem_cfg = services.encryption_service.memory_config
+        self.memory_config = mem_cfg or MemoryConfig()
         LoggingConfigurator.setup(log_file, app_config.debug_mode, app_config.raw)
         self.logger = logger or get_logger(log_file)
         self.shared_memory_service = shared_memory_service or SharedMemoryService(
@@ -149,7 +152,9 @@ class PSATimeAutomation:
         # Initialise orchestrator helpers
         self.page_navigator = self._create_page_navigator()
         self.resource_manager = ResourceManager(
-            log_file, memory_config=self.memory_config
+            log_file,
+            encryption_service=self.encryption_service,
+            memory_config=self.memory_config,
         )
         self.orchestrator: AutomationOrchestrator | None = None
 


### PR DESCRIPTION
## Contexte et objectif
- Évitait une seconde initialisation du service de chiffrement provoquant `File exists` sur la mémoire partagée
- Mutualise la configuration mémoire entre l’interface et l’automatisation

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/launcher.py src/sele_saisie_auto/saisie_automatiser_psatime.py src/sele_saisie_auto/resources/resource_context.py`
- `poetry run pytest -k 'not pyinstaller_onefile'`

## Impact éventuel sur les autres agents
- Simplifie l’initialisation de `PSATimeAutomation` en réutilisant la mémoire partagée existante

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688e5e9d0bc083218dfc5a1d749e338f