### PR TITLE
[launcher] ajout d'onglets de configuration

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -15,6 +15,13 @@ from sele_saisie_auto.app_config import AppConfig
 from sele_saisie_auto.automation.browser_session import BrowserSession
 from sele_saisie_auto.config_manager import ConfigManager
 from sele_saisie_auto.configuration import Services, service_configurator_factory
+from sele_saisie_auto.dropdown_options import (
+    cgi_options,
+    cgi_options_billing_action,
+    cgi_options_dejeuner,
+    work_location_options,
+    work_schedule_options,
+)
 from sele_saisie_auto.encryption_utils import EncryptionService
 from sele_saisie_auto.enums import LogLevel
 from sele_saisie_auto.gui_builder import (
@@ -230,6 +237,9 @@ def start_configuration(
     else:  # fallback for DummyRoot in tests
         notebook = root
     frame = create_tab(cast(ttk.Notebook, notebook), title="Paramètres")
+    planning_tab = create_tab(cast(ttk.Notebook, notebook), title="Planning de travail")
+    cgi_tab = create_tab(cast(ttk.Notebook, notebook), title="Informations CGI")
+    location_tab = create_tab(cast(ttk.Notebook, notebook), title="Lieu de travail")
 
     date_var = tk.StringVar(value=config["settings"].get("date_cible", ""))
     debug_var = tk.StringVar(value=config["settings"].get("debug_mode", "INFO"))
@@ -242,6 +252,86 @@ def start_configuration(
     create_modern_label_with_pack(debug_row, "Log Level:", side="left")
     create_combobox_with_pack(debug_row, debug_var, values=LOG_LEVEL_CHOICES)
 
+    days = [
+        "dimanche",
+        "lundi",
+        "mardi",
+        "mercredi",
+        "jeudi",
+        "vendredi",
+        "samedi",
+    ]
+
+    work_schedule_labels = [o.label for o in work_schedule_options]
+    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]] = {}
+    for day in days:
+        row = create_a_frame(planning_tab, padding=(10, 10, 10, 10))
+        create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
+        existing = config.get("work_schedule", {}).get(day, "")
+        opt, _, hours = existing.partition(",")
+        opt_var = tk.StringVar(value=opt)
+        hours_var = tk.StringVar(value=hours)
+        create_combobox_with_pack(
+            row, opt_var, values=work_schedule_labels, side="left"
+        )
+        create_modern_entry_with_pack(row, hours_var, side="left", width=8)
+        schedule_vars[day] = (opt_var, hours_var)
+
+    cgi_labels = [o.label for o in cgi_options]
+    cgi_dej_labels = [o.label for o in cgi_options_dejeuner]
+    billing_labels = [o.label for o in cgi_options_billing_action]
+
+    billing_var = tk.StringVar(
+        value=config.get("project_information", {}).get("billing_action", "")
+    )
+    billing_row = create_a_frame(cgi_tab, padding=(10, 10, 10, 10))
+    create_modern_label_with_pack(billing_row, "Billing action:", side="left")
+    create_combobox_with_pack(
+        billing_row, billing_var, values=billing_labels, side="left"
+    )
+
+    cgi_vars: dict[str, dict[str, tk.StringVar]] = {}
+    for day in days:
+        row = create_a_frame(cgi_tab, padding=(5, 5, 5, 5))
+        create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
+        rest_var = tk.StringVar(
+            value=config.get("additional_information_rest_period_respected", {}).get(
+                day, ""
+            )
+        )
+        work_var = tk.StringVar(
+            value=config.get("additional_information_work_time_range", {}).get(day, "")
+        )
+        half_var = tk.StringVar(
+            value=config.get("additional_information_half_day_worked", {}).get(day, "")
+        )
+        lunch_var = tk.StringVar(
+            value=config.get("additional_information_lunch_break_duration", {}).get(
+                day, ""
+            )
+        )
+        create_combobox_with_pack(row, rest_var, values=cgi_labels, side="left")
+        create_combobox_with_pack(row, work_var, values=cgi_labels, side="left")
+        create_combobox_with_pack(row, half_var, values=cgi_labels, side="left")
+        create_combobox_with_pack(row, lunch_var, values=cgi_dej_labels, side="left")
+        cgi_vars[day] = {
+            "rest": rest_var,
+            "work": work_var,
+            "half": half_var,
+            "lunch": lunch_var,
+        }
+
+    work_location_labels = [o.label for o in work_location_options]
+    location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]] = {}
+    for day in days:
+        row = create_a_frame(location_tab, padding=(10, 10, 10, 10))
+        create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
+        am_var = tk.StringVar(value=config.get("work_location_am", {}).get(day, ""))
+        pm_var = tk.StringVar(value=config.get("work_location_pm", {}).get(day, ""))
+        create_combobox_with_pack(row, am_var, values=work_location_labels, side="left")
+        create_combobox_with_pack(row, pm_var, values=work_location_labels, side="left")
+        location_vars[day] = (am_var, pm_var)
+
     def save() -> None:
         """Enregistre la configuration saisie."""
         config["settings"]["date_cible"] = date_var.get()
