### PR TITLE
refactor configuration window layout with grid-based tabs

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -28,8 +28,11 @@ from sele_saisie_auto.enums import LogLevel
 from sele_saisie_auto.gui_builder import (
     create_a_frame,
     create_button_with_style,
+    create_combobox,
     create_combobox_with_pack,
+    create_modern_entry_with_grid,
     create_modern_entry_with_pack,
+    create_modern_label_with_grid,
     create_modern_label_with_pack,
     create_tab,
 )
@@ -272,44 +275,87 @@ def tab_settings(
 
 def tab_planning(
     nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
-) -> dict[str, tuple[tk.StringVar, tk.StringVar]]:
+) -> tuple[dict[str, tuple[tk.StringVar, tk.StringVar]], dict[str, tk.StringVar]]:
     planning_tab = create_tab(cast(ttk.Notebook, nb), title="Planning de travail")
+    headers = ("Jour", "Description", "Heures travaillées")
+    for col, text in enumerate(headers):
+        create_modern_label_with_grid(planning_tab, text, row=0, col=col, sticky="w")
+
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]] = {}
-    for day in DAYS:
-        row = create_a_frame(planning_tab, padding=(10, 10, 10, 10))
-        create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
+    for row, day in enumerate(DAYS, start=1):
+        create_modern_label_with_grid(
+            planning_tab, day.capitalize(), row=row, col=0, sticky="w"
+        )
         existing = config.get("work_schedule", {}).get(day, "")
         opt, _, hours = existing.partition(",")
         opt_var = tk.StringVar(value=opt)
         hours_var = tk.StringVar(value=hours)
-        create_combobox_with_pack(
-            row, opt_var, values=WORK_SCHEDULE_LABELS, side="left"
+        create_combobox(
+            planning_tab,
+            opt_var,
+            values=WORK_SCHEDULE_LABELS,
+            row=row,
+            col=1,
+            width=20,
         )
-        create_modern_entry_with_pack(row, hours_var, side="left", width=8)
+        create_modern_entry_with_grid(planning_tab, hours_var, row=row, col=2, width=10)
         schedule_vars[day] = (opt_var, hours_var)
-    return schedule_vars
+
+    mission_frame = ttk.LabelFrame(planning_tab, text="Informations de mission")
+    mission_frame.grid(row=1, column=3, rowspan=len(DAYS), padx=15, pady=5, sticky="n")
+    labels = (
+        "Project Code:",
+        "Activity Code:",
+        "Category Code:",
+        "Sub Category Code:",
+        "Billing Action:",
+    )
+    keys = (
+        "project_code",
+        "activity_code",
+        "category_code",
+        "sub_category_code",
+        "billing_action",
+    )
+    mission_vars: dict[str, tk.StringVar] = {}
+    for i, (label, key) in enumerate(zip(labels, keys)):
+        ttk.Label(mission_frame, text=label).grid(
+            row=i, column=0, sticky="w", padx=5, pady=2
+        )
+        var = tk.StringVar(value=config.get("project_information", {}).get(key, ""))
+        if key == "billing_action":
+            create_combobox(
+                mission_frame, var, values=BILLING_LABELS, row=i, col=1, width=15
+            )
+        else:
+            create_modern_entry_with_grid(mission_frame, var, row=i, col=1, width=20)
+        mission_vars[key] = var
+    return schedule_vars, mission_vars
 
 
 def tab_cgi(
     nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
-) -> tuple[dict[str, dict[str, tk.StringVar]], tk.StringVar]:
+) -> dict[str, dict[str, tk.StringVar]]:
     cgi_tab = create_tab(cast(ttk.Notebook, nb), title="Informations CGI")
