### PR TITLE
[saisie_automatiser_psatime] expose managers for tests

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -34,6 +34,7 @@ from sele_saisie_auto.read_or_write_file_config_ini_utils import (
     read_config_ini,
     write_config_ini,
 )
+from sele_saisie_auto.resources.resource_manager import ResourceManager
 from sele_saisie_auto.shared_utils import get_log_file
 
 DEFAULT_SETTINGS = {"date_cible": "", "debug_mode": "INFO"}

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -42,13 +42,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -4,6 +4,7 @@
 # ---------------- Import des bibliothèques nécessaires ----------------------- #
 # ----------------------------------------------------------------------------- #
 
+import sys
 from dataclasses import dataclass
 from multiprocessing import shared_memory
 from types import TracebackType
@@ -21,9 +22,11 @@ from sele_saisie_auto.automation.additional_info_page import (
 from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.automation.date_entry_page import DateEntryPage
 from sele_saisie_auto.automation.login_handler import LoginHandler
+from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import Services, service_configurator_factory
 from sele_saisie_auto.decorators import handle_selenium_errors
 from sele_saisie_auto.encryption_utils import Credentials as EncryptionCredentials
+from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.exceptions import AutomationExitError
 from sele_saisie_auto.interfaces.protocols import LoggerProtocol
 from sele_saisie_auto.locators import Locators
@@ -45,9 +48,9 @@ from sele_saisie_auto.selenium_utils import (
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import wait_for_dom_after
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.date_utils import get_next_saturday_if_not_saturday
@@ -74,6 +77,8 @@ class Credentials:
 __all__ = [
     "PSATimeAutomation",
     "Credentials",
+    "ConfigManager",
+    "EncryptionService",
     "modifier_date_input",
     "send_keys_to_element",
     "click_element_without_wait",


### PR DESCRIPTION
## Contexte et objectif
- expose `ResourceManager` dans `launcher`
- rend `ConfigManager` et `EncryptionService` disponibles dans `saisie_automatiser_psatime`
- import explicite de `sys` pour permettre le mock lors des tests
- ajustements mineurs d'imports suite à isort

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact éventuel
- aucun impact attendu sur les autres agents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_688f6d3951308321ba3fdae4163f77b6