### PR TITLE
feat(gui): modernize palette

### DIFF
--- a/src/sele_saisie_auto/launcher.py
+++ b/src/sele_saisie_auto/launcher.py
@@ -244,7 +244,8 @@ def load_config_with_defaults(
 def build_root() -> tuple[tk.Tk, ttk.Notebook | tk.Tk]:
     root = tk.Tk()
     root.title("Configuration")
-    root.minsize(700, 530)
+    if hasattr(root, "minsize"):
+        root.minsize(700, 530)
     setup_modern_style(root, COLORS)
     if hasattr(root, "tk"):
         notebook = ttk.Notebook(root, style="Modern.TNotebook")

--- a/src/sele_saisie_auto/styles.py
+++ b/src/sele_saisie_auto/styles.py
@@ -4,11 +4,13 @@ import tkinter as tk
 from tkinter import ttk
 
 COLORS: dict[str, str] = {
-    "background": "#f5f5f5",
-    "secondary": "#e6e6e6",
-    "primary": "#1976D2",
-    "hover": "#1565C0",
-    "text": "#333333",
+    "background": "#F5F6FA",
+    "secondary": "#E8ECF5",
+    "primary": "#2F54EB",
+    "hover": "#4D70F0",
+    "text": "#1E2A38",
+    "danger": "#E43F5A",
+    "success": "#2BB57B",
 }
 
 


### PR DESCRIPTION
## Summary
- centralize a modern UI color palette in `styles.py`
- guard `minsize` usage for test-friendly `DummyRoot`

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/styles.py src/sele_saisie_auto/launcher.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/styles.py src/sele_saisie_auto/launcher.py`
- `poetry run mypy --strict --no-incremental src`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a99f3800d4832184a22cfc7980d9b7