-    billing_var = tk.StringVar(
-        value=config.get("project_information", {}).get("billing_action", "")
+    headers = (
+        "Jour",
+        "période repos respectée",
+        "plage horaire travail",
+        "demi-journée travaillée",
+        "durée pause déjeuner",
     )
-    billing_row = create_a_frame(cgi_tab, padding=(10, 10, 10, 10))
-    create_modern_label_with_pack(billing_row, "Billing action:", side="left")
-    create_combobox_with_pack(
-        billing_row, billing_var, values=BILLING_LABELS, side="left"
-    )
+    for col, text in enumerate(headers):
+        create_modern_label_with_grid(cgi_tab, text, row=0, col=col, sticky="w")
 
     cgi_vars: dict[str, dict[str, tk.StringVar]] = {}
-    for day in DAYS:
-        row = create_a_frame(cgi_tab, padding=(5, 5, 5, 5))
-        create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
+    for row, day in enumerate(DAYS, start=1):
+        create_modern_label_with_grid(
+            cgi_tab, day.capitalize(), row=row, col=0, sticky="w"
+        )
         rest_var = tk.StringVar(
             value=config.get("additional_information_rest_period_respected", {}).get(
-                day, ""
+                day,
+                "",
             )
         )
         work_var = tk.StringVar(
@@ -320,34 +366,46 @@ def tab_cgi(
         )
         lunch_var = tk.StringVar(
             value=config.get("additional_information_lunch_break_duration", {}).get(
-                day, ""
+                day,
+                "",
             )
         )
-        create_combobox_with_pack(row, rest_var, values=CGI_LABELS, side="left")
-        create_combobox_with_pack(row, work_var, values=CGI_LABELS, side="left")
-        create_combobox_with_pack(row, half_var, values=CGI_LABELS, side="left")
-        create_combobox_with_pack(row, lunch_var, values=CGI_DEJ_LABELS, side="left")
+        create_combobox(cgi_tab, rest_var, values=CGI_LABELS, row=row, col=1, width=7)
+        create_combobox(cgi_tab, work_var, values=CGI_LABELS, row=row, col=2, width=7)
+        create_combobox(cgi_tab, half_var, values=CGI_LABELS, row=row, col=3, width=7)
+        create_combobox(
+            cgi_tab, lunch_var, values=CGI_DEJ_LABELS, row=row, col=4, width=5
+        )
         cgi_vars[day] = {
             "rest": rest_var,
             "work": work_var,
             "half": half_var,
             "lunch": lunch_var,
         }
-    return cgi_vars, billing_var
+    return cgi_vars
 
 
 def tab_locations(
     nb: ttk.Notebook | tk.Tk, config: dict[str, dict[str, str]]
 ) -> dict[str, tuple[tk.StringVar, tk.StringVar]]:
     location_tab = create_tab(cast(ttk.Notebook, nb), title="Lieu de travail")
+    headers = ("Jour", "Matin", "Après-midi")
+    for col, text in enumerate(headers):
+        create_modern_label_with_grid(location_tab, text, row=0, col=col, sticky="w")
+
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]] = {}
-    for day in DAYS:
-        row = create_a_frame(location_tab, padding=(10, 10, 10, 10))
-        create_modern_label_with_pack(row, f"{day.capitalize()}:", side="left")
+    for row, day in enumerate(DAYS, start=1):
+        create_modern_label_with_grid(
+            location_tab, day.capitalize(), row=row, col=0, sticky="w"
+        )
         am_var = tk.StringVar(value=config.get("work_location_am", {}).get(day, ""))
         pm_var = tk.StringVar(value=config.get("work_location_pm", {}).get(day, ""))
-        create_combobox_with_pack(row, am_var, values=WORK_LOCATION_LABELS, side="left")
-        create_combobox_with_pack(row, pm_var, values=WORK_LOCATION_LABELS, side="left")
+        create_combobox(
+            location_tab, am_var, values=WORK_LOCATION_LABELS, row=row, col=1, width=15
+        )
+        create_combobox(
+            location_tab, pm_var, values=WORK_LOCATION_LABELS, row=row, col=2, width=15
+        )
         location_vars[day] = (am_var, pm_var)
     return location_vars
 
