### PR TITLE
feat: extend planning configuration

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -36,6 +36,15 @@ jeudi = En mission,7,70
 vendredi = En mission,7,70
 samedi = ,
 
+[work_description]
+dimanche =
+lundi =
+mardi =
+mercredi =
+jeudi =
+vendredi =
+samedi =
+
 [project_information]
 project_code = 300000000105047
 activity_code = PROJET

--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -29,6 +29,7 @@ from sele_saisie_auto.gui_builder import (
     create_a_frame,
     create_button_with_style,
     create_combobox_with_pack,
+    create_labeled_frame,
     create_modern_entry_with_pack,
     create_modern_label_with_pack,
     create_tab,
@@ -270,38 +271,79 @@ def tab_settings(
     return frame, date_var, debug_var
 
 
-def tab_planning(
-    nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
-) -> dict[str, tuple[tk.StringVar, tk.StringVar]]:
+def tab_planning(nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]) -> tuple[
+    dict[str, tuple[tk.StringVar, tk.StringVar, tk.StringVar]],
+    dict[str, tk.StringVar],
+]:
     planning_tab = create_tab(cast(ttk.Notebook, nb), title="Planning de travail")
-    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]] = {}
+
+    main_frame = create_a_frame(planning_tab)
+    planning_frame = create_a_frame(main_frame, side="left")
+    mission_frame = create_labeled_frame(
+        main_frame,
+        text="Informations de mission",
+        side="right",
+        padx=10,
+        pady=10,
+    )
+
+    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar, tk.StringVar]] = {}
+    desc_section = config.get("work_description", {})
     for day in DAYS:
-        row = create_a_frame(planning_tab, padding=(10, 10, 10, 10))
+        row = create_a_frame(planning_frame, padding=(10, 10, 10, 10))
         create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
         existing = config.get("work_schedule", {}).get(day, "")
         opt, _, hours = existing.partition(",")
         opt_var = tk.StringVar(value=opt)
+        desc_var = tk.StringVar(value=desc_section.get(day, ""))
         hours_var = tk.StringVar(value=hours)
         create_combobox_with_pack(
             row, opt_var, values=WORK_SCHEDULE_LABELS, side="left"
         )
+        create_modern_entry_with_pack(row, desc_var, side="left")
         create_modern_entry_with_pack(row, hours_var, side="left", width=8)
-        schedule_vars[day] = (opt_var, hours_var)
-    return schedule_vars
+        schedule_vars[day] = (opt_var, desc_var, hours_var)
+
+    mission_vars = {
+        "project_code": tk.StringVar(
+            value=config.get("project_information", {}).get("project_code", "")
+        ),
+        "activity_code": tk.StringVar(
+            value=config.get("project_information", {}).get("activity_code", "")
+        ),
+        "category_code": tk.StringVar(
+            value=config.get("project_information", {}).get("category_code", "")
+        ),
+        "sub_category_code": tk.StringVar(
+            value=config.get("project_information", {}).get("sub_category_code", "")
+        ),
+        "billing_action": tk.StringVar(
+            value=config.get("project_information", {}).get("billing_action", "")
+        ),
+    }
+    for label, key in [
+        ("Project Code", "project_code"),
+        ("Activity Code", "activity_code"),
+        ("Category Code", "category_code"),
+        ("Sub Category Code", "sub_category_code"),
+        ("Billing Action", "billing_action"),
+    ]:
+        row = create_a_frame(mission_frame, padding=(5, 5, 5, 5))
+        create_modern_label_with_pack(row, f"{label}:", side="left")
+        if key == "billing_action":
+            create_combobox_with_pack(
+                row, mission_vars[key], values=BILLING_LABELS, side="left"
+            )
+        else:
+            create_modern_entry_with_pack(row, mission_vars[key], side="left")
+
+    return schedule_vars, mission_vars
 
 
 def tab_cgi(
     nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
-) -> tuple[dict[str, dict[str, tk.StringVar]], tk.StringVar]:
+) -> dict[str, dict[str, tk.StringVar]]:
     cgi_tab = create_tab(cast(ttk.Notebook, nb), title="Informations CGI")
-    billing_var = tk.StringVar(
-        value=config.get("project_information", {}).get("billing_action", "")
-    )
-    billing_row = create_a_frame(cgi_tab, padding=(10, 10, 10, 10))
-    create_modern_label_with_pack(billing_row, "Billing action:", side="left")
-    create_combobox_with_pack(
-        billing_row, billing_var, values=BILLING_LABELS, side="left"
-    )
 
     cgi_vars: dict[str, dict[str, tk.StringVar]] = {}
     for day in DAYS:
@@ -333,7 +375,7 @@ def tab_cgi(
             "half": half_var,
             "lunch": lunch_var,
         }
-    return cgi_vars, billing_var
+    return cgi_vars
 
 
 def tab_locations(
@@ -354,19 +396,24 @@ def tab_locations(
 
 def update_schedule(
     config: dict[str, dict[str, str]],
-    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar, tk.StringVar]],
 ) -> None:
     section = config.setdefault("work_schedule", {})
