### PR TITLE
[cli] Harmoniser le point d'entrée CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Lors du démarrage, une clé AES temporaire est générée pour chiffrer ces inf
   ```bash
   poetry run psatime-auto
   ```
-  Cette commande crée automatiquement un fichier de log dans le répertoire `logs/` si aucun chemin n'est spécifié.
-  Pour ajuster le lancement du navigateur, les commandes `psatime-auto` et `psatime-launcher` acceptent aussi : 
+  Cette commande utilise le point d'entrée Python `sele_saisie_auto.cli.main` et crée automatiquement un fichier de log dans le répertoire `logs/` si aucun chemin n'est spécifié.
+  Pour ajuster le lancement du navigateur, les commandes `psatime-auto` et `psatime-launcher` acceptent aussi :
   - `--headless`
   - `--no-sandbox`
   - `--cleanup-mem`

--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -17,7 +17,7 @@ L'utilisateur dispose d'un fichier `config.ini` minimal et souhaite renseigner s
 poetry run psatime-auto
 ```
 
-Cette commande lit `config.ini` dans le répertoire courant et lance directement l'automatisation. Un fichier de log est créé automatiquement sous `logs/` si aucun chemin n'est spécifié.
+Cette commande repose sur le point d'entrée `sele_saisie_auto.cli.main`, lit `config.ini` dans le répertoire courant et lance directement l'automatisation. Un fichier de log est créé automatiquement sous `logs/` si aucun chemin n'est spécifié.
 Vous pouvez également utiliser les options `--headless` et `--no-sandbox` pour contrôler la façon dont le navigateur est lancé.
 
 ### Exemple de configuration minimale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ strict = true
 
 [tool.poetry.scripts]
 psatime-launcher = "sele_saisie_auto.launcher:main"
-psatime-auto = "sele_saisie_auto.cli:cli_main"
+psatime-auto = "sele_saisie_auto.cli:main"
 
 [tool.ruff]
 line-length = 88

--- a/src/sele_saisie_auto/cli.py
+++ b/src/sele_saisie_auto/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 from typing import cast
 
+import sele_saisie_auto.shared_utils as shared_utils
 from sele_saisie_auto import __version__
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import service_configurator_factory
@@ -92,21 +93,15 @@ def cli_main(
 ) -> None:
     """Entry point used by the ``psatime-auto`` console script."""
 
-    if log_file is None:
-        log_file = get_log_file()
+    if log_file is not None:
+        shared_utils._log_file = log_file
 
-    with get_logger(log_file) as logger:
-        cfg = ConfigManager(log_file=log_file).load()
-        service_configurator = service_configurator_factory(cfg)
-        automation = PSATimeAutomation(log_file, cfg, logger=logger)
-        orchestrator = AutomationOrchestrator.from_components(
-            automation.resource_manager,
-            automation.page_navigator,
-            service_configurator,
-            automation.context,
-            cast(LoggerProtocol, automation.logger),
-        )
-        orchestrator.run(headless=headless, no_sandbox=no_sandbox)
+    argv: list[str] = []
+    if headless:
+        argv.append("--headless")
+    if no_sandbox:
+        argv.append("--no-sandbox")
+    main(argv)
 
 
 __all__ = ["parse_args", "main", "cli_main"]

--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -122,17 +122,17 @@ def _run_psa_time(
             cfg, memory_config=memory_config
         )
     elif encryption_service is not None:
-        memory_config = encryption_service.memory_config  # type: ignore[attr-defined]
+        memory_config = encryption_service.memory_config
         service_configurator = service_configurator_factory(
             cfg, memory_config=memory_config
         )
         waiter = service_configurator.create_waiter()
         browser_session = BrowserSession(log_file, cfg, waiter=waiter)
         login_handler = service_configurator.create_login_handler(
-            log_file, encryption_service, browser_session  # type: ignore[arg-type]
+            log_file, encryption_service, browser_session
         )
         services = Services(
-            encryption_service,  # type: ignore[arg-type]
+            encryption_service,
             browser_session,
             waiter,
             login_handler,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,7 +141,7 @@ def test_main_cleanup_flag(monkeypatch):
     assert called["clean"] is True
 
 
-def test_cleanup_mem_flag_removes_segments(monkeypatch):
+def test_cleanup_mem_flag_removes_segments_and_skips_automation(monkeypatch):
     dummy_args = types.SimpleNamespace(
         log_level=None,
         headless=False,
@@ -170,9 +170,16 @@ def test_cleanup_mem_flag_removes_segments(monkeypatch):
         "cleanup_memory_segments",
         lambda: orig_cleanup(mem_cfg),
     )
+    called: dict[str, bool] = {}
+    monkeypatch.setattr(
+        cli,
+        "PSATimeAutomation",
+        lambda *a, **k: called.setdefault("automation", True),
+    )
 
     cli.main([])
 
+    assert "automation" not in called
     for name in leftovers:
         with pytest.raises(FileNotFoundError):
             shared_memory.SharedMemory(name=name)


### PR DESCRIPTION
## Contexte et objectif
- La commande `psatime-auto` doit désormais appeler `sele_saisie_auto.cli.main`
- Ajout de tests pour le nettoyage mémoire via `--cleanup-mem`
- Documentation mise à jour pour refléter le nouveau point d'entrée

## Étapes pour tester
- `poetry run pre-commit run --files pyproject.toml README.md docs/guides/usage-example.md src/sele_saisie_auto/cli.py src/sele_saisie_auto/launcher.py tests/test_cli.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`

## Impact
- Lancement unifié de l'automatisation via `cli.main`
- Vérification explicite du nettoyage mémoire sans exécuter l'automatisation

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688e734996c48321a7572e2a012a2292