@@ -361,12 +419,18 @@ def update_schedule(
         section[day] = f"{opt_var.get()},{hours_var.get()}"
 
 
+def update_project_info(
+    config: dict[str, dict[str, str]], mission_vars: dict[str, tk.StringVar]
+) -> None:
+    section = config.setdefault("project_information", {})
+    for key, var in mission_vars.items():
+        section[key] = var.get()
+
+
 def update_cgi_info(
     config: dict[str, dict[str, str]],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
 ) -> None:
-    config.setdefault("project_information", {})["billing_action"] = billing_var.get()
     rest = config.setdefault("additional_information_rest_period_respected", {})
     work = config.setdefault("additional_information_work_time_range", {})
     half = config.setdefault("additional_information_half_day_worked", {})
@@ -410,8 +474,8 @@ def write_raw_cfg(
     raw_cfg: configparser.ConfigParser,
     config: dict[str, dict[str, str]],
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    mission_vars: dict[str, tk.StringVar],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     debug_val: str,
     log_file: str,
@@ -434,7 +498,8 @@ def write_raw_cfg(
     raw_cfg.set("settings", "debug_mode", debug_val)
     for day, (opt_var, hours_var) in schedule_vars.items():
         raw_cfg.set("work_schedule", day, f"{opt_var.get()},{hours_var.get()}")
-    raw_cfg.set("project_information", "billing_action", billing_var.get())
+    for key, var in mission_vars.items():
+        raw_cfg.set("project_information", key, var.get())
     for day, vars_dict in cgi_vars.items():
         raw_cfg.set(
             "additional_information_rest_period_respected", day, vars_dict["rest"].get()
@@ -461,8 +526,8 @@ def save_all(
     date_var: tk.StringVar,
     debug_var: tk.StringVar,
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    mission_vars: dict[str, tk.StringVar],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
 ) -> None:
     config["settings"]["date_cible"] = date_var.get()
@@ -471,15 +536,16 @@ def save_all(
         debug_val = debug_val.value
     config["settings"]["debug_mode"] = debug_val
     update_schedule(config, schedule_vars)
-    update_cgi_info(config, cgi_vars, billing_var)
+    update_project_info(config, mission_vars)
+    update_cgi_info(config, cgi_vars)
     update_locations(config, location_vars)
     if isinstance(raw_cfg, configparser.ConfigParser):
         write_raw_cfg(
             raw_cfg,
             config,
             schedule_vars,
+            mission_vars,
             cgi_vars,
-            billing_var,
             location_vars,
             debug_val,
             log_file,
@@ -496,8 +562,8 @@ def save_and_close(
     date_var: tk.StringVar,
     debug_var: tk.StringVar,
     schedule_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
+    mission_vars: dict[str, tk.StringVar],
     cgi_vars: dict[str, dict[str, tk.StringVar]],
-    billing_var: tk.StringVar,
     location_vars: dict[str, tuple[tk.StringVar, tk.StringVar]],
     cle_aes: bytes,
     root: tk.Tk,
@@ -512,8 +578,8 @@ def save_and_close(
         date_var,
         debug_var,
         schedule_vars,
+        mission_vars,
         cgi_vars,
-        billing_var,
         location_vars,
     )
     messagebox.showinfo("Info", messages.CONFIGURATION_SAVED)
@@ -542,8 +608,8 @@ def start_configuration(
     config, raw_cfg = load_config_with_defaults(log_file)
     root, notebook = build_root()
     frame, date_var, debug_var = tab_settings(notebook, config)
-    schedule_vars = tab_planning(notebook, config)
-    cgi_vars, billing_var = tab_cgi(notebook, config)
+    schedule_vars, mission_vars = tab_planning(notebook, config)
+    cgi_vars = tab_cgi(notebook, config)
     location_vars = tab_locations(notebook, config)
     btn_row = create_a_frame(frame, padding=(10, 10, 10, 10))
     create_button_with_style(
@@ -557,8 +623,8 @@ def start_configuration(
             date_var,
             debug_var,
             schedule_vars,
+            mission_vars,
             cgi_vars,
-            billing_var,
             location_vars,
             cle_aes,
             root,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -453,11 +453,24 @@ def test_start_configuration_and_save(monkeypatch):
     monkeypatch.setattr(launcher.tk, "Tk", lambda: root)
     monkeypatch.setattr(launcher.tk, "StringVar", fake_stringvar)
     monkeypatch.setattr(launcher.ttk, "Style", DummyStyle)
+    monkeypatch.setattr(
+        launcher.ttk,
+        "LabelFrame",
+        lambda *a, **k: types.SimpleNamespace(grid=lambda *a, **k: None),
+    )
+    monkeypatch.setattr(
+        launcher.ttk,
+        "Label",
+        lambda *a, **k: types.SimpleNamespace(grid=lambda *a, **k: None),
+    )
     monkeypatch.setattr(launcher, "create_tab", lambda *a, **k: object())
     monkeypatch.setattr(launcher, "create_a_frame", lambda *a, **k: object())
     monkeypatch.setattr(launcher, "create_modern_label_with_pack", lambda *a, **k: None)
     monkeypatch.setattr(launcher, "create_modern_entry_with_pack", lambda *a, **k: None)
     monkeypatch.setattr(launcher, "create_combobox_with_pack", lambda *a, **k: None)
+    monkeypatch.setattr(launcher, "create_modern_label_with_grid", lambda *a, **k: None)
+    monkeypatch.setattr(launcher, "create_modern_entry_with_grid", lambda *a, **k: None)
+    monkeypatch.setattr(launcher, "create_combobox", lambda *a, **k: None)
 
     def fake_button(frame, text, command):
         button["cmd"] = command

--- a/tests/test_launcher_roundtrip.py
+++ b/tests/test_launcher_roundtrip.py
@@ -33,7 +33,7 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
             "lunch": DummyVar("OUI"),
         }
     }
-    billing_var = DummyVar("FACTURER")
+    mission_vars = {"billing_action": DummyVar("FACTURER")}
     location_vars = {"lundi": (DummyVar("Site"), DummyVar("Remote"))}
     log_file = str(tmp_path / "log.html")
 
@@ -44,8 +44,8 @@ def test_save_all_roundtrip(tmp_path: Path, monkeypatch) -> None:
         date_var,
         debug_var,
         schedule_vars,
+        mission_vars,
         cgi_vars,
-        billing_var,
         location_vars,
     )
 


### PR DESCRIPTION
## Summary
- switch planning, CGI info, and location tabs to `grid` layout for consistent column alignment
- group mission details into a new panel and streamline saving logic
- adjust tests for new UI helpers

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/launcher.py tests/test_launcher.py tests/test_launcher_roundtrip.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/launcher.py tests/test_launcher.py tests/test_launcher_roundtrip.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7724693648321a9f047c361c25155