### PR TITLE
Refactor EncryptionService shared memory workflow

### DIFF
--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -158,68 +158,47 @@ class EncryptionService:
     # Context manager utilities
     # ------------------------------------------------------------------
 
-    def __enter__(self) -> "EncryptionService":
-        """Generate and store the AES key in shared memory."""
-        self.cle_aes = self.generer_cle_aes(self.memory_config.key_size)
-        mem = None
+    def _creer_segment_si_besoin(
+        self, nom: str, donnees: bytes
+    ) -> shared_memory.SharedMemory:
+        """Crée un segment mémoire en réessayant une fois après nettoyage."""
+
         try:
-            mem = self.shared_memory_service.stocker_en_memoire_partagee(
-                self.memory_config.cle_name,
-                self.cle_aes,
-            )
-            self._memoires.append(mem)
+            return self.shared_memory_service.stocker_en_memoire_partagee(nom, donnees)
         except FileExistsError:
             self.logger.info(
                 "⚠️ Segment déjà présent, nettoyage puis nouvelle tentative"
             )
-            try:
-                self.shared_memory_service.ensure_clean_segment(
-                    self.memory_config.cle_name,
-                    len(self.cle_aes),
-                )
-                mem = self.shared_memory_service.stocker_en_memoire_partagee(
-                    self.memory_config.cle_name,
-                    self.cle_aes,
-                )
-                self._memoires.append(mem)
-            except Exception as retry_exc:
-                if mem is not None:
-                    try:
-                        self.remove_shared_memory(mem)
-                    except Exception:  # nosec B110
-                        pass
-                self.cle_aes = None
-                self.logger.error(
-                    f"❌ Impossible d'initialiser la mémoire partagée : {retry_exc}"
-                )
-                raise
-        except Exception as exc:
-            if mem is not None:
-                try:
-                    self.remove_shared_memory(mem)
-                except Exception:  # nosec B110
-                    pass
-            self.cle_aes = None
-            self.logger.error(
-                f"❌ Impossible d'initialiser la mémoire partagée : {exc}"
-            )
+            self.shared_memory_service.ensure_clean_segment(nom, len(donnees))
+            return self.shared_memory_service.stocker_en_memoire_partagee(nom, donnees)
+        except Exception as exc:  # pragma: no cover - simple passthrough
+            self.logger.error(f"❌ Impossible de créer le segment '{nom}' : {exc}")
             raise
-        else:
-            if self.log_file:
-                self.logger.info("✅ Mémoire partagée initialisée")
+
+    def __enter__(self) -> "EncryptionService":
+        """Generate and store the AES key in shared memory."""
+
+        self.cle_aes = self.generer_cle_aes(self.memory_config.key_size)
+        mem = self._creer_segment_si_besoin(self.memory_config.cle_name, self.cle_aes)
+        try:
+            self._memoires.append(mem)
+        except Exception:
+            self.remove_shared_memory(mem)
+            self.cle_aes = None
+            raise
+        self.logger.info("✅ Mémoire partagée initialisée")
         return self
 
     def store_credentials(self, login_data: bytes, password_data: bytes) -> None:
         """Save encrypted credentials in shared memory."""
-        mem_login = self.shared_memory_service.stocker_en_memoire_partagee(
-            self.memory_config.login_name,
-            login_data,
+        mem_login = self._creer_segment_si_besoin(
+            self.memory_config.login_name, login_data
         )
-        mem_pwd = self.shared_memory_service.stocker_en_memoire_partagee(
-            self.memory_config.password_name,
-            password_data,
+        self._memoires.append(mem_login)
+        mem_pwd = self._creer_segment_si_besoin(
+            self.memory_config.password_name, password_data
         )
-        self._memoires.extend([mem_login, mem_pwd])
+        self._memoires.append(mem_pwd)
 
     def __exit__(
         self,
@@ -242,26 +221,13 @@ class EncryptionService:
             self.memory_config.cle_name,
             self.memory_config.key_size,
         )
-        write_log(f"💀 Clé AES récupérée : {aes_key.hex()}", self.log_file, "CRITICAL")
+        self.logger.info(
+            f"Segment '{self.memory_config.cle_name}' lu ({len(aes_key)} octets)"
+        )
 
         try:
-            mem_login = shared_memory.SharedMemory(name=self.memory_config.login_name)
-            taille_nom = len(bytes(mem_login.buf).rstrip(b"\x00"))
-            login = bytes(mem_login.buf[:taille_nom])
-            write_log(
-                f"💀 Taille du login chiffré : {len(login)}",
-                self.log_file,
-                "CRITICAL",
-            )
-
-            mem_pwd = shared_memory.SharedMemory(name=self.memory_config.password_name)
-            taille_pwd = len(bytes(mem_pwd.buf).rstrip(b"\x00"))
-            password = bytes(mem_pwd.buf[:taille_pwd])
-            write_log(
-                f"💀 Taille du mot de passe chiffré : {len(password)}",
-                self.log_file,
-                "CRITICAL",
-            )
+            mem_login, login = self._read_segment(self.memory_config.login_name)
+            mem_pwd, password = self._read_segment(self.memory_config.password_name)
         except FileNotFoundError as exc:
             msg = "identifiants non trouvés : lancez d'abord psatime-launcher"
             self.logger.error(msg)
@@ -276,3 +242,12 @@ class EncryptionService:
             password=password,
             mem_password=mem_pwd,
         )
+
+    def _read_segment(self, nom: str) -> tuple[shared_memory.SharedMemory, bytes]:
+        """Ouvre un segment mémoire et retourne les octets utiles."""
+
+        memoire = shared_memory.SharedMemory(name=nom)
+        brut = bytes(memoire.buf)
+        taille = len(brut.rstrip(b"\x00"))
+        self.logger.info(f"Segment '{nom}' lu ({taille} octets)")
+        return memoire, brut[:taille]


### PR DESCRIPTION
## Summary
- factor segment creation into `_creer_segment_si_besoin` and use it across the service
- streamline context management and credential storage
- centralize credential retrieval with `_read_segment` and avoid logging secrets

## Testing
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption_utils.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run radon cc src/sele_saisie_auto/encryption_utils.py -s -a`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68988cd3c5248321b1fcda5563870078