### PR TITLE
feat: centralize credential access

### DIFF
--- a/tests/test_page_navigator.py
+++ b/tests/test_page_navigator.py
@@ -40,7 +40,8 @@ def make_navigator():
 
 def test_login_delegates():
     _, login, _, _, _, nav = make_navigator()
-    nav.login("drv", b"k", b"u", b"p")
+    creds = Credentials(b"k", None, b"u", None, b"p", None)
+    nav.login("drv", creds)
     login.connect_to_psatime.assert_called_once_with("drv", b"k", b"u", b"p")
 
 


### PR DESCRIPTION
## Summary
- centralize credential tuple retrieval with `Credentials.get_auth_tuple`
- use credential protocol in navigation to avoid direct attribute access
- adjust tests for new credential handling

## Testing
- `poetry run radon cc -s -a src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/navigation/page_navigator.py`
- `poetry run pre-commit run --files src/sele_saisie_auto/orchestration/automation_orchestrator.py src/sele_saisie_auto/navigation/page_navigator.py tests/test_page_navigator.py`
- `poetry run mypy --strict --no-incremental src/`
- `poetry run pytest --ignore=tests/test_pyinstaller_onefile.py --ignore=tests/test_launcher_roundtrip.py`


------
https://chatgpt.com/codex/tasks/task_e_68b721ece4148321abd95165f9cc5907