### PR TITLE
Refactor configuration UI layout

### DIFF
--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -450,6 +450,8 @@ def test_start_configuration_and_save(monkeypatch):
     cfg = {"settings": {}}
     button = {}
 
+    dummy_widget = types.SimpleNamespace(grid=lambda *a, **k: None)
+
     monkeypatch.setattr(launcher.tk, "Tk", lambda: root)
     monkeypatch.setattr(launcher.tk, "StringVar", fake_stringvar)
     monkeypatch.setattr(launcher.ttk, "Style", DummyStyle)
@@ -458,6 +460,10 @@ def test_start_configuration_and_save(monkeypatch):
     monkeypatch.setattr(launcher, "create_modern_label_with_pack", lambda *a, **k: None)
     monkeypatch.setattr(launcher, "create_modern_entry_with_pack", lambda *a, **k: None)
     monkeypatch.setattr(launcher, "create_combobox_with_pack", lambda *a, **k: None)
+    monkeypatch.setattr(launcher, "create_modern_label_with_grid", lambda *a, **k: None)
+    monkeypatch.setattr(launcher, "create_modern_entry_with_grid", lambda *a, **k: None)
+    monkeypatch.setattr(launcher, "create_combobox", lambda *a, **k: None)
+    monkeypatch.setattr(launcher.ttk, "LabelFrame", lambda *a, **k: dummy_widget)
 
     def fake_button(frame, text, command):
         button["cmd"] = command

--- a/tests/test_launcher_roundtrip.py
+++ b/tests/test_launcher_roundtrip.py
@@ -33,7 +33,13 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
             "lunch": DummyVar("OUI"),
         }
     }
-    billing_var = DummyVar("FACTURER")
+    project_vars = {
+        "project_code": DummyVar("X"),
+        "activity_code": DummyVar("A"),
+        "category_code": DummyVar("C"),
+        "sub_category_code": DummyVar("S"),
+        "billing_action": DummyVar("FACTURER"),
+    }
     location_vars = {"lundi": (DummyVar("Site"), DummyVar("Remote"))}
     log_file = str(tmp_path / "log.html")
 
@@ -44,8 +50,8 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
         date_var,
         debug_var,
         schedule_vars,
+        project_vars,
         cgi_vars,
-        billing_var,
         location_vars,
     )
 
@@ -53,6 +59,7 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
     assert isinstance(reread, configparser.ConfigParser)
     assert reread.get("settings", "date_cible") == "2024-07-01"
     assert reread.get("project_information", "billing_action") == "FACTURER"
+    assert reread.get("project_information", "project_code") == "X"
     assert reread.get("work_schedule", "lundi").startswith("remote")
     assert reread.get("work_location_am", "lundi") == "Site"
     assert reread.get("additional_information_lunch_break_duration", "lundi") == "OUI"


### PR DESCRIPTION
## Summary
- align configuration tabs using grid-based layout
- persist mission and location details in configuration file
- adapt tests for new configuration workflow

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/launcher.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/launcher.py tests/test_launcher.py tests/test_launcher_roundtrip.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7724693648321a9f047c361c25155