### PR TITLE
[Automation] Réutilisation du service de chiffrement existant

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -146,12 +146,6 @@ def _run_psa_time(
         logger=logger,
         services=services,
     )
-    if services is not None:
-        automation.resource_manager = ResourceManager(
-            log_file,
-            services.encryption_service,
-            memory_config=services.encryption_service.memory_config,
-        )
     orchestrator = AutomationOrchestrator.from_components(
         automation.resource_manager,
         automation.page_navigator,

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -42,13 +42,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT


### PR DESCRIPTION
## Contexte et objectif
- éviter la collision de segments mémoire lorsque l'automatisation est lancée après le menu
- s'appuyer sur le service de chiffrement fourni au lieu d'en créer un nouveau

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact
- PSATimeAutomation et le lanceur réutilisent désormais la même configuration mémoire

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688e5e9d0bc083218dfc5a1d749e338f