### PR TITLE
fix: ensure cleanup of AES key segment on credential retrieval failure

### DIFF
--- a/src/sele_saisie_auto/encryption_utils.py
+++ b/src/sele_saisie_auto/encryption_utils.py
@@ -241,6 +241,13 @@ class EncryptionService:
             self.logger.error(msg)
             with suppress(Exception):  # nosec B110
                 self.remove_shared_memory(mem_key)
+                # Ensure the AES key segment is fully removed even if another
+                # handle is still open.  This avoids leaving a stale shared
+                # memory block accessible under ``cle_name`` when retrieving
+                # credentials fails partway through.
+                self.shared_memory_service.ensure_clean_segment(
+                    self.memory_config.cle_name, self.memory_config.key_size
+                )
             raise AutomationExitError(msg) from exc
 
         return Credentials(


### PR DESCRIPTION
## Summary
- ensure AES key shared memory segment is removed if credential retrieval fails

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/encryption_utils.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/encryption_utils.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6e56cf7108321a8ca63f0b8d775a2