### PR TITLE
[DuplicateDayDetector] Simplifie la détection des doublons

### DIFF
--- a/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
+++ b/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
@@ -1,8 +1,7 @@
-# src\sele_saisie_auto\selenium_utils\duplicate_day_detector.py
 """Detect duplicate days in time sheet entries."""
+
 from __future__ import annotations
 
-from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
@@ -21,56 +20,58 @@ class DuplicateDayDetector:
         self.logger = logger or get_default_logger()
 
     @staticmethod
-    def _determine_row_range(driver: WebDriver, max_rows: int | None) -> range:
-        if max_rows is None:
-            row_elements = driver.find_elements(By.CSS_SELECTOR, "[id^='POL_DESCR$']")
-            return range(len(row_elements))
-        return range(max_rows)
-
-    @staticmethod
     def _update_tracker(
         tracker: dict[str, list[str]], day_counter: int, description: str
     ) -> None:
         day_name = JOURS_SEMAINE[day_counter]
         tracker.setdefault(day_name, []).append(description)
 
-    def detect(self, driver: WebDriver, max_rows: int | None = None) -> None:
-        """Log duplicate days across description lines."""
-        filled_days: dict[str, list[str]] = {}
-        row_range = self._determine_row_range(driver, max_rows)
+    @staticmethod
+    def _parse_row_index(elem_id: str) -> int | None:
+        """Extract the numeric index from an id like 'POL_DESCR$12'."""
+        if not elem_id or "$" not in elem_id:
+            return None
+        suffix = elem_id.rsplit("$", 1)[-1]
+        try:
+            return int(suffix)
+        except ValueError:
+            return None
 
-        for row_index in row_range:
-            try:
-                current_line_description = driver.find_element(
-                    By.ID, f"POL_DESCR${row_index}"
-                )
-            except NoSuchElementException:
-                if max_rows is None:
-                    self.logger.debug(
-                        f"Fin de l'analyse des lignes à l'index {row_index}"
-                    )
-                    break
-                continue
+    def _iter_row_descriptions(self, driver: WebDriver, max_rows: int | None):
+        """Yield (row_index, description) for each visible description row."""
+        row_elements = driver.find_elements(By.CSS_SELECTOR, "[id^='POL_DESCR$']")
+        if max_rows is not None:
+            row_elements = row_elements[:max_rows]
 
