### PR TITLE
[Logger] helpers d'E/S et propagation d'OSError

### DIFF
--- a/tests/test_logger_utils.py
+++ b/tests/test_logger_utils.py
@@ -74,6 +74,16 @@ def test_initialize_logger_invalid_config(tmp_path):
     assert mod.LOG_LEVEL_FILTER == LogLevel.INFO
 
 
+def test_initialize_logger_override_and_config_invalid(tmp_path):
+    mod = importlib.reload(logger_utils)
+    cfg = configparser.ConfigParser()
+    cfg["settings"] = {"debug_mode": "BAD"}
+    log_file = tmp_path / "log.html"
+    mod.initialize_logger(cfg, log_level_override="NOPE", log_file=str(log_file))
+    assert mod.LOG_LEVEL_FILTER == LogLevel.INFO
+    assert "Invalid log level" in log_file.read_text(encoding="utf-8")
+
+
 def test_initialize_html_log_file_cleanup(tmp_path):
     log_file = tmp_path / "log.html"
     log_file.write_text("</table></body></html>", encoding="utf-8")
@@ -134,7 +144,7 @@ def test_write_log_oserror(monkeypatch, tmp_path):
 
     monkeypatch.setattr(logger_utils, "initialize_html_log_file", lambda *a, **k: None)
     monkeypatch.setattr("builtins.open", bad_open)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(OSError):
         logger_utils.write_log(
             "msg", str(log_file), level=LogLevel.INFO, log_format="html"
         )
@@ -152,7 +162,7 @@ def test_close_logs_error(monkeypatch, tmp_path):
         raise OSError("fail")
 
     monkeypatch.setattr("builtins.open", bad_open)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(OSError):
         logger_utils.close_logs(str(log_file))
 
 
@@ -176,6 +186,21 @@ def test_close_logs_already_closed(tmp_path):
     logger_utils.close_logs(str(log_file))
     content = log_file.read_text(encoding="utf-8")
     assert content.endswith("</table></body></html>")
+
+
+def test_close_logs_no_double(tmp_path):
+    seq = "</table></body></html>"
+    file1 = tmp_path / "a.html"
+    file1.write_text("<table>", encoding="utf-8")
+    logger_utils.close_logs(str(file1))
+    content1 = file1.read_text(encoding="utf-8")
+    assert content1.count(seq) == 1
+
+    file2 = tmp_path / "b.html"
+    file2.write_text(seq, encoding="utf-8")
+    logger_utils.close_logs(str(file2))
+    content2 = file2.read_text(encoding="utf-8")
+    assert content2.count(seq) == 1
 
 
 def test_close_logs_generic_error(monkeypatch, tmp_path):
@@ -242,3 +267,11 @@ column_widths = timestamp10%
     monkeypatch.chdir(tmp_path)
     with pytest.raises(InvalidConfigError):
         logger_utils.get_html_style()
+
+
+def test_validate_log_style_missing_value():
+    parser = configparser.ConfigParser(interpolation=None)
+    parser.add_section("log_style")
+    parser.set("log_style", "column_widths", "timestamp:10%,level")
+    with pytest.raises(InvalidConfigError):
+        logger_utils.validate_log_style(parser)


### PR DESCRIPTION
## Contexte
- factorise l'accès disque du logger
- conserve les erreurs `OSError` pour faciliter les mocks et la détection
- tests supplémentaires sur la configuration et la fermeture des logs

## Étapes pour tester
- `poetry run radon cc src/sele_saisie_auto/logger_utils.py -s -a`
- `poetry run pre-commit run --files src/sele_saisie_auto/logger_utils.py tests/test_logger_utils.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`

## Impact
- meilleur contrôle des écritures disque
- aucun impact attendu sur les autres agents

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_6897c8ca08c48321ab17f02cb178a321