### PR TITLE
feat(cli): prompt for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Lors du démarrage, une clé AES temporaire est générée pour chiffrer ces inf
   ```bash
   poetry run psatime-auto
   ```
-  Cette commande utilise le point d'entrée Python `sele_saisie_auto.cli.main` et crée automatiquement un fichier de log dans le répertoire `logs/` si aucun chemin n'est spécifié.
+  Cette commande utilise le point d'entrée Python `sele_saisie_auto.cli.main` et crée automatiquement un fichier de log dans le répertoire `logs/` si aucun chemin n'est spécifié. Si `config.ini` ne contient pas `encrypted_login` et `encrypted_mdp`, le programme demande le login et le mot de passe dans le terminal, les chiffre via `EncryptionService` puis les stocke en mémoire partagée.
   Pour ajuster le lancement du navigateur, les commandes `psatime-auto` et `psatime-launcher` acceptent aussi :
   - `--headless`
   - `--no-sandbox`

--- a/docs/guides/usage-example.md
+++ b/docs/guides/usage-example.md
@@ -17,7 +17,7 @@ L'utilisateur dispose d'un fichier `config.ini` minimal et souhaite renseigner s
 poetry run psatime-auto
 ```
 
-Cette commande repose sur le point d'entrée `sele_saisie_auto.cli.main`, lit `config.ini` dans le répertoire courant et lance directement l'automatisation. Un fichier de log est créé automatiquement sous `logs/` si aucun chemin n'est spécifié.
+Cette commande repose sur le point d'entrée `sele_saisie_auto.cli.main`, lit `config.ini` dans le répertoire courant et lance directement l'automatisation. Un fichier de log est créé automatiquement sous `logs/` si aucun chemin n'est spécifié. Si `config.ini` ne définit pas `encrypted_login` et `encrypted_mdp`, le programme demande ces informations dans le terminal, les chiffre puis les stocke en mémoire partagée.
 Vous pouvez également utiliser les options `--headless` et `--no-sandbox` pour contrôler la façon dont le navigateur est lancé.
 
 ### Exemple de configuration minimale

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,7 +48,7 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
     monkeypatch.setattr(cli, "parse_args", lambda argv: dummy_args)
     monkeypatch.setattr(cli, "get_log_file", lambda: "log.html")
 
-    cfg = types.SimpleNamespace(raw={})
+    cfg = types.SimpleNamespace(raw={}, encrypted_login="x", encrypted_mdp="y")
     monkeypatch.setattr(
         cli,
         "ConfigManager",
@@ -63,7 +63,7 @@ def test_main_creates_services_and_passes_flags(monkeypatch):
 
         def build_services(self, log_file):
             service_calls["log_file"] = log_file
-            return "services"
+            return types.SimpleNamespace(encryption_service=types.SimpleNamespace())
 
     monkeypatch.setattr(
         cli,
@@ -183,3 +183,106 @@ def test_cleanup_mem_flag_removes_segments_and_skips_automation(monkeypatch):
     for name in leftovers:
         with pytest.raises(FileNotFoundError):
             shared_memory.SharedMemory(name=name)
+
+
+def test_prompts_and_encrypts_when_credentials_missing(monkeypatch):
+    dummy_args = types.SimpleNamespace(
+        log_level=None,
+        headless=False,
+        no_sandbox=False,
+        cleanup_mem=False,
+    )
+    monkeypatch.setattr(cli, "parse_args", lambda argv: dummy_args)
+    monkeypatch.setattr(cli, "get_log_file", lambda: "log.html")
+
+    cfg = types.SimpleNamespace(raw={}, encrypted_login=None, encrypted_mdp=None)
+    monkeypatch.setattr(
+        cli,
+        "ConfigManager",
+        lambda log_file=None: types.SimpleNamespace(load=lambda: cfg),
+    )
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "user")
+    monkeypatch.setattr(cli.getpass, "getpass", lambda prompt="": "pass")
+
+    class DummyEnc:
+        def __init__(self):
+            self.cle_aes = None
+
+        def __enter__(self):
+            self.cle_aes = b"k" * 32
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def chiffrer_donnees(self, donnees, cle, taille_bloc=128):
+            return f"enc:{donnees}".encode()
+
+        def store_credentials(self, login_data, password_data):
+            self.login = login_data
+            self.pwd = password_data
+
+        def retrieve_credentials(self):
+            from sele_saisie_auto.encryption_utils import Credentials
+
+            return Credentials(
+                aes_key=self.cle_aes or b"",
+                mem_key=object(),
+                login=self.login,
+                mem_login=object(),
+                password=self.pwd,
+                mem_password=object(),
+            )
+
+        def dechiffrer_donnees(self, data, cle, taille_bloc=128):
+            return data.decode().split("enc:", 1)[1]
+
+    class DummyConfigurator:
+        def __init__(self, conf):
+            self.cfg = conf
+
+        def build_services(self, log_file):
+            enc = DummyEnc()
+            return types.SimpleNamespace(encryption_service=enc)
+
+    monkeypatch.setattr(
+        cli,
+        "service_configurator_factory",
+        lambda conf, **kw: DummyConfigurator(conf),
+    )
+
+    results: dict[str, object] = {}
+
+    class DummyAutomation:
+        def __init__(self, lf, conf, logger=None, services=None):
+            enc = services.encryption_service
+            creds = enc.retrieve_credentials()
+            results["login"] = enc.dechiffrer_donnees(creds.login, creds.aes_key)
+            results["password"] = enc.dechiffrer_donnees(creds.password, creds.aes_key)
+            results["enc_login"] = creds.login
+            results["enc_pwd"] = creds.password
+            results["enc"] = enc
+            self.resource_manager = object()
+            self.page_navigator = object()
+            self.context = types.SimpleNamespace()
+            self.logger = logger
+
+    class DummyOrchestrator:
+        @classmethod
+        def from_components(cls, *a, **k):
+            return cls()
+
+        def run(self, headless=False, no_sandbox=False):
+            pass
+
+    monkeypatch.setattr(cli, "PSATimeAutomation", DummyAutomation)
+    monkeypatch.setattr(cli, "AutomationOrchestrator", DummyOrchestrator)
+
+    cli.main([])
+
+    results["enc"].__exit__(None, None, None)
+    assert results["login"] == "user"
+    assert results["password"] == "pass"
+    assert results["enc_login"] != b"user"
+    assert results["enc_pwd"] != b"pass"

--- a/tests/test_saisie_automatiser_psatime.py
+++ b/tests/test_saisie_automatiser_psatime.py
@@ -13,6 +13,7 @@ from sele_saisie_auto.utils import misc as utils_misc
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))  # noqa: E402
 
+import sele_saisie_auto.cli as cli  # noqa: E402
 import sele_saisie_auto.logger_utils as logger_utils  # noqa: E402
 from sele_saisie_auto import messages  # noqa: E402
 from sele_saisie_auto import saisie_automatiser_psatime as sap  # noqa: E402
@@ -172,6 +173,13 @@ def setup_init(monkeypatch, cfg, *, patch_services: bool = True):
     monkeypatch.setattr(sap, "LoginHandler", DummyLoginHandler)
     monkeypatch.setattr(sap, "DateEntryPage", DummyDateEntryPage)
     monkeypatch.setattr(sap, "AdditionalInfoPage", DummyAdditionalInfoPage)
+    monkeypatch.setattr(
+        cli,
+        "ConfigManager",
+        lambda log_file=None: types.SimpleNamespace(load=lambda: app_cfg),
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "user")
+    monkeypatch.setattr(cli.getpass, "getpass", lambda prompt="": "pass")
     from sele_saisie_auto.resources import resource_manager as rm
 
     if patch_services:

--- a/tests/test_saisie_automatiser_psatime_additional.py
+++ b/tests/test_saisie_automatiser_psatime_additional.py
@@ -18,6 +18,7 @@ from selenium.common.exceptions import (  # noqa: E402
     WebDriverException,
 )
 
+import sele_saisie_auto.cli as cli  # noqa: E402
 from sele_saisie_auto import saisie_automatiser_psatime as sap  # noqa: E402
 
 pytestmark = pytest.mark.slow
@@ -93,6 +94,13 @@ def setup_init(monkeypatch, cfg):
     app_cfg = AppConfig.from_raw(AppConfigRaw(cfg))
     monkeypatch.setattr(sap, "set_log_file_selenium", lambda lf: None)
     monkeypatch.setattr(sap, "SharedMemoryService", lambda logger: DummySHMService())
+    monkeypatch.setattr(
+        cli,
+        "ConfigManager",
+        lambda log_file=None: types.SimpleNamespace(load=lambda: app_cfg),
+    )
+    monkeypatch.setattr("builtins.input", lambda prompt="": "user")
+    monkeypatch.setattr(cli.getpass, "getpass", lambda prompt="": "pass")
     from sele_saisie_auto.configuration import Services
     from sele_saisie_auto.resources import resource_manager as rm
     from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter


### PR DESCRIPTION
## Summary
- prompt for login and password when no encrypted credentials are configured
- document CLI credential prompt in README and usage guide
- add CLI test covering interactive credential encryption

## Testing
- `pre-commit run --files README.md docs/guides/usage-example.md src/sele_saisie_auto/cli.py tests/test_cli.py tests/test_saisie_automatiser_psatime.py tests/test_saisie_automatiser_psatime_additional.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e77f529688321b6993feab62fbb7e