### PR TITLE
Refactor GUI builder for lower complexity

### DIFF
--- a/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
+++ b/src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import cast
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -43,9 +42,8 @@ class DuplicateDayDetector:
 
     @staticmethod
     def _get_row_elements(driver: WebDriver, max_rows: int | None) -> list[WebElement]:
-        row_elements = cast(
-            list[WebElement],
-            driver.find_elements(By.CSS_SELECTOR, "[id^='POL_DESCR$']"),
+        row_elements: list[WebElement] = driver.find_elements(
+            By.CSS_SELECTOR, "[id^='POL_DESCR$']"
         )
         if max_rows is not None:
             row_elements = row_elements[:max_rows]


### PR DESCRIPTION
## Summary
- simplify GUI builder by centralizing pack logic and optional padding
- streamline button creation and remove redundant cast in duplicate day detector

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/gui_builder.py`
- `poetry run radon cc -s -a src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/gui_builder.py src/sele_saisie_auto/selenium_utils/duplicate_day_detector.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4f0ce99188321af46a705131d39e5