### PR TITLE
[PageNavigator] Simplify credential access

### DIFF
--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -90,6 +90,10 @@ class Credentials:
     password: bytes
     mem_password: shared_memory.SharedMemory
 
+    def get_auth_tuple(self) -> tuple[bytes, bytes, bytes]:
+        """Return the AES key, encrypted login and password."""
+        return self.aes_key, self.login, self.password
+
 
 class EncryptionService:
     """Service chargé de chiffrer et déchiffrer les données sensibles."""

--- a/src/sele_saisie_auto/navigation/page_navigator.py
+++ b/src/sele_saisie_auto/navigation/page_navigator.py
@@ -110,12 +110,8 @@ class PageNavigator:
         if self.credentials is None or self.date_cible is None:
             raise RuntimeError("PageNavigator not prepared")
 
-        self.login(
-            driver,
-            self.credentials.aes_key,
-            self.credentials.login,
-            self.credentials.password,
-        )
+        aes_key, login, password = self.credentials.get_auth_tuple()
+        self.login(driver, aes_key, login, password)
         self.navigate_to_date_entry(driver, self.date_cible)
         self.fill_timesheet(driver)
         self.finalize_timesheet(driver)

--- a/src/sele_saisie_auto/saisie_automatiser_psatime.py
+++ b/src/sele_saisie_auto/saisie_automatiser_psatime.py
@@ -49,9 +49,11 @@ from sele_saisie_auto.selenium_utils import (  # noqa: F401  # re-export  # noqa
     detecter_doublons_jours,
     modifier_date_input,
     send_keys_to_element,
-    wait_for_dom_after,
 )
 from sele_saisie_auto.selenium_utils import set_log_file as set_log_file_selenium
+from sele_saisie_auto.selenium_utils import (  # noqa: F401  # re-export  # noqa: F401  # re-export  # noqa: F401  # re-export  # noqa: F401  # re-export
+    wait_for_dom_after,
+)
 from sele_saisie_auto.shared_memory_service import SharedMemoryService
 from sele_saisie_auto.timeouts import DEFAULT_TIMEOUT
 from sele_saisie_auto.utils.date_utils import get_next_saturday_if_not_saturday
@@ -73,6 +75,10 @@ class Credentials:
     mem_login: shared_memory.SharedMemory
     password: bytes
     mem_password: shared_memory.SharedMemory
+
+    def get_auth_tuple(self) -> tuple[bytes, bytes, bytes]:
+        """Return the AES key, encrypted login and password."""
+        return self.aes_key, self.login, self.password
 
 
 __all__ = [


### PR DESCRIPTION
## Contexte et objectif
- centralise la récupération des identifiants via `Credentials.get_auth_tuple`
- réduit le couplage entre `PageNavigator` et la structure interne des identifiants

## Étapes pour tester
- `poetry run radon cc -s -a src/sele_saisie_auto/encryption_utils.py src/sele_saisie_auto/navigation/page_navigator.py src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/saisie_automatiser_psatime.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption_utils.py src/sele_saisie_auto/navigation/page_navigator.py src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/saisie_automatiser_psatime.py`
- `poetry run mypy --strict --no-incremental src\\`
- `poetry run pytest`

## Impact sur les autres agents
- touche `AutomationOrchestrator` et le chargement des identifiants

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68b6d76a4c288321881be36ad5b47e65