### PR TITLE
[DuplicateDayDetector] Simplification de la détection des doublons

### DIFF
--- a/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
+++ b/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
@@ -21,60 +21,71 @@ class DuplicateDayDetector:
         self.logger = logger or get_default_logger()
 
     @staticmethod
-    def _determine_row_range(driver: WebDriver, max_rows: int | None) -> range:
-        if max_rows is None:
-            row_elements = driver.find_elements(By.CSS_SELECTOR, "[id^='POL_DESCR$']")
-            return range(len(row_elements))
-        return range(max_rows)
-
-    @staticmethod
     def _update_tracker(
         tracker: dict[str, list[str]], day_counter: int, description: str
     ) -> None:
         day_name = JOURS_SEMAINE[day_counter]
         tracker.setdefault(day_name, []).append(description)
 
-    def detect(self, driver: WebDriver, max_rows: int | None = None) -> None:
-        """Log duplicate days across description lines."""
-        filled_days: dict[str, list[str]] = {}
-        row_range = self._determine_row_range(driver, max_rows)
+    def _iter_row_descriptions(self, driver: WebDriver, max_rows: int | None):
+        """Yield (row_index, description) for each description row."""
+        row_elements = driver.find_elements(By.CSS_SELECTOR, "[id^='POL_DESCR$']")
+        if max_rows is not None:
+            row_elements = row_elements[:max_rows]
 
-        for row_index in row_range:
+        self.logger.debug(f"{len(row_elements)} ligne(s) de description détectée(s).")
+
+        for index in range(len(row_elements)):
             try:
-                current_line_description = driver.find_element(
-                    By.ID, f"POL_DESCR${row_index}"
-                )
+                elem = driver.find_element(By.ID, f"POL_DESCR${index}")
             except NoSuchElementException:
                 if max_rows is None:
-                    self.logger.debug(
-                        f"Fin de l'analyse des lignes à l'index {row_index}"
-                    )
+                    self.logger.debug(f"Fin de l'analyse des lignes à l'index {index}")
                     break
                 continue
+            description = (elem.text or "").strip()
+            self.logger.debug(f"Analyse de la ligne '{description}' à l'index {index}")
+            yield index, description
 
-            description = current_line_description.text.strip()
-            self.logger.debug(
-                f"Analyse de la ligne '{description}' à l'index {row_index}"
+    def _is_day_filled(
+        self, driver: WebDriver, row_index: int, day_counter: int
+    ) -> bool:
+        """Return True if the cell for (row_index, day_counter) is non-empty."""
+        day_input_id = ElementIdBuilder.build_day_input_id(
+            "POL_TIME", day_counter, row_index
+        )
+        try:
+            day_field = driver.find_element(By.ID, day_input_id)
+        except NoSuchElementException:
+            self.logger.warning(
+                f"{messages.IMPOSSIBLE_DE_TROUVER} l'élément pour le jour "
+                f"'{JOURS_SEMAINE[day_counter]}' avec l'ID '{day_input_id}'"
             )
+            return False
 
-            for day_counter in range(1, 8):
-                day_input_id = ElementIdBuilder.build_day_input_id(
-                    "POL_TIME", day_counter, row_index
-                )
-                try:
-                    day_field = driver.find_element(By.ID, day_input_id)
-                    day_content: str | None = day_field.get_attribute("value")
-                    if day_content and day_content.strip():
-                        self._update_tracker(filled_days, day_counter, description)
-                except NoSuchElementException:
-                    self.logger.warning(
-                        f"{messages.IMPOSSIBLE_DE_TROUVER} l'élément pour le jour '{JOURS_SEMAINE[day_counter]}' avec l'ID '{day_input_id}'"
-                    )
+        value: str | None = day_field.get_attribute("value")
+        return bool(value and value.strip())
 
+    def _report_duplicates(self, filled_days: dict[str, list[str]]) -> None:
         for day_name, lines in filled_days.items():
             if len(lines) > 1:
                 self.logger.warning(
-                    f"Doublon détecté pour le jour '{day_name}' dans les lignes : {', '.join(lines)}"
+                    f"Doublon détecté pour le jour '{day_name}' dans les lignes : "
+                    f"{', '.join(lines)}"
                 )
             else:
                 self.logger.debug(f"Aucun doublon détecté pour le jour '{day_name}'")
+
+    def detect(self, driver: WebDriver, max_rows: int | None = None) -> None:
+        """Log duplicate days across description lines."""
+        filled_days: dict[str, list[str]] = {}
+
+        for row_index, description in self._iter_row_descriptions(driver, max_rows):
+            self.logger.debug(
+                f"Analyse de la ligne '{description}' à l'index {row_index}"
+            )
+            for day_counter in range(1, 8):
+                if self._is_day_filled(driver, row_index, day_counter):
+                    self._update_tracker(filled_days, day_counter, description)
+
+        self._report_duplicates(filled_days)


### PR DESCRIPTION
## Contexte et objectif
- Réduction de la complexité cyclomatique du service `DuplicateDayDetector`
- Suppression de la gestion des doublons via exceptions dans la méthode principale

## Étapes pour tester
- `poetry run pre-commit run --files src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py`
- `poetry run pytest`

## Impact éventuel
- Affecte uniquement la logique de détection des jours dupliqués dans les feuilles de temps

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_689db228cef8832188c50b3115b3a946