### PR TITLE
[EncryptionService] ensure key cleanup on retrieval failure

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -42,13 +42,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT

--- a/tests/test_encryption_context_manager.py
+++ b/tests/test_encryption_context_manager.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from sele_saisie_auto.encryption_utils import EncryptionService
+from sele_saisie_auto.exceptions import AutomationExitError
 from sele_saisie_auto.logging_service import Logger
 from sele_saisie_auto.memory_config import MemoryConfig
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
@@ -226,3 +227,24 @@ def test_store_credentials_cleans_up_on_exit(mem_cfg):
     )
     assert service.cle_aes is None
     assert service._memoires == []
+
+
+def test_retrieve_credentials_missing_segment_cleans_key_best_effort(
+    mem_cfg, monkeypatch
+):
+    expected_key = b"k" * mem_cfg.key_size
+    mem_key = object()
+    mock_service = Mock(spec=SharedMemoryService)
+    mock_service.recuperer_de_memoire_partagee.return_value = (mem_key, expected_key)
+    monkeypatch.setattr(
+        EncryptionService,
+        "_lire_segment",
+        lambda self, nom: (_ for _ in ()).throw(FileNotFoundError("boom")),
+    )
+    service = _make_service(mock_service, mem_cfg, expected_key)
+    with service as enc:
+        with pytest.raises(AutomationExitError):
+            enc.retrieve_credentials()
+        mock_service.supprimer_memoire_partagee_securisee.assert_called_once_with(
+            mem_key
+        )

--- a/tests/test_encryption_service.py
+++ b/tests/test_encryption_service.py
@@ -234,6 +234,8 @@ def test_retrieve_credentials_missing_segment(missing):
         enc.remove_shared_memory(mem)
         with pytest.raises(AutomationExitError, match="identifiants non trouvés"):
             enc.retrieve_credentials()
+        with pytest.raises(FileNotFoundError):
+            shared_memory.SharedMemory(name=enc.memory_config.cle_name)
 
 
 def test_enter_cleans_on_failure(monkeypatch):


### PR DESCRIPTION
## Contexte
- Vérifie que la suppression du segment de clé est bien effectuée lorsque `retrieve_credentials` échoue.
- Ajout d'un test simulant cet échec avec mocks et vérification du nettoyage.
- Correction d'ordre d'import pour respecter isort.

## Étapes pour tester
- `poetry run pre-commit run --all-files`
- `poetry run pytest`

## Impact
- Renforce la fiabilité du rollback de la clé en mémoire partagée.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_689cf0d1f1c08321bc52d006f210e5d9