-            description = current_line_description.text.strip()
-            self.logger.debug(
-                f"Analyse de la ligne '{description}' à l'index {row_index}"
+        self.logger.debug(f"{len(row_elements)} ligne(s) de description détectée(s).")
+
+        for fallback_idx, el in enumerate(row_elements):
+            el_id = el.get_attribute("id") or ""
+            row_index = self._parse_row_index(el_id)
+            if row_index is None:
+                row_index = fallback_idx
+            description = (el.text or "").strip()
+            yield row_index, description
+
+    def _is_day_filled(
+        self, driver: WebDriver, row_index: int, day_counter: int
+    ) -> bool:
+        """Return True if the cell for (row_index, day_counter) has a value."""
+        day_input_id = ElementIdBuilder.build_day_input_id(
+            "POL_TIME", day_counter, row_index
+        )
+        elems = driver.find_elements(By.ID, day_input_id)
+        if not elems:
+            self.logger.warning(
+                f"{messages.IMPOSSIBLE_DE_TROUVER} l'élément pour le jour "
+                f"'{JOURS_SEMAINE[day_counter]}' avec l'ID '{day_input_id}'"
             )
+            return False
 
-            for day_counter in range(1, 8):
-                day_input_id = ElementIdBuilder.build_day_input_id(
-                    "POL_TIME", day_counter, row_index
-                )
-                try:
-                    day_field = driver.find_element(By.ID, day_input_id)
-                    day_content: str | None = day_field.get_attribute("value")
-                    if day_content and day_content.strip():
-                        self._update_tracker(filled_days, day_counter, description)
-                except NoSuchElementException:
-                    self.logger.warning(
-                        f"{messages.IMPOSSIBLE_DE_TROUVER} l'élément pour le jour '{JOURS_SEMAINE[day_counter]}' avec l'ID '{day_input_id}'"
-                    )
+        value = elems[0].get_attribute("value")
+        return bool(value and value.strip())
 
+    def _report_duplicates(self, filled_days: dict[str, list[str]]) -> None:
         for day_name, lines in filled_days.items():
             if len(lines) > 1:
                 self.logger.warning(
@@ -78,3 +79,17 @@ class DuplicateDayDetector:
                 )
             else:
                 self.logger.debug(f"Aucun doublon détecté pour le jour '{day_name}'")
+
+    def detect(self, driver: WebDriver, max_rows: int | None = None) -> None:
+        """Log duplicate days across description lines."""
+        filled_days: dict[str, list[str]] = {}
+
+        for row_index, description in self._iter_row_descriptions(driver, max_rows):
+            self.logger.debug(
+                f"Analyse de la ligne '{description}' à l'index {row_index}"
+            )
+            for day_counter in range(1, 8):
+                if self._is_day_filled(driver, row_index, day_counter):
+                    self._update_tracker(filled_days, day_counter, description)
+
+        self._report_duplicates(filled_days)

--- a/tests/test_fonctions_selenium_utils.py
+++ b/tests/test_fonctions_selenium_utils.py
@@ -376,15 +376,21 @@ def test_definir_taille_navigateur():
 
 
 class DummyDesc:
-    def __init__(self, text=""):
+    def __init__(self, text: str = "", element_id: str = ""):
         self.text = text
+        self.element_id = element_id
+
+    def get_attribute(self, name: str) -> str | None:
+        if name == "id":
+            return self.element_id
+        return None
 
 
 class DummyField:
-    def __init__(self, value=""):
+    def __init__(self, value: str = ""):
         self.value = value
 
-    def get_attribute(self, name):
+    def get_attribute(self, name: str) -> str:
         return self.value
 
 
@@ -393,24 +399,19 @@ class DummyDoublonDriver:
         self.descs = descs
         self.values = values
 
-    def find_element(self, by, ident):
-        if ident.startswith("POL_DESCR$"):
-            idx = int(ident.split("$")[1])
-            if idx in self.descs:
-                return DummyDesc(self.descs[idx])
-            raise fsu.NoSuchElementException("desc")
-        if ident.startswith("POL_TIME"):
-            prefix, row = ident.split("$")
+    def find_elements(self, by, value):
+        if by == "css selector" and value == "[id^='POL_DESCR$']":
+            return [
+                DummyDesc(self.descs[idx], f"POL_DESCR${idx}")
+                for idx in sorted(self.descs)
+            ]
+        if by == "id" and value.startswith("POL_TIME"):
+            prefix, row = value.split("$")
             day = int(prefix[8:])
             idx = int(row)
             if (day, idx) in self.values:
-                return DummyField(self.values[(day, idx)])
-            raise fsu.NoSuchElementException("day")
-        raise fsu.NoSuchElementException("unknown")
-
-    def find_elements(self, by, value):
-        if by == "css selector" and value == "[id^='POL_DESCR$']":
-            return [DummyDesc(self.descs[idx]) for idx in sorted(self.descs)]
+                return [DummyField(self.values[(day, idx)])]
+            return []
         return []
 
 


### PR DESCRIPTION
## Contexte et objectif
- Refactorisation de `DuplicateDayDetector` pour réduire la complexité cyclomatique.
- Suppression de la logique basée sur les exceptions et ajout de fonctions utilitaires claires.

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py tests/test_duplicate_day_detector.py tests/test_fonctions_selenium_utils.py`
- `poetry run pytest`

## Impact éventuel sur les autres agents
- Aucun impact attendu sur les autres agents : l'API publique reste inchangée.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_689db228cef8832188c50b3115b3a946