### PR TITLE
fix: handle leftover shared memory segments

### DIFF
--- a/src/sele_saisie_auto/shared_memory_service.py
+++ b/src/sele_saisie_auto/shared_memory_service.py
@@ -7,17 +7,22 @@ from sele_saisie_auto.logging_service import Logger
 
 
 def ensure_clean_segment(name: str, size: int) -> shared_memory.SharedMemory:
-    """Return a new shared memory segment with ``name`` and ``size``.
+    """Return a shared memory segment ready for writing.
 
-    If a segment with the same name already exists, it is closed and unlinked
-    before the new one is created. This helper avoids ``FileExistsError`` when
-    a previous run left behind a shared memory block.
+    ``multiprocessing.shared_memory`` raises ``FileExistsError`` when a segment
+    with the requested ``name`` already exists.  This situation commonly occurs
+    when a previous run crashes without cleaning the segment.  The helper below
+    first tries to remove any stale block and then creates a fresh one.  If the
+    operating system still reports that the name is in use (for instance because
+    another handle is lingering on Windows), the existing segment is reused after
+    its buffer has been cleared.
     """
 
+    # Attempt to remove an existing segment if present
     try:
         existing = shared_memory.SharedMemory(name=name)
     except FileNotFoundError:
-        pass
+        existing = None
     else:
         try:
             existing.close()
@@ -27,7 +32,14 @@ def ensure_clean_segment(name: str, size: int) -> shared_memory.SharedMemory:
             except FileNotFoundError:
                 pass
 
-    return shared_memory.SharedMemory(name=name, create=True, size=size)
+    # First try to create a brand new segment
+    try:
+        return shared_memory.SharedMemory(name=name, create=True, size=size)
+    except FileExistsError:
+        # As a last resort, fall back to reusing the existing segment
+        existing = shared_memory.SharedMemory(name=name)
+        existing.buf[: existing.size] = b"\x00" * existing.size
+        return existing
 
 
 class SharedMemoryService:
@@ -38,11 +50,22 @@ class SharedMemoryService:
         self.logger = logger
 
     def ensure_clean_segment(self, name: str, size: int) -> None:
-        """Remove any existing segment named ``name`` and create a fresh one."""
+        """Remove an existing segment if it is still present.
 
-        seg = ensure_clean_segment(name, size)
-        seg.close()
-        seg.unlink()
+        This method is mainly useful for cleaning up when a previous execution
+        crashed before calling ``unlink``.  It does **not** return a handle and
+        simply ensures the name no longer refers to a shared memory block.
+        """
+
+        try:
+            seg = shared_memory.SharedMemory(name=name)
+        except FileNotFoundError:
+            return
+        for action in ("close", "unlink"):
+            try:
+                getattr(seg, action)()
+            except FileNotFoundError:
+                pass
 
     def stocker_en_memoire_partagee(
         self, nom: str, donnees: bytes


### PR DESCRIPTION
## Summary
- handle stale shared memory segments and reuse them when necessary
- add cleanup helper to remove lingering shared memory blocks

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/shared_memory_service.py`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8179437483219b0ba466fc40a228