@@ -249,11 +339,84 @@ def start_configuration(
         if isinstance(debug_val, LogLevel):
             debug_val = debug_val.value
         config["settings"]["debug_mode"] = debug_val
+
+        ws_section = config.setdefault("work_schedule", {})
+        for day, (opt_var, hours_var) in schedule_vars.items():
+            ws_section[day] = f"{opt_var.get()},{hours_var.get()}"
+
+        proj_section = config.setdefault("project_information", {})
+        proj_section["billing_action"] = billing_var.get()
+
+        rest_section = config.setdefault(
+            "additional_information_rest_period_respected", {}
+        )
+        work_section = config.setdefault("additional_information_work_time_range", {})
+        half_section = config.setdefault("additional_information_half_day_worked", {})
+        lunch_section = config.setdefault(
+            "additional_information_lunch_break_duration", {}
+        )
+        for day, vars_dict in cgi_vars.items():
+            rest_section[day] = vars_dict["rest"].get()
+            work_section[day] = vars_dict["work"].get()
+            half_section[day] = vars_dict["half"].get()
+            lunch_section[day] = vars_dict["lunch"].get()
+
+        loc_am_section = config.setdefault("work_location_am", {})
+        loc_pm_section = config.setdefault("work_location_pm", {})
+        for day, (am_var, pm_var) in location_vars.items():
+            loc_am_section[day] = am_var.get()
+            loc_pm_section[day] = pm_var.get()
+
         if isinstance(raw_cfg, configparser.ConfigParser):
-            if not raw_cfg.has_section("settings"):
-                raw_cfg.add_section("settings")
+
+            def ensure(section: str) -> None:
+                if not raw_cfg.has_section(section):
+                    raw_cfg.add_section(section)
+
+            ensure("settings")
+            ensure("work_schedule")
+            ensure("project_information")
+            ensure("additional_information_rest_period_respected")
+            ensure("additional_information_work_time_range")
+            ensure("additional_information_half_day_worked")
+            ensure("additional_information_lunch_break_duration")
+            ensure("work_location_am")
+            ensure("work_location_pm")
+
             raw_cfg.set("settings", "date_cible", config["settings"]["date_cible"])
             raw_cfg.set("settings", "debug_mode", debug_val)
+
+            for day, (opt_var, hours_var) in schedule_vars.items():
+                raw_cfg.set("work_schedule", day, f"{opt_var.get()},{hours_var.get()}")
+
+            raw_cfg.set("project_information", "billing_action", billing_var.get())
+
+            for day, vars_dict in cgi_vars.items():
+                raw_cfg.set(
+                    "additional_information_rest_period_respected",
+                    day,
+                    vars_dict["rest"].get(),
+                )
+                raw_cfg.set(
+                    "additional_information_work_time_range",
+                    day,
+                    vars_dict["work"].get(),
+                )
+                raw_cfg.set(
+                    "additional_information_half_day_worked",
+                    day,
+                    vars_dict["half"].get(),
+                )
+                raw_cfg.set(
+                    "additional_information_lunch_break_duration",
+                    day,
+                    vars_dict["lunch"].get(),
+                )
+
+            for day, (am_var, pm_var) in location_vars.items():
+                raw_cfg.set("work_location_am", day, am_var.get())
+                raw_cfg.set("work_location_pm", day, pm_var.get())
+
             write_config_ini(raw_cfg, log_file)
         else:
             write_config_ini(config, log_file)


### PR DESCRIPTION
## Contexte
- Ajout d'onglets pour planifier le travail, renseigner les informations CGI et définir le lieu de travail.
- Sauvegarde des choix dans `config.ini` via le lanceur.

## Étapes pour tester
1. `poetry run pre-commit run --all-files`
2. `poetry run pytest`

## Impact
- Aucun impact attendu sur les autres agents.

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68a711fc4d748321bdf6989259c229d3