### PR TITLE
[launcher] Ajout informations mission dans planning

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -272,37 +272,63 @@ def tab_settings(
 
 def tab_planning(
     nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
-) -> dict[str, tuple[tk.StringVar, tk.StringVar]]:
+) -> tuple[dict[str, tuple[tk.StringVar, tk.StringVar]], dict[str, tk.StringVar]]:
     planning_tab = create_tab(cast(ttk.Notebook, nb), title="Planning de travail")
+
+    main_frame = create_a_frame(planning_tab, side="left", padding=(10, 10, 10, 10))
+    header = create_a_frame(main_frame, padding=(5, 5, 5, 5))
+    create_modern_label_with_pack(header, "Jour", side="left")
+    create_modern_label_with_pack(header, "Description", side="left")
+    create_modern_label_with_pack(header, "Heures travaillées", side="left")
+
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]] = {}
     for day in DAYS:
-        row = create_a_frame(planning_tab, padding=(10, 10, 10, 10))
+        row = create_a_frame(main_frame, padding=(5, 5, 5, 5))
         create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
         existing = config.get("work_schedule", {}).get(day, "")
-        opt, _, hours = existing.partition(",")
-        opt_var = tk.StringVar(value=opt)
+        desc, _, hours = existing.partition(",")
+        desc_var = tk.StringVar(value=desc)
         hours_var = tk.StringVar(value=hours)
         create_combobox_with_pack(
-            row, opt_var, values=WORK_SCHEDULE_LABELS, side="left"
+            row, desc_var, values=WORK_SCHEDULE_LABELS, side="left"
         )
         create_modern_entry_with_pack(row, hours_var, side="left", width=8)
-        schedule_vars[day] = (opt_var, hours_var)
-    return schedule_vars
+        schedule_vars[day] = (desc_var, hours_var)
+
+    mission_frame = create_a_frame(planning_tab, side="right", padding=(10, 10, 10, 10))
+    create_modern_label_with_pack(mission_frame, "Informations de mission", side="top")
+    info = config.get("project_information", {})
+    mission_vars: dict[str, tk.StringVar] = {
+        "project_code": tk.StringVar(value=info.get("project_code", "")),
+        "activity_code": tk.StringVar(value=info.get("activity_code", "")),
+        "category_code": tk.StringVar(value=info.get("category_code", "")),
+        "sub_category_code": tk.StringVar(value=info.get("sub_category_code", "")),
+        "billing_action": tk.StringVar(value=info.get("billing_action", "")),
+    }
+    labels = {
+        "project_code": "Project Code:",
+        "activity_code": "Activity Code:",
+        "category_code": "Category Code:",
+        "sub_category_code": "Sub Category Code:",
+        "billing_action": "Billing Action:",
+    }
+    for key, label in labels.items():
+        row = create_a_frame(mission_frame, padding=(5, 5, 5, 5))
+        create_modern_label_with_pack(row, label, side="left")
+        if key == "billing_action":
+            create_combobox_with_pack(
+                row, mission_vars[key], values=BILLING_LABELS, side="left"
+            )
+        else:
+            create_modern_entry_with_pack(row, mission_vars[key], side="left")
+
+    return schedule_vars, mission_vars
 
 
 def tab_cgi(
     nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
-) -> tuple[dict[str, dict[str, tk.StringVar]], tk.StringVar]:
+) -> dict[str, dict[str, tk.StringVar]]:
     cgi_tab = create_tab(cast(ttk.Notebook, nb), title="Informations CGI")
-    billing_var = tk.StringVar(
-        value=config.get("project_information", {}).get("billing_action", "")
-    )
-    billing_row = create_a_frame(cgi_tab, padding=(10, 10, 10, 10))
-    create_modern_label_with_pack(billing_row, "Billing action:", side="left")
-    create_combobox_with_pack(
-        billing_row, billing_var, values=BILLING_LABELS, side="left"
-    )
-
     cgi_vars: dict[str, dict[str, tk.StringVar]] = {}
     for day in DAYS:
         row = create_a_frame(cgi_tab, padding=(5, 5, 5, 5))
@@ -333,7 +359,7 @@ def tab_cgi(
             "half": half_var,
             "lunch": lunch_var,
         }