-    for day, (opt_var, hours_var) in schedule_vars.items():
+    desc_section = config.setdefault("work_description", {})
+    for day, (opt_var, desc_var, hours_var) in schedule_vars.items():
         section[day] = f"{opt_var.get()},{hours_var.get()}"
+        desc_section[day] = desc_var.get()
 
 
 def update_cgi_info(
     config: dict[str, dict[str, str]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
 ) -> None:
-    config.setdefault("project_information", {})["billing_action"] = billing_var.get()
+    project_info = config.setdefault("project_information", {})
+    for key, var in mission_vars.items():
+        project_info[key] = var.get()
+
     rest = config.setdefault("additional_information_rest_period_respected", {})
     work = config.setdefault("additional_information_work_time_range", {})
     half = config.setdefault("additional_information_half_day_worked", {})
@@ -409,9 +456,9 @@ def ensure_sections(
 def write_raw_cfg(
     raw_cfg: configparser.ConfigParser,
     config: dict[str, dict[str, str]],
-    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar, tk.StringVar]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     debug_val: str,
     log_file: str,
@@ -421,6 +468,7 @@ def write_raw_cfg(
         [
             "settings",
             "work_schedule",
+            "work_description",
             "project_information",
             "additional_information_rest_period_respected",
             "additional_information_work_time_range",
@@ -432,9 +480,11 @@ def write_raw_cfg(
     )
     raw_cfg.set("settings", "date_cible", config["settings"]["date_cible"])
     raw_cfg.set("settings", "debug_mode", debug_val)
-    for day, (opt_var, hours_var) in schedule_vars.items():
+    for day, (opt_var, desc_var, hours_var) in schedule_vars.items():
         raw_cfg.set("work_schedule", day, f"{opt_var.get()},{hours_var.get()}")
-    raw_cfg.set("project_information", "billing_action", billing_var.get())
+        raw_cfg.set("work_description", day, desc_var.get())
+    for key, var in mission_vars.items():
+        raw_cfg.set("project_information", key, var.get())
     for day, vars_dict in cgi_vars.items():
         raw_cfg.set(
             "additional_information_rest_period_respected", day, vars_dict["rest"].get()
@@ -460,9 +510,9 @@ def save_all(
     log_file: str,
     date_var: tk.StringVar,
     debug_var: tk.StringVar,
-    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar, tk.StringVar]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
 ) -> None:
     config["settings"]["date_cible"] = date_var.get()
@@ -471,7 +521,7 @@ def save_all(
         debug_val = debug_val.value
     config["settings"]["debug_mode"] = debug_val
     update_schedule(config, schedule_vars)
-    update_cgi_info(config, cgi_vars, billing_var)
+    update_cgi_info(config, cgi_vars, mission_vars)
     update_locations(config, location_vars)
     if isinstance(raw_cfg, configparser.ConfigParser):
         write_raw_cfg(
@@ -479,7 +529,7 @@ def save_all(
             config,
             schedule_vars,
             cgi_vars,
-            billing_var,
+            mission_vars,
             location_vars,
             debug_val,
             log_file,
@@ -495,9 +545,9 @@ def save_and_close(
     log_file: str,
     date_var: tk.StringVar,
     debug_var: tk.StringVar,
-    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar, tk.StringVar]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     cle_aes: bytes,
     root: tk.Tk,
@@ -513,7 +563,7 @@ def save_and_close(
         debug_var,
         schedule_vars,
         cgi_vars,
-        billing_var,
+        mission_vars,
         location_vars,
     )
     messagebox.showinfo("Info", messages.CONFIGURATION_SAVED)
@@ -542,8 +592,8 @@ def start_configuration(
     config, raw_cfg = load_config_with_defaults(log_file)
     root, notebook = build_root()
     frame, date_var, debug_var = tab_settings(notebook, config)
-    schedule_vars = tab_planning(notebook, config)
-    cgi_vars, billing_var = tab_cgi(notebook, config)
+    schedule_vars, mission_vars = tab_planning(notebook, config)
+    cgi_vars = tab_cgi(notebook, config)
     location_vars = tab_locations(notebook, config)
     btn_row = create_a_frame(frame, padding=(10, 10, 10, 10))
     create_button_with_style(
@@ -558,7 +608,7 @@ def start_configuration(
             debug_var,
             schedule_vars,
             cgi_vars,
-            billing_var,
+            mission_vars,
             location_vars,
             cle_aes,
             root,


### PR DESCRIPTION
## Summary
- add description and hours fields for each day in planning tab
- include mission information panel and persist project fields
- update tests and configuration for new schedule data

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/launcher.py tests/test_launcher_roundtrip.py tests/test_launcher.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/launcher.py tests/test_launcher_roundtrip.py tests/test_launcher.py config.ini`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a760d25b58832181407f7d26e10978