### PR TITLE
fix: robust cleanup of shared memory

### DIFF
--- a/src/sele_saisie_auto/shared_memory_service.py
+++ b/src/sele_saisie_auto/shared_memory_service.py
@@ -7,27 +7,42 @@ from sele_saisie_auto.logging_service import Logger
 
 
 def ensure_clean_segment(name: str, size: int) -> shared_memory.SharedMemory:
-    """Return a new shared memory segment with ``name`` and ``size``.
+    """Return a shared memory segment ready for writing.
 
-    If a segment with the same name already exists, it is closed and unlinked
-    before the new one is created. This helper avoids ``FileExistsError`` when
-    a previous run left behind a shared memory block.
+    ``multiprocessing.shared_memory`` raises ``FileExistsError`` when a segment
+    with the requested ``name`` already exists.  This situation commonly occurs
+    when a previous run crashes without cleaning the segment.  The helper below
+    first tries to remove any stale block and then creates a fresh one.  If the
+    operating system still reports that the name is in use (for instance because
+    another handle is lingering on Windows), the existing segment is reused after
+    its buffer has been cleared.
     """
 
+    # Attempt to remove an existing segment if present
     try:
         existing = shared_memory.SharedMemory(name=name)
     except FileNotFoundError:
         pass
     else:
         try:
-            existing.close()
+            existing.unlink()
         finally:
+            existing.close()
+
+    # First try to create a brand new segment
+    try:
+        return shared_memory.SharedMemory(name=name, create=True, size=size)
+    except FileExistsError:
+        # Fall back to reusing or recreating the existing segment
+        existing = shared_memory.SharedMemory(name=name)
+        if existing.size < size:
             try:
                 existing.unlink()
-            except FileNotFoundError:
-                pass
-
-    return shared_memory.SharedMemory(name=name, create=True, size=size)
+            finally:
+                existing.close()
+            return shared_memory.SharedMemory(name=name, create=True, size=size)
+        existing.buf[: existing.size] = b"\x00" * existing.size
+        return existing
 
 
 class SharedMemoryService:
@@ -38,11 +53,26 @@ class SharedMemoryService:
         self.logger = logger
 
     def ensure_clean_segment(self, name: str, size: int) -> None:
-        """Remove any existing segment named ``name`` and create a fresh one."""
+        """Remove an existing segment if it is still present.
 
-        seg = ensure_clean_segment(name, size)
-        seg.close()
-        seg.unlink()
+        This method is mainly useful for cleaning up when a previous execution
+        crashed before calling ``unlink``.  It does **not** return a handle and
+        simply ensures the name no longer refers to a shared memory block.
+        """
+
+        try:
+            seg = shared_memory.SharedMemory(name=name)
+        except FileNotFoundError:
+            return
+        try:
+            seg.unlink()
+        except FileNotFoundError:
+            pass
+        finally:
+            try:
+                seg.close()
+            except FileNotFoundError:
+                pass
 
     def stocker_en_memoire_partagee(
         self, nom: str, donnees: bytes


### PR DESCRIPTION
## Summary
- unlink before closing shared memory segments
- recreate shared memory when an existing block is too small
- add regression test for shared-memory recreation

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/shared_memory_service.py tests/test_shared_memory_service.py`
- `poetry run pytest`
- `poetry run mypy --strict --no-incremental src`


------
https://chatgpt.com/codex/tasks/task_e_688f8179437483219b0ba466fc40a228