-    return cgi_vars, billing_var
+    return cgi_vars
 
 
 def tab_locations(
@@ -364,9 +390,11 @@ def update_schedule(
 def update_cgi_info(
     config: dict[str, dict[str, str]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
 ) -> None:
-    config.setdefault("project_information", {})["billing_action"] = billing_var.get()
+    project_info = config.setdefault("project_information", {})
+    for key, var in mission_vars.items():
+        project_info[key] = var.get()
     rest = config.setdefault("additional_information_rest_period_respected", {})
     work = config.setdefault("additional_information_work_time_range", {})
     half = config.setdefault("additional_information_half_day_worked", {})
@@ -411,7 +439,7 @@ def write_raw_cfg(
     config: dict[str, dict[str, str]],
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     debug_val: str,
     log_file: str,
@@ -432,9 +460,10 @@ def write_raw_cfg(
     )
     raw_cfg.set("settings", "date_cible", config["settings"]["date_cible"])
     raw_cfg.set("settings", "debug_mode", debug_val)
-    for day, (opt_var, hours_var) in schedule_vars.items():
-        raw_cfg.set("work_schedule", day, f"{opt_var.get()},{hours_var.get()}")
-    raw_cfg.set("project_information", "billing_action", billing_var.get())
+    for day, (desc_var, hours_var) in schedule_vars.items():
+        raw_cfg.set("work_schedule", day, f"{desc_var.get()},{hours_var.get()}")
+    for key, var in mission_vars.items():
+        raw_cfg.set("project_information", key, var.get())
     for day, vars_dict in cgi_vars.items():
         raw_cfg.set(
             "additional_information_rest_period_respected", day, vars_dict["rest"].get()
@@ -462,7 +491,7 @@ def save_all(
     debug_var: tk.StringVar,
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
 ) -> None:
     config["settings"]["date_cible"] = date_var.get()
@@ -471,7 +500,7 @@ def save_all(
         debug_val = debug_val.value
     config["settings"]["debug_mode"] = debug_val
     update_schedule(config, schedule_vars)
-    update_cgi_info(config, cgi_vars, billing_var)
+    update_cgi_info(config, cgi_vars, mission_vars)
     update_locations(config, location_vars)
     if isinstance(raw_cfg, configparser.ConfigParser):
         write_raw_cfg(
@@ -479,7 +508,7 @@ def save_all(
             config,
             schedule_vars,
             cgi_vars,
-            billing_var,
+            mission_vars,
             location_vars,
             debug_val,
             log_file,
@@ -497,7 +526,7 @@ def save_and_close(
     debug_var: tk.StringVar,
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
+    mission_vars: dict[str, tk.StringVar],
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     cle_aes: bytes,
     root: tk.Tk,
@@ -513,7 +542,7 @@ def save_and_close(
         debug_var,
         schedule_vars,
         cgi_vars,
-        billing_var,
+        mission_vars,
         location_vars,
     )
     messagebox.showinfo("Info", messages.CONFIGURATION_SAVED)
@@ -542,8 +571,8 @@ def start_configuration(
     config, raw_cfg = load_config_with_defaults(log_file)
     root, notebook = build_root()
     frame, date_var, debug_var = tab_settings(notebook, config)
-    schedule_vars = tab_planning(notebook, config)
-    cgi_vars, billing_var = tab_cgi(notebook, config)
+    schedule_vars, mission_vars = tab_planning(notebook, config)
+    cgi_vars = tab_cgi(notebook, config)
     location_vars = tab_locations(notebook, config)
     btn_row = create_a_frame(frame, padding=(10, 10, 10, 10))
     create_button_with_style(
@@ -558,7 +587,7 @@ def start_configuration(
             debug_var,
             schedule_vars,
             cgi_vars,
-            billing_var,
+            mission_vars,
             location_vars,
             cle_aes,
             root,

--- a/tests/test_launcher_roundtrip.py
+++ b/tests/test_launcher_roundtrip.py
@@ -33,7 +33,13 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
             "lunch": DummyVar("OUI"),
         }
     }
-    billing_var = DummyVar("FACTURER")
+    mission_vars = {
+        "project_code": DummyVar("P1"),
+        "activity_code": DummyVar("A1"),
+        "category_code": DummyVar("C1"),
+        "sub_category_code": DummyVar("S1"),
+        "billing_action": DummyVar("FACTURER"),
+    }
     location_vars = {"lundi": (DummyVar("Site"), DummyVar("Remote"))}
     log_file = str(tmp_path / "log.html")
 
@@ -45,14 +51,19 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
         debug_var,
         schedule_vars,
         cgi_vars,
-        billing_var,
+        mission_vars,
         location_vars,
     )
 
     reread = read_config_ini(log_file)
     assert isinstance(reread, configparser.ConfigParser)
-    assert reread.get("settings", "date_cible") == "2024-07-01"
-    assert reread.get("project_information", "billing_action") == "FACTURER"
+    expectations = {
+        ("settings", "date_cible"): "2024-07-01",
+        ("project_information", "billing_action"): "FACTURER",
+        ("project_information", "project_code"): "P1",
+        ("work_location_am", "lundi"): "Site",
+        ("additional_information_lunch_break_duration", "lundi"): "OUI",
+    }
+    for (section, key), value in expectations.items():
+        assert reread.get(section, key) == value
     assert reread.get("work_schedule", "lundi").startswith("remote")
-    assert reread.get("work_location_am", "lundi") == "Site"
-    assert reread.get("additional_information_lunch_break_duration", "lundi") == "OUI"


### PR DESCRIPTION
## Contexte
- étend l'onglet de planning pour saisir description, heures travaillées et informations de mission
- persiste ces nouvelles données dans la configuration

## Étapes pour tester
- `poetry run radon cc -s -a src/sele_saisie_auto/launcher.py tests/test_launcher_roundtrip.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/launcher.py tests/test_launcher_roundtrip.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`

## Impact
- met à jour les fonctions de sauvegarde/lecture de la configuration

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68a760d25b58832181407f7d26e10978