### PR TITLE
refactor: extract day filling logic

### DIFF
--- a/src/sele_saisie_auto/day_filler.py
+++ b/src/sele_saisie_auto/day_filler.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
+
+from selenium.common.exceptions import StaleElementReferenceException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+
+from sele_saisie_auto import messages
+from sele_saisie_auto.constants import JOURS_SEMAINE
+from sele_saisie_auto.interfaces import WaiterProtocol
+from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
+from sele_saisie_auto.utils.mission import est_en_mission
+
+if TYPE_CHECKING:
+    from sele_saisie_auto.remplir_jours_feuille_de_temps import TimeSheetContext
+
+MAX_ATTEMPTS = 5
+JOUR_TO_INDEX = {v: k for k, v in JOURS_SEMAINE.items()}
+
+
+class DayFiller:
+    """Encapsulates the day filling logic."""
+
+    MAX_ATTEMPTS = MAX_ATTEMPTS
+
+    def __init__(
+        self, context: "TimeSheetContext", waiter: WaiterProtocol | None = None
+    ) -> None:
+        self.context = context
+        self.waiter = waiter
+        self.log_file = context.log_file
+
+    def wait_for_dom(
+        self, driver: WebDriver, waiter: WaiterProtocol | None = None
+    ) -> None:
+        from sele_saisie_auto.remplir_jours_feuille_de_temps import (
+            wait_for_dom as external_wait_for_dom,
+        )
+
+        external_wait_for_dom(driver, waiter)
+
+    @staticmethod
+    def est_en_mission_presente(work_days: dict[str, tuple[str, str]]) -> bool:
+        return any(value[0] == "En mission" for value in work_days.values())
+
+    @staticmethod
+    def ajouter_jour_a_jours_remplis(jour: str, filled_days: list[str]) -> list[str]:
+        if jour not in filled_days:
+            filled_days.append(jour)
+        return filled_days
+
+    @staticmethod
+    def _should_skip_field(key: str | None) -> bool:
+        return key is None or key == "sub_category_code"
+
+    def _collect_filled_days_for_row(
+        self, driver: WebDriver, row_index: int, week_days: dict[int, str]
+    ) -> list[str]:
+        collected: list[str] = []
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        for jour_index, jour_name in week_days.items():
+            input_id = f"POL_TIME{jour_index}${row_index}"
+            element = cast(Any, rjf.wait_for_element)(
+                driver, By.ID, input_id, timeout=DEFAULT_TIMEOUT
+            )
+            if element:
+                jour_rempli = rjf.verifier_champ_jour_rempli(element, jour_name)
+                if jour_rempli:
+                    collected.append(jour_rempli)
+        return collected
+
+    def remplir_jours(
+        self,
+        driver: WebDriver,
+        item_descriptions: list[str],
+        week_days: dict[int, str],
+        filled_days: list[str],
+    ) -> list[str]:
+        if not item_descriptions:
+            return filled_days
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        for description_cible in item_descriptions:
+            row_index = rjf.trouver_ligne_par_description(
+                driver, description_cible, "POL_DESCR$"
+            )
+            if row_index is not None:
+                filled_days.extend(
+                    self._collect_filled_days_for_row(driver, row_index, week_days)
+                )
+        return filled_days
+
+    def _get_day_element(
+        self, driver: WebDriver, jour: str, description_cible: str
+    ) -> tuple[str, Any | None]:
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        row_index = rjf.trouver_ligne_par_description(
+            driver, description_cible, "POL_DESCR$"
+        )
+        if row_index is None:
+            return "", None
+        input_id = f"POL_TIME{JOUR_TO_INDEX[jour]}${row_index}"
+        element = cast(Any, rjf.wait_for_element)(
+            driver, By.ID, input_id, timeout=DEFAULT_TIMEOUT
+        )
+        return input_id, element
+
+    def traiter_jour(
+        self,
+        driver: WebDriver,
+        jour: str,
+        description_cible: str,
+        value_to_fill: str,
+        filled_days: list[str],
+    ) -> list[str]:
+        if jour in filled_days or not description_cible:
+            return filled_days
+        input_id, element = self._get_day_element(driver, jour, description_cible)
+        waiter = self.waiter
+        if element is None or not self.insert_with_retries(
+            driver, input_id, value_to_fill, waiter
+        ):
+            return filled_days
+        self.ajouter_jour_a_jours_remplis(jour, filled_days)
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        rjf.afficher_message_insertion(
+            jour, value_to_fill, 0, "après insertion", self.log_file
+        )
+        return filled_days
+
+    def remplir_mission_specifique(
+        self,
+        driver: WebDriver,
+        jour: str,
+        value_to_fill: str,
+        filled_days: list[str],
+    ) -> None:
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        input_id = f"TIME{JOUR_TO_INDEX[jour]}$0"
+        element = cast(Any, rjf.wait_for_element)(
+            driver, By.ID, input_id, timeout=DEFAULT_TIMEOUT
+        )
+        waiter = self.waiter
+        if element and self.insert_with_retries(
+            driver, input_id, value_to_fill, waiter
+        ):
+            self.ajouter_jour_a_jours_remplis(jour, filled_days)
+            rjf.afficher_message_insertion(
+                jour, value_to_fill, 0, "après insertion", self.log_file
+            )
+
+    def remplir_mission(
+        self,
+        driver: WebDriver,
+        work_days: dict[str, tuple[str, str]],
+        filled_days: list[str],
+    ) -> list[str]:
+        for jour, (description_cible, value_to_fill) in work_days.items():
+            if jour in filled_days or not description_cible:
+                continue
+            if est_en_mission(description_cible):
+                self.remplir_mission_specifique(
+                    driver, jour, value_to_fill, filled_days
+                )
+            else:
+                self.traiter_jour(
+                    driver, jour, description_cible, value_to_fill, filled_days
+                )
+        return filled_days
+
+    def _wait_and_get_element(
+        self, driver: WebDriver, field_id: str, waiter: WaiterProtocol | None
+    ) -> Any | None:
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        self.wait_for_dom(driver, waiter)
+        getter: Callable[..., Any] = (
+            waiter.wait_for_element if waiter else cast(Any, rjf.wait_for_element)
+        )
+        return getter(driver, By.ID, field_id, timeout=DEFAULT_TIMEOUT)
+
+    def _try_fill_once(self, driver: WebDriver, field_id: str, value: str) -> bool:
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        input_field, is_correct_value = rjf.detecter_et_verifier_contenu(
+            driver, field_id, value
+        )
+        if input_field is None:
+            raise RuntimeError("detecter_et_verifier_contenu returned None")
+        if is_correct_value:
+            rjf.write_log(
+                f"Valeur correcte déjà présente pour '{field_id}'.",
+                self.log_file,
+                "DEBUG",
+            )
+            return True
+        rjf.effacer_et_entrer_valeur(input_field, value)
+        rjf.program_break_time(1, "Stabilisation du DOM après insertion.")
+        rjf.write_log(messages.DOM_STABLE, self.log_file, "DEBUG")
+        if cast(Callable[[Any, str], bool], rjf.controle_insertion)(input_field, value):
+            rjf.write_log(
+                f"Valeur '{value}' insérée avec succès pour '{field_id}'.",
+                self.log_file,
+                "DEBUG",
+            )
+            return True
+        return False
+
+    def _log_insert_failure(self, field_id: str, max_attempts: int) -> None:
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        rjf.write_log(
+            f"{messages.ECHEC_INSERTION} pour '{field_id}' après {max_attempts} tentatives.",
+            self.log_file,
+            "ERROR",
+        )
+
+    def _insert_value_with_retries(
+        self,
+        driver: WebDriver,
+        field_id: str,
+        value: str,
+        max_attempts: int,
+        waiter: WaiterProtocol | None,
+    ) -> bool:
+        if not self._wait_and_get_element(driver, field_id, waiter):
+            return False
+        for attempt in range(max_attempts):
+            try:
+                if self._try_fill_once(driver, field_id, value):
+                    return True
+            except StaleElementReferenceException:
+                from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+                rjf.write_log(
+                    f"{messages.REFERENCE_OBSOLETE} pour '{field_id}', tentative {attempt + 1}.",
+                    self.log_file,
+                    "ERROR",
+                )
+        self._log_insert_failure(field_id, max_attempts)
+        return False
+
+    def insert_with_retries(
+        self,
+        driver: WebDriver,
+        field_id: str,
+        value: str,
+        waiter: WaiterProtocol | None = None,
+    ) -> bool:
+        waiter_to_use = waiter or self.waiter
+        return self._insert_value_with_retries(
+            driver, field_id, value, MAX_ATTEMPTS, waiter_to_use
+        )
+
+    def traiter_champs_mission(
+        self,
+        driver: WebDriver,
+        listes_id_informations_mission: list[str],
+        id_to_key_mapping: dict[str, str],
+        project_mission_info: dict[str, str],
+        max_attempts: int = MAX_ATTEMPTS,
+        waiter: WaiterProtocol | None = None,
+    ) -> None:
+        from sele_saisie_auto import remplir_jours_feuille_de_temps as rjf
+
+        for id in listes_id_informations_mission:
+            key = id_to_key_mapping.get(id)
+            if self._should_skip_field(key):
+                continue
+            key = cast(str, key)
+            value_to_fill = project_mission_info.get(key)
+            if not value_to_fill:
+                rjf.write_log(
+                    f"Aucune valeur trouvée pour le champ '{key}' (ID: {id}).",
+                    self.log_file,
+                    "DEBUG",
+                )
+                continue
+            rjf.write_log(
+                f"Traitement de l'élément : {key} avec ID : {id} et valeur : {value_to_fill}.",
+                self.log_file,
+                "DEBUG",
+            )
+            waiter_to_use = waiter or self.waiter
+            self._insert_value_with_retries(
+                driver, id, value_to_fill, max_attempts, waiter_to_use
+            )

