### PR TITLE
[EncryptionService] sécurisation du rollback & des logs

### DIFF
--- a/src/sele_saisie_auto/configuration/service_configurator.py
+++ b/src/sele_saisie_auto/configuration/service_configurator.py
@@ -17,6 +17,7 @@ from sele_saisie_auto.interfaces import (
     LoginHandlerProtocol,
     WaiterProtocol,
 )
+from sele_saisie_auto.logging_service import get_logger
 from sele_saisie_auto.memory_config import MemoryConfig
 from sele_saisie_auto.selenium_utils import Waiter
 
@@ -81,8 +82,9 @@ class ServiceConfigurator:
 
     def create_encryption_service(self, log_file: str) -> EncryptionService:
         """Return a new :class:`EncryptionService`."""
-
-        backend = self.encryption_backend or DefaultEncryptionBackend(log_file)
+        backend = self.encryption_backend or DefaultEncryptionBackend(
+            get_logger(log_file)
+        )
         return EncryptionService(
             log_file,
             backend=backend,

--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -1,6 +1,7 @@
 # encryption_utils.py
 
 import os
+from contextlib import suppress
 from dataclasses import dataclass
 from multiprocessing import shared_memory
 from typing import Protocol, runtime_checkable
@@ -9,8 +10,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.padding import PKCS7
 
 from sele_saisie_auto.exceptions import AutomationExitError
-from sele_saisie_auto.logger_utils import write_log
-from sele_saisie_auto.logging_service import get_logger
+from sele_saisie_auto.logging_service import Logger, get_logger
 from sele_saisie_auto.memory_config import MemoryConfig
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.shared_utils import get_log_file
@@ -34,19 +34,14 @@ class EncryptionBackend(Protocol):
 class DefaultEncryptionBackend:
     """Backend concret reposant sur ``cryptography``."""
 
-    def __init__(self, log_file: str | None = None) -> None:
-        # Garantit que ``write_log`` reçoit toujours une *str*
-        self.log_file: str = log_file if log_file is not None else get_log_file()
+    def __init__(self, logger: Logger | None = None) -> None:
+        self.logger: Logger = logger or get_logger(None)
 
     def generer_cle_aes(self, taille_cle: int = 32) -> bytes:
         try:
             return os.urandom(taille_cle)
         except Exception as e:
-            write_log(
-                f"❌ Erreur lors de la génération de la clé AES : {e}",
-                self.log_file,
-                "ERROR",
-            )
+            self.logger.error(f"❌ Erreur lors de la génération de la clé AES : {e}")
             raise
 
     def chiffrer_donnees(
@@ -59,14 +54,10 @@ class DefaultEncryptionBackend:
             donnees_pad = padder.update(donnees.encode()) + padder.finalize()
             donnees_chiffrees = chiffreur.update(donnees_pad) + chiffreur.finalize()
             iv_bytes: bytes = bytes(chiffre.mode.initialization_vector)
-            write_log("💀 Données chiffrées avec succès.", self.log_file, "CRITICAL")
+            self.logger.debug("Données chiffrées avec succès")
             return bytes(iv_bytes + donnees_chiffrees)
         except Exception as e:
-            write_log(
-                f"❌ Erreur lors du chiffrement des données : {e}",
-                self.log_file,
-                "ERROR",
-            )
+            self.logger.error(f"❌ Erreur lors du chiffrement des données : {e}")
             raise
 
     def dechiffrer_donnees(
@@ -80,15 +71,11 @@ class DefaultEncryptionBackend:
             donnees_pad = dechiffreur.update(message_chiffre) + dechiffreur.finalize()
             unpadder = PKCS7(taille_bloc).unpadder()
             donnees = unpadder.update(donnees_pad) + unpadder.finalize()
-            write_log("💀 Données déchiffrées avec succès.", self.log_file, "CRITICAL")
+            self.logger.debug("Données déchiffrées avec succès")
             decoded: str = donnees.decode()
             return decoded
         except Exception as e:
-            write_log(
-                f"❌ Erreur lors du déchiffrement des données : {e}",
-                self.log_file,
-                "ERROR",
-            )
+            self.logger.error(f"❌ Erreur lors du déchiffrement des données : {e}")
             raise
 
 
@@ -115,18 +102,20 @@ class EncryptionService:
         memory_config: MemoryConfig | None = None,
     ) -> None:
         """Prépare le service de chiffrement."""
-        # Toujours fournir un chemin de fichier valide à ``write_log``
-        self.log_file: str = log_file if log_file is not None else get_log_file()
-        self.backend = backend or DefaultEncryptionBackend(log_file)
-        self.memory_config = memory_config or MemoryConfig()
-        if shared_memory_service is None:
-            logger = get_logger(log_file)
-            self.shared_memory_service = SharedMemoryService(logger)
-        else:
-            self.shared_memory_service = shared_memory_service
+        self.log_file: str = log_file or get_log_file()
         self.logger = get_logger(log_file)
+        self.backend = backend or DefaultEncryptionBackend(self.logger)
+        self.memory_config = memory_config or MemoryConfig()
+        self.shared_memory_service = self._resolve_shared_memory_service(
+            shared_memory_service
+        )
         self.cle_aes: bytes | None = None
         self._memoires: list[shared_memory.SharedMemory] = []
+
+    def _resolve_shared_memory_service(
+        self, service: SharedMemoryService | None
+    ) -> SharedMemoryService:
+        return service or SharedMemoryService(self.logger)
 
     def remove_shared_memory(self, memoire: shared_memory.SharedMemory) -> None:
         """Delegate secure removal of ``memoire`` to the underlying service."""
@@ -191,7 +180,8 @@ class EncryptionService:
         try:
             self._memoires.append(mem)
         except Exception:
-            self.remove_shared_memory(mem)
+            with suppress(Exception):
+                self.remove_shared_memory(mem)
             raise
         self.cle_aes = key
         self.logger.info("✅ Mémoire partagée initialisée")
@@ -208,7 +198,8 @@ class EncryptionService:
                 self.memory_config.password_name, password_data
             )
         except Exception:
-            self.remove_shared_memory(mem_login)
+            with suppress(Exception):
+                self.remove_shared_memory(mem_login)
             raise
 
         self._memoires.extend([mem_login, mem_pwd])
@@ -221,15 +212,17 @@ class EncryptionService:
     ) -> None:
         """Securely remove all allocated shared memories."""
         for mem in self._memoires:
-            try:
+            with suppress(Exception):  # nosec B110
                 self.remove_shared_memory(mem)
-            except Exception:  # nosec B110
-                pass
         self._memoires.clear()
         self.cle_aes = None
 
     def retrieve_credentials(self) -> Credentials:
-        """Retrieve encrypted credentials from shared memory."""
+        """Retrieve encrypted credentials from shared memory.
+
+        The caller is responsible for releasing the returned segments,
+        e.g. via :meth:`close_credentials`.
+        """
         mem_key, aes_key = self.shared_memory_service.recuperer_de_memoire_partagee(
             self.memory_config.cle_name,
             self.memory_config.key_size,
@@ -253,3 +246,10 @@ class EncryptionService:
             password=password,
             mem_password=mem_pwd,
         )
+
+    def close_credentials(self, creds: Credentials) -> None:
+        """Release shared memory segments obtained via ``retrieve_credentials``."""
+
+        for mem in (creds.mem_key, creds.mem_login, creds.mem_password):
+            with suppress(Exception):  # nosec B110
+                self.remove_shared_memory(mem)

--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -235,7 +235,8 @@ class EncryptionService:
         except FileNotFoundError as exc:
             msg = "identifiants non trouvés : lancez d'abord psatime-launcher"
             self.logger.error(msg)
-            self.remove_shared_memory(mem_key)
+            with suppress(Exception):  # nosec B110
+                self.remove_shared_memory(mem_key)
             raise AutomationExitError(msg) from exc
 
         return Credentials(


### PR DESCRIPTION
## Contexte et objectif
- sécurisation des rollbacks de segments mémoire pour ne pas masquer l'erreur d'origine
- harmonisation de la politique de logs du backend de chiffrement
- ajout d'une méthode pour libérer explicitement les segments renvoyés par `retrieve_credentials`

## Étapes pour tester
- `poetry run radon cc src/sele_saisie_auto/encryption_utils.py -s -a`
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption_utils.py src/sele_saisie_auto/configuration/service_configurator.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`

## Impact sur les autres agents
- `ServiceConfigurator` instancie désormais `DefaultEncryptionBackend` avec un logger, sans autre impact fonctionnel.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68990b74aec88321ad850f0307376d69