### PR TITLE
test: add dict to configparser test

### DIFF
--- a/tests/test_launcher_dict_to_configparser.py
+++ b/tests/test_launcher_dict_to_configparser.py
@@ -1,0 +1,12 @@
+from sele_saisie_auto.launcher import _dict_to_configparser
+
+
+def test_dict_to_configparser_creates_sections_and_entries() -> None:
+    data = {
+        "section1": {"key1": "value1"},
+        "section2": {"key2": "value2"},
+    }
+    parser = _dict_to_configparser(data)
+    assert set(parser.sections()) == {"section1", "section2"}
+    assert parser.get("section1", "key1") == "value1"
+    assert parser.get("section2", "key2") == "value2"


### PR DESCRIPTION
## Summary
- add a unit test ensuring `_dict_to_configparser` preserves sections and key/value pairs

## Testing
- `poetry run radon cc -s -a tests/test_launcher_dict_to_configparser.py`
- `poetry run pre-commit run --files tests/test_launcher_dict_to_configparser.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a759b6f1a483218ea546e40b11486a