### PR TITLE
[EncryptionService] durcir rollbacks et homogénéiser les logs

### DIFF
--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -1,6 +1,7 @@
 # encryption_utils.py
 
 import os
+from contextlib import suppress
 from dataclasses import dataclass
 from multiprocessing import shared_memory
 from typing import Protocol, runtime_checkable
@@ -9,7 +10,6 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.padding import PKCS7
 
 from sele_saisie_auto.exceptions import AutomationExitError
-from sele_saisie_auto.logger_utils import write_log
 from sele_saisie_auto.logging_service import get_logger
 from sele_saisie_auto.memory_config import MemoryConfig
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
@@ -35,18 +35,14 @@ class DefaultEncryptionBackend:
     """Backend concret reposant sur ``cryptography``."""
 
     def __init__(self, log_file: str | None = None) -> None:
-        # Garantit que ``write_log`` reçoit toujours une *str*
         self.log_file: str = log_file if log_file is not None else get_log_file()
+        self.logger = get_logger(self.log_file)
 
     def generer_cle_aes(self, taille_cle: int = 32) -> bytes:
         try:
             return os.urandom(taille_cle)
         except Exception as e:
-            write_log(
-                f"❌ Erreur lors de la génération de la clé AES : {e}",
-                self.log_file,
-                "ERROR",
-            )
+            self.logger.error(f"Erreur lors de la génération de la clé AES : {e}")
             raise
 
     def chiffrer_donnees(
@@ -59,14 +55,10 @@ class DefaultEncryptionBackend:
             donnees_pad = padder.update(donnees.encode()) + padder.finalize()
             donnees_chiffrees = chiffreur.update(donnees_pad) + chiffreur.finalize()
             iv_bytes: bytes = bytes(chiffre.mode.initialization_vector)
-            write_log("💀 Données chiffrées avec succès.", self.log_file, "CRITICAL")
+            self.logger.debug("Données chiffrées avec succès")
             return bytes(iv_bytes + donnees_chiffrees)
         except Exception as e:
-            write_log(
-                f"❌ Erreur lors du chiffrement des données : {e}",
-                self.log_file,
-                "ERROR",
-            )
+            self.logger.error(f"Erreur lors du chiffrement des données : {e}")
             raise
 
     def dechiffrer_donnees(
@@ -80,15 +72,11 @@ class DefaultEncryptionBackend:
             donnees_pad = dechiffreur.update(message_chiffre) + dechiffreur.finalize()
             unpadder = PKCS7(taille_bloc).unpadder()
             donnees = unpadder.update(donnees_pad) + unpadder.finalize()
-            write_log("💀 Données déchiffrées avec succès.", self.log_file, "CRITICAL")
+            self.logger.debug("Données déchiffrées avec succès")
             decoded: str = donnees.decode()
             return decoded
         except Exception as e:
-            write_log(
-                f"❌ Erreur lors du déchiffrement des données : {e}",
-                self.log_file,
-                "ERROR",
-            )
+            self.logger.error(f"Erreur lors du déchiffrement des données : {e}")
             raise
 
 
@@ -115,7 +103,7 @@ class EncryptionService:
         memory_config: MemoryConfig | None = None,
     ) -> None:
         """Prépare le service de chiffrement."""
-        # Toujours fournir un chemin de fichier valide à ``write_log``
+        # Toujours fournir un chemin de fichier valide au logger
         self.log_file: str = log_file if log_file is not None else get_log_file()
         self.backend = backend or DefaultEncryptionBackend(log_file)
         self.memory_config = memory_config or MemoryConfig()
@@ -154,9 +142,12 @@ class EncryptionService:
         """Read a segment and return the useful bytes without trailing nulls."""
 
         mem = shared_memory.SharedMemory(name=nom)
-        raw = bytes(mem.buf)
-        taille = len(raw.rstrip(b"\x00"))
-        data = raw[:taille]
+        buf = mem.buf
+        end = len(buf) - 1
+        while end >= 0 and buf[end] == 0:
+            end -= 1
+        taille = end + 1
+        data = bytes(buf[:taille])
         self.logger.info(f"Segment '{nom}' lu ({taille} octets)")
         return mem, data
 
@@ -191,7 +182,8 @@ class EncryptionService:
         try:
             self._memoires.append(mem)
         except Exception:
-            self.remove_shared_memory(mem)
+            with suppress(Exception):
+                self.remove_shared_memory(mem)
             raise
         self.cle_aes = key
         self.logger.info("✅ Mémoire partagée initialisée")
@@ -208,7 +200,8 @@ class EncryptionService:
                 self.memory_config.password_name, password_data
             )
         except Exception:
-            self.remove_shared_memory(mem_login)
+            with suppress(Exception):
+                self.remove_shared_memory(mem_login)
             raise
 
         self._memoires.extend([mem_login, mem_pwd])
@@ -221,15 +214,13 @@ class EncryptionService:
     ) -> None:
         """Securely remove all allocated shared memories."""
         for mem in self._memoires:
-            try:
+            with suppress(Exception):
                 self.remove_shared_memory(mem)
-            except Exception:  # nosec B110
-                pass
         self._memoires.clear()
         self.cle_aes = None
 
     def retrieve_credentials(self) -> Credentials:
-        """Retrieve encrypted credentials from shared memory."""
+        """Retrieve credentials; caller must release segments via ``close_credentials``."""
         mem_key, aes_key = self.shared_memory_service.recuperer_de_memoire_partagee(
             self.memory_config.cle_name,
             self.memory_config.key_size,
@@ -253,3 +244,10 @@ class EncryptionService:
             password=password,
             mem_password=mem_pwd,
         )
+
+    def close_credentials(self, creds: Credentials) -> None:
+        """Release all segments associated with ``creds``."""
+
+        for mem in (creds.mem_key, creds.mem_login, creds.mem_password):
+            with suppress(Exception):
+                self.remove_shared_memory(mem)


### PR DESCRIPTION
## Contexte et objectif
- sécuriser les rollbacks pour ne pas masquer l'erreur d'origine
- unifier les logs avec le logger interne et réduire leur verbosité
- offrir un nettoyage explicite des segments mémoire

## Étapes pour tester
- `poetry run radon cc src/sele_saisie_auto/encryption_utils.py -s -a`
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption_utils.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`

## Impact sur les autres agents
- aucun impact attendu

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68990b74aec88321ad850f0307376d69