--- a/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
+++ b/src/sele_saisie_auto/remplir_jours_feuille_de_temps.py
@@ -4,10 +4,9 @@
 # Import des bibliothèques nécessaires
 from __future__ import annotations
 
-from collections.abc import Callable
 from configparser import ConfigParser
 from dataclasses import dataclass
-from typing import Any, Protocol, cast, runtime_checkable
+from typing import Protocol, cast, runtime_checkable
 
 from selenium.common.exceptions import (
     NoSuchElementException,
@@ -15,7 +14,6 @@ from selenium.common.exceptions import (
     TimeoutException,
     WebDriverException,
 )
-from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
 from sele_saisie_auto import messages
@@ -25,6 +23,7 @@ from sele_saisie_auto.constants import (
     JOURS_SEMAINE,
     LISTES_ID_INFORMATIONS_MISSION,
 )
+from sele_saisie_auto.day_filler import DayFiller
 from sele_saisie_auto.dropdown_options import (
     cgi_options_billing_action as default_cgi_options_billing_action,
 )
@@ -42,18 +41,43 @@ from sele_saisie_auto.selenium_utils import (
     controle_insertion,
     detecter_et_verifier_contenu,
     effacer_et_entrer_valeur,
+)
+from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (
     trouver_ligne_par_description,
     verifier_champ_jour_rempli,
     wait_for_dom_ready,
     wait_for_element,
     wait_until_dom_is_stable,
 )
-from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
 from sele_saisie_auto.selenium_utils.wait_helpers import Waiter
 from sele_saisie_auto.selenium_utils.waiter_factory import create_waiter
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT, LONG_TIMEOUT
 from sele_saisie_auto.utils.misc import program_break_time
 from sele_saisie_auto.utils.mission import est_en_mission
+
+__all__ = [
+    "TimeSheetContext",
+    "TimeSheetHelper",
+    "wait_for_dom",
+    "est_en_mission_presente",
+    "ajouter_jour_a_jours_remplis",
+    "remplir_jours",
+    "traiter_jour",
+    "remplir_mission",
+    "remplir_mission_specifique",
+    "insert_with_retries",
+    "traiter_champs_mission",
+    "trouver_ligne_par_description",
+    "wait_for_element",
+    "detecter_et_verifier_contenu",
+    "effacer_et_entrer_valeur",
+    "controle_insertion",
+    "verifier_champ_jour_rempli",
+    "program_break_time",
+    "afficher_message_insertion",
+    "write_log",
+]
 
 
 @dataclass
@@ -99,9 +123,7 @@ def context_from_app_config(app_config: AppConfig, log_file: str) -> TimeSheetCo
 # ------------------------------------------------------------------------------------------- #
 # Variables initialisées lors de l'``initialize``
 LOG_FILE: str = ""
-
-MAX_ATTEMPTS = 5
-JOUR_TO_INDEX: dict[str, int] = {v: k for k, v in JOURS_SEMAINE.items()}
+MAX_ATTEMPTS = DayFiller.MAX_ATTEMPTS
 
 
 # ------------------------------- Helpers "initialize" ------------------------------- #
@@ -166,54 +188,15 @@ def wait_for_dom(driver: WebDriver, waiter: WaiterProtocol | None = None) -> Non
         waiter.wait_for_dom_ready(driver, LONG_TIMEOUT)
 
 
+# Compatibility wrappers delegating to :class:`DayFiller`.
+
+
 def est_en_mission_presente(work_days: dict[str, tuple[str, str]]) -> bool:
-    """Vérifie si un jour de travail est marqué comme 'En mission'."""
-    return any(value[0] == "En mission" for value in work_days.values())
+    return DayFiller.est_en_mission_presente(work_days)
 
 
 def ajouter_jour_a_jours_remplis(jour: str, filled_days: list[str]) -> list[str]:
-    """Ajoute un jour à la liste jours_remplis si ce n'est pas déjà fait."""
-    if jour not in filled_days:
-        filled_days.append(jour)
-    return filled_days
-
-
-def _collect_filled_days_for_row(
-    driver: WebDriver, row_index: int, week_days: dict[int, str]
-) -> list[str]:
-    """Retourne les jours déjà remplis pour une ligne donnée."""
-
-    collected: list[str] = []
-    for jour_index, jour_name in week_days.items():
-        input_id = f"POL_TIME{jour_index}${row_index}"
-
-        element = cast(Any, wait_for_element)(
-            driver, By.ID, input_id, timeout=DEFAULT_TIMEOUT
-        )
-        if element:
-            jour_rempli = verifier_champ_jour_rempli(element, jour_name)
-            if jour_rempli:
-                collected.append(jour_rempli)
-    return collected
-
-
-def _get_day_element(
-    driver: WebDriver, jour: str, description_cible: str
-) -> tuple[str, Any | None]:
-    """Retourne l'ID et l'élément du jour cible."""
-    row_index = trouver_ligne_par_description(driver, description_cible, "POL_DESCR$")
-    if row_index is None:
-        return "", None
-    input_id = f"POL_TIME{JOUR_TO_INDEX[jour]}${row_index}"
-    element = cast(Any, wait_for_element)(
-        driver, By.ID, input_id, timeout=DEFAULT_TIMEOUT
-    )
-    return input_id, element
-
-
-# ------------------------------------------------------------------------------------------- #
-# ----------------------------------- FONCTIONS --------------------------------------------- #
-# ------------------------------------------------------------------------------------------- #
+    return DayFiller.ajouter_jour_a_jours_remplis(jour, filled_days)
 
 
 def remplir_jours(
@@ -223,23 +206,9 @@ def remplir_jours(
     filled_days: list[str],
     context: TimeSheetContext,
 ) -> list[str]:
-    """Remplir les jours dans l'application web."""
-    if not item_descriptions:
-        return filled_days
-
-    # Parcourir chaque description dans item_descriptions
-    for description_cible in item_descriptions:
-        # Recherche de la ligne avec la description spécifiée pour le jour
-        id_value = "POL_DESCR$"
-        row_index = trouver_ligne_par_description(driver, description_cible, id_value)
-
-        # Si la ligne est trouvée, collecter les jours remplis pour cette ligne
-        if row_index is not None:
-            filled_days.extend(
-                _collect_filled_days_for_row(driver, row_index, week_days)
-            )
-
-    return filled_days
+    return DayFiller(context).remplir_jours(
+        driver, item_descriptions, week_days, filled_days
+    )
 
 
 def traiter_jour(
@@ -250,17 +219,9 @@ def traiter_jour(
     filled_days: list[str],
     context: TimeSheetContext,
 ) -> list[str]:
-    """Traiter un jour spécifique pour le remplissage (flux épuré, garde-fous précoces)."""
-    if jour in filled_days or not description_cible:
-        return filled_days
-    input_id, element = _get_day_element(driver, jour, description_cible)
-    if element is None or not insert_with_retries(
-        driver, input_id, value_to_fill, None
-    ):
-        return filled_days
-    filled_days = ajouter_jour_a_jours_remplis(jour, filled_days)
-    afficher_message_insertion(jour, value_to_fill, 0, "après insertion", LOG_FILE)
-    return filled_days
+    return DayFiller(context).traiter_jour(
+        driver, jour, description_cible, value_to_fill, filled_days
+    )
 
 
 def remplir_mission(
@@ -269,11 +230,8 @@ def remplir_mission(
     filled_days: list[str],
     context: TimeSheetContext,
 ) -> list[str]:
-    """Remplir les jours de travail pour les missions."""
     for jour, (description_cible, value_to_fill) in work_days.items():
-        if jour in filled_days:
-            continue
-        if not description_cible:
+        if jour in filled_days or not description_cible:
             continue
         if est_en_mission(description_cible):
             remplir_mission_specifique(
@@ -298,93 +256,9 @@ def remplir_mission_specifique(
     filled_days: list[str],
     context: TimeSheetContext,
 ) -> None:
-    """Cas spécifique pour les jours en mission.
-    Cas où description_cible est "En mission", on écrit directement dans les IDs spécifiques sans utiliser `description_cible`
-    """
-    input_id = f"TIME{JOUR_TO_INDEX[jour]}$0"
-    element = cast(Any, wait_for_element)(
-        driver, By.ID, input_id, timeout=DEFAULT_TIMEOUT
+    DayFiller(context).remplir_mission_specifique(
+        driver, jour, value_to_fill, filled_days
     )
-    if element and insert_with_retries(driver, input_id, value_to_fill, None):
-        filled_days = ajouter_jour_a_jours_remplis(jour, filled_days)
-        afficher_message_insertion(
-            jour,
-            value_to_fill,
-            0,
-            "après insertion",
-            LOG_FILE,
-        )
-
-
-def _wait_and_get_element(
-    driver: WebDriver, field_id: str, waiter: WaiterProtocol | None
-) -> Any | None:
-    """Attendre le DOM puis récupérer l'élément."""
-    if waiter is not None:
-        wait_for_dom(driver, waiter=waiter)
-    else:
-        wait_for_dom(driver)
-    getter: Callable[..., Any] = (
-        waiter.wait_for_element if waiter else cast(Any, wait_for_element)
-    )
-    return getter(driver, By.ID, field_id, timeout=DEFAULT_TIMEOUT)
-
-
-def _try_fill_once(driver: WebDriver, field_id: str, value: str) -> bool:
-    """Une tentative d'insertion (succès si déjà correct ou insertion ok)."""
-    input_field, is_correct_value = detecter_et_verifier_contenu(
-        driver, field_id, value
-    )
-    if input_field is None:
-        raise RuntimeError("detecter_et_verifier_contenu returned None")
-    if is_correct_value:
-        write_log(
-            f"Valeur correcte déjà présente pour '{field_id}'.", LOG_FILE, "DEBUG"
-        )
-        return True
-    effacer_et_entrer_valeur(input_field, value)
-    program_break_time(1, "Stabilisation du DOM après insertion.")
-    write_log(messages.DOM_STABLE, LOG_FILE, "DEBUG")
-    if cast(Callable[[Any, str], bool], controle_insertion)(input_field, value):
-        write_log(
-            f"Valeur '{value}' insérée avec succès pour '{field_id}'.",
-            LOG_FILE,
-            "DEBUG",
-        )
-        return True
-    return False
-
-
-def _log_insert_failure(field_id: str, max_attempts: int) -> None:
-    write_log(
-        f"{messages.ECHEC_INSERTION} pour '{field_id}' après {max_attempts} tentatives.",
-        LOG_FILE,
-        "ERROR",
-    )
-
-
-def _insert_value_with_retries(
-    driver: WebDriver,
-    field_id: str,
-    value: str,
-    max_attempts: int,
-    waiter: WaiterProtocol | None,
-) -> bool:
-    """Essaye d'insérer la valeur plusieurs fois si nécessaire (boucle compacte)."""
-    if not _wait_and_get_element(driver, field_id, waiter):
-        return False
-    for attempt in range(max_attempts):
-        try:
-            if _try_fill_once(driver, field_id, value):
-                return True
-        except StaleElementReferenceException:
-            write_log(
-                f"{messages.REFERENCE_OBSOLETE} pour '{field_id}', tentative {attempt + 1}.",
-                LOG_FILE,
-                "ERROR",
-            )
-    _log_insert_failure(field_id, max_attempts)
-    return False
 
 
 def insert_with_retries(
@@ -393,9 +267,8 @@ def insert_with_retries(
     value: str,
     waiter: WaiterProtocol | None = None,
 ) -> bool:
-    """Generic helper using :func:`_insert_value_with_retries` with default attempts."""
-
-    return _insert_value_with_retries(driver, field_id, value, MAX_ATTEMPTS, waiter)
+    ctx = TimeSheetContext(LOG_FILE, [], {}, {})
+    return DayFiller(ctx, waiter).insert_with_retries(driver, field_id, value, waiter)
 
 
 def traiter_champs_mission(
@@ -407,35 +280,14 @@ def traiter_champs_mission(
     max_attempts: int = 5,
     waiter: WaiterProtocol | None = None,
 ) -> None:
-    """Traite les champs associés aux missions ('En mission') en insérant les valeurs nécessaires."""
-    for id in listes_id_informations_mission:
-        key = id_to_key_mapping.get(id)
-        if (
-            key is None or key == "sub_category_code"
-        ):  # Exclure les champs non concernés
-            continue
-
-        value_to_fill = project_mission_info.get(key)
-        if not value_to_fill:
-            write_log(
-                f"Aucune valeur trouvée pour le champ '{key}' (ID: {id}).",
-                context.log_file,
-                "DEBUG",
-            )
-            continue
-
-        write_log(
-            f"Traitement de l'élément : {key} avec ID : {id} et valeur : {value_to_fill}.",
-            context.log_file,
-            "DEBUG",
-        )
-        _insert_value_with_retries(
-            driver,
-            id,
-            value_to_fill,
-            max_attempts,
-            waiter,
-        )
+    DayFiller(context, waiter).traiter_champs_mission(
+        driver,
+        listes_id_informations_mission,
+        id_to_key_mapping,
+        project_mission_info,
+        max_attempts=max_attempts,
+        waiter=waiter,
+    )
 
 
 # ----------------------------------------------------------------------------- #
@@ -473,6 +325,7 @@ class TimeSheetHelper:
             self.waiter = waiter
         self.additional_info_page = additional_info_page
         self.browser_session = browser_session
+        self.day_filler = DayFiller(context, self.waiter)
         global LOG_FILE
         LOG_FILE = self.log_file  # type: ignore[assignment]
 

--- a/tests/test_description_processor.py
+++ b/tests/test_description_processor.py
@@ -146,7 +146,6 @@ def test_fill_days_does_not_mutate_inputs(monkeypatch):
     assert day_values == {"mardi": "1"}
     assert filled_days == ["lundi"]
 
-+
 
 def test_day_values_sanitation_uses_week_days_and_logs(monkeypatch):
     # Capture logs


### PR DESCRIPTION
## Summary
- move granular timesheet filling helpers into new `DayFiller` class
- delegate orchestration steps in `TimeSheetHelper` to thin wrappers
- tidy tests

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/day_filler.py src/sele_saisie_auto/remplir_jours_feuille_de_temps.py tests/test_description_processor.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/day_filler.py src/sele_saisie_auto/remplir_jours_feuille_de_temps.py tests/test_description_processor.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a89f75a08321b22e647ad2e5f266