### PR TITLE
[EncryptionService] Nettoyage clé mémoire lors de segments manquants

### DIFF
--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -241,6 +241,11 @@ class EncryptionService:
             self.logger.error(msg)
             with suppress(Exception):  # nosec B110
                 self.remove_shared_memory(mem_key)
+                for mem in list(self._memoires):
+                    if mem.name == self.memory_config.cle_name:
+                        self.remove_shared_memory(mem)
+                        self._memoires.remove(mem)
+                        break
             raise AutomationExitError(msg) from exc
 
         return Credentials(


### PR DESCRIPTION
## Contexte et objectif
- corrige la fuite d'un segment de mémoire partagée lorsque login ou mot de passe est absent

## Étapes pour tester
- `poetry run radon cc -s -a src/sele_saisie_auto/encryption_utils.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption_utils.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`

## Impact sur les autres agents
- sécurise `EncryptionService` en cas d'usage partiel, aucun impact fonctionnel attendu

@codecov-ai-reviewer review
@codecov-ai-reviewer test

------
https://chatgpt.com/codex/tasks/task_e_68b6e56cf7108321a8ca63f0b8d775a2