### PR TITLE
Improve row lookup typing and tests

### DIFF
--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -42,13 +42,15 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT


### PR DESCRIPTION
## Summary
- add `CompareFn` type alias for row comparisons and strip all whitespace in `_normalize_text`
- log debug when `trouver_ligne_par_description` finds no match with bounded search
- extend selenium utils tests for non-contiguous IDs, bad suffixes, and NBSP handling
- reorder imports in timesheet helper per pre-commit

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/selenium_utils/element_actions.py`
- `poetry run pre-commit run -a`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f041d359483218df8246a4136597a