### PR TITLE
Restore modern Tkinter styling

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -44,6 +44,7 @@ from sele_saisie_auto.read_or_write_file_config_ini_utils import (
 )
 from sele_saisie_auto.resources.resource_manager import ResourceManager  # noqa: F401
 from sele_saisie_auto.shared_utils import get_log_file
+from sele_saisie_auto.styles import COLORS, setup_modern_style
 
 __all__ = ["ResourceManager"]
 
@@ -244,8 +245,7 @@ def build_root() -> tuple[tk.Tk, ttk.Notebook | tk.Tk]:
     root = tk.Tk()
     root.title("Configuration")
     root.geometry("400x200")
-    style = ttk.Style(root)
-    style.theme_use("clam")
+    setup_modern_style(root, COLORS)
     if hasattr(root, "tk"):
         notebook = ttk.Notebook(root)
         notebook.pack(fill="both", expand=True)

--- a/src/sele_saisie_auto/main_menu.py
+++ b/src/sele_saisie_auto/main_menu.py
@@ -15,6 +15,7 @@ from sele_saisie_auto.gui_builder import (
     create_modern_label_with_grid,
 )
 from sele_saisie_auto.launcher import run_psatime_with_credentials, start_configuration
+from sele_saisie_auto.styles import COLORS, setup_modern_style
 
 
 def main_menu(
@@ -30,6 +31,7 @@ def main_menu(
     menu.title("Program PSATime Auto")
     menu.resizable(False, False)
     menu.geometry("400x300")
+    setup_modern_style(menu, COLORS)
 
     # Conteneur ttk pour satisfaire les helpers typés « ttk.Widget »
     root_frame: ttk.Frame | Any

--- a/src/sele_saisie_auto/styles.py
+++ b/src/sele_saisie_auto/styles.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Style configuration for the Tkinter interface."""
+
+import tkinter as tk
+from tkinter import ttk
+
+COLORS: dict[str, str] = {
+    "background": "#f5f5f5",
+    "secondary": "#e6e6e6",
+    "primary": "#1976D2",
+    "hover": "#1565C0",
+    "text": "#333333",
+}
+
+
+def setup_modern_style(root: tk.Misc, colors: dict[str, str] = COLORS) -> None:
+    """Apply the project's modern style to a ``Tk`` widget tree."""
+    try:
+        style = ttk.Style(root)
+    except Exception:  # pragma: no cover - defensive for dummy objects in tests
+        return
+    style.theme_use("clam")
+
+    style.configure("Modern.TFrame", background=colors["background"])
+    style.configure(
+        "Modern.TLabel",
+        background=colors["background"],
+        foreground=colors["text"],
+        font=("Segoe UI", 10),
+    )
+    style.configure(
+        "Title.TLabel", font=("Segoe UI", 11, "bold"), foreground=colors["primary"]
+    )
+
+    style.configure("Modern.TNotebook", background=colors["background"])
+    style.configure(
+        "Modern.TNotebook.Tab",
+        padding=[15, 5],
+        font=("Segoe UI", 9),
+        background=colors["secondary"],
+        foreground=colors["text"],
+    )
+    if hasattr(style, "map"):
+        style.map(
+            "Modern.TNotebook.Tab",
+            background=[("selected", colors["primary"]), ("active", colors["hover"])],
+            foreground=[("selected", colors["background"]), ("active", colors["text"])],
+        )
+
+    style.configure(
+        "Modern.TEntry", fieldbackground=colors["secondary"], padding=[5, 5]
+    )
+    style.configure(
+        "Settings.TEntry", fieldbackground=colors["secondary"], padding=[5, 5]
+    )
+    style.configure(
+        "Modern.TCombobox",
+        background=colors["secondary"],
+        fieldbackground=colors["secondary"],
+        padding=[5, 5],
+    )
+
+    style.configure(
+        "Modern.TButton",
+        padding=[20, 10],
+        background=colors["primary"],
+        foreground=colors["background"],
+        font=("Segoe UI", 10, "bold"),
+    )
+    if hasattr(style, "map"):
+        style.map("Modern.TButton", background=[("active", colors["hover"])])
+
+    style.configure(
+        "Parametres.TLabelframe",
+        background=colors["background"],
+        padding=10,
+        borderwidth=1,
+        relief="solid",
+    )
+    style.configure(
+        "Parametres.TLabelframe.Label",
+        background=colors["background"],
+        font=("Segoe UI", 10, "bold"),
+    )


### PR DESCRIPTION
## Summary
- define central `setup_modern_style` with color constants
- apply modern styles when building configuration and main menu windows

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/styles.py src/sele_saisie_auto/launcher.py src/sele_saisie_auto/main_menu.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/styles.py src/sele_saisie_auto/launcher.py src/sele_saisie_auto/main_menu.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b3814dfc832188424d1c